### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# CHANGELOG
+
+## [v0.4.0](https://github.com/auth0/express-openid-connect/tree/v0.4.0) (2019-09-26)
+[Full Changelog](https://github.com/auth0/express-openid-connect/compare/v0.3.0...v0.4.0)
+
+**Important note:** This release bumps the minimum Node version required to `^10.13.0`.
+
+**Closed issues**
+- GetUser [\#10](https://github.com/auth0/express-openid-connect/issues/10)
+- Thoughts on user info endpoint? [\#7](https://github.com/auth0/express-openid-connect/issues/7)
+
+**Changed**
+- feat: bump openid-client [\#12](https://github.com/auth0/express-openid-connect/pull/12) ([panva](https://github.com/panva))
+
+**Removed**
+- Remove debugging callbacks [\#17](https://github.com/auth0/express-openid-connect/pull/17) ([joshcanhelp](https://github.com/joshcanhelp))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-openid-connect",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An Express.js middleware to protect OpenID Connect web applications.",
   "homepage": "https://github.com/auth0/express-openid-connect",
   "license": "MIT",


### PR DESCRIPTION
See the milestone or CHANGELOG below for changes and removals. This release bumps the minimum Node version required to `^10.13.0`.