### PR TITLE
feat: allow custom login and logout paths

### DIFF
--- a/API.md
+++ b/API.md
@@ -14,12 +14,15 @@ In general, you won't need to configure this middleware besides the required par
 | clientSecret        | `env.CLIENT_SECRET`             | The client secret, only required for some grants.                              |
 | clockTolerance      | `5`                             | The clock's tolerance in seconds for token verification.                       |
 | getUser             | `tokenSet => tokenSet.claims()` | An async function receiving a tokenset and returning the profile for `req.openid.user`. |
-| required            | `true`                            | If true requires authentication for all the routes in the stack. You can also provide a function to determine if is required based on the request.               |
+| required            | `true`                          | If true requires authentication for all the routes in the stack. You can also provide a function to determine if is required based on the request.               |
 | handleUnauthorizedErrors | `true`                     | Install a middleware that handles Unauthorized/401 errors by triggering the login process. |
 | routes              | `true`                          | Installs the `GET /login` and `GET /logout` route.                              |
 | idpLogout           | `false`                         | Logout the user from the identity provider on logout                            |
 | auth0Logout         | `false`                         | Enable Auth0's non-compliant logout feature, only if Auth0 can be detected and the Auth0 instance does not support OpenID Connect session management. |
-| authorizationParams | See bellow                      | The parameters for the authorization call.                                      |
+| redirectUriPath     | `/callback`                     | Relative path for the callback URL; sent to the authroize endpoint in the `redirectUri` parameter. |
+| loginPath           | `/login`                        | Relative path to login.                                                         |
+| logoutPath          | `/logout`                       | Relative path to logout.                                                        |
+| authorizationParams | See below                       | The parameters for the authorization call.                                      |
 
 Default value for `authorizationParams` is:
 

--- a/API.md
+++ b/API.md
@@ -19,7 +19,7 @@ In general, you won't need to configure this middleware besides the required par
 | routes              | `true`                          | Installs the `GET /login` and `GET /logout` route.                              |
 | idpLogout           | `false`                         | Logout the user from the identity provider on logout                            |
 | auth0Logout         | `false`                         | Enable Auth0's non-compliant logout feature, only if Auth0 can be detected and the Auth0 instance does not support OpenID Connect session management. |
-| redirectUriPath     | `/callback`                     | Relative path for the callback URL; sent to the authroize endpoint in the `redirectUri` parameter. |
+| redirectUriPath     | `/callback`                     | Relative path for the callback URL; sent to the authorize endpoint in the `redirectUri` parameter. |
 | loginPath           | `/login`                        | Relative path to login.                                                         |
 | logoutPath          | `/logout`                       | Relative path to logout.                                                        |
 | authorizationParams | See below                       | The parameters for the authorization call.                                      |

--- a/API.md
+++ b/API.md
@@ -14,9 +14,9 @@ In general, you won't need to configure this middleware besides the required par
 | clientSecret        | `env.CLIENT_SECRET`             | The client secret, only required for some grants.                              |
 | clockTolerance      | `5`                             | The clock's tolerance in seconds for token verification.                       |
 | getUser             | `tokenSet => tokenSet.claims()` | An async function receiving a tokenset and returning the profile for `req.openid.user`. |
-| required            | `true`                          | If true requires authentication for all the routes in the stack. You can also provide a function to determine if is required based on the request.               |
+| required            | `true`                          | If `true`, requires authentication for all routes (redirects to `loginPath`). Pass a function instead of a boolean to base this on the request.  |
 | handleUnauthorizedErrors | `true`                     | Install a middleware that handles Unauthorized/401 errors by triggering the login process. |
-| routes              | `true`                          | Installs the `GET /login` and `GET /logout` route.                              |
+| routes              | `true`                          | Installs the `GET /login` and `GET /logout` routes.                              |
 | idpLogout           | `false`                         | Logout the user from the identity provider on logout                            |
 | auth0Logout         | `false`                         | Enable Auth0's non-compliant logout feature, only if Auth0 can be detected and the Auth0 instance does not support OpenID Connect session management. |
 | redirectUriPath     | `/callback`                     | Relative path for the callback URL; sent to the authorize endpoint in the `redirectUri` parameter. |

--- a/lib/config.js
+++ b/lib/config.js
@@ -29,6 +29,8 @@ const paramsSchema = Joi.object().keys({
   errorOnRequiredAuth: Joi.boolean().optional().default(false),
   auth0Logout: Joi.boolean().optional().default(false),
   redirectUriPath: Joi.string().optional().default('/callback'),
+  loginPath: Joi.string().optional().default('/login'),
+  logoutPath: Joi.string().optional().default('/logout'),
   idpLogout: Joi.boolean().optional().default(false)
     .when('auth0Logout', { is: true, then: Joi.boolean().optional().default(true) })
 });

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -64,10 +64,10 @@ module.exports = function (params) {
   });
 
   if (config.routes) {
-    router.get('/login', (req, res) => {
+    router.get(config.loginPath, (req, res) => {
       res.openid.login({ returnTo: config.baseURL });
     });
-    router.get('/logout', (req, res) => res.openid.logout());
+    router.get(config.logoutPath, (req, res) => res.openid.logout());
   }
 
   let callbackMethod;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-openid-connect",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -220,7 +220,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -1892,7 +1892,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -1965,13 +1965,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2315,7 +2315,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -2435,7 +2435,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -3045,7 +3045,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -91,4 +91,47 @@ describe('config', function() {
     });
   });
 
+  describe('default auth paths', function() {
+    const config = getConfig({
+      clientID: '123',
+      issuerBaseURL: 'https://flosser.auth0.com',
+      baseURL: 'https://jjj.com',
+    });
+
+    it('should set the default callback path', function() {
+      assert.equal(config.redirectUriPath, '/callback');
+    });
+
+    it('should set the default login path', function() {
+      assert.equal(config.loginPath, '/login');
+    });
+
+    it('should set the default logout path', function() {
+      assert.equal(config.logoutPath, '/logout');
+    });
+  });
+
+  describe('custom auth paths', function() {
+    const config = getConfig({
+      clientID: '123',
+      issuerBaseURL: 'https://flosser.auth0.com',
+      baseURL: 'https://jjj.com',
+      redirectUriPath: '/custom-callback',
+      loginPath: '/custom-login',
+      logoutPath: '/custom-logout',
+    });
+
+    it('should accept the custom callback path', function() {
+      assert.equal(config.redirectUriPath, '/custom-callback');
+    });
+
+    it('should accept the login path', function() {
+      assert.equal(config.loginPath, '/custom-login');
+    });
+
+    it('should accept the logout path', function() {
+      assert.equal(config.logoutPath, '/custom-logout');
+    });
+  });
+
 });


### PR DESCRIPTION
### Description

Allows custom login and logout paths in the same way as custom callback ones. See API.md for more information. Custom routes can also be done [this way](https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md#example-2).

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
