### PR TITLE
Add configurable HTTP options

### DIFF
--- a/API.md
+++ b/API.md
@@ -9,6 +9,7 @@ In general, you won't need to configure this middleware besides the required par
 | Name                | Default                         | Description                                                                    |
 |---------------------|---------------------------------|--------------------------------------------------------------------------------|
 | issuerBaseURL       | `env.ISSUER_BASE_URL`           | The url address for the token issuer.                                          |
+| httpOptions         | none                            | Default options used for all HTTP calls made by the library ([possible options](https://github.com/sindresorhus/got/tree/v9.6.0#options)) |
 | baseURL             | `env.BASE_URL`                  | The url of the web application where you are installing the router.            |
 | clientID            | `env.CLIENT_ID`                 | The client id.                                                                 |
 | clientSecret        | `env.CLIENT_SECRET`             | The client secret, only required for some grants.                              |

--- a/lib/client.js
+++ b/lib/client.js
@@ -42,12 +42,13 @@ Supported types:
 `);
   }
 
-  if (authorizeParams.response_mode && Array.isArray(issuer.response_modes_supported) &&
-    !issuer.response_modes_supported.includes(authorizeParams.response_mode)) {
-    throw new Error(`The issuer doesn't support the response_mode ${authorizeParams.response_mode}
-Supported response modes:
-- ${issuer.response_modes_supported.sort().join('\n- ')}
-`);
+  const configRespMode = authorizeParams.response_mode;
+  const issuerRespModes = Array.isArray(issuer.response_modes_supported) ? issuer.response_modes_supported : [];
+  if (configRespMode && ! issuerRespModes.includes(authorizeParams.response_mode)) {
+    throw new Error(
+      `Response mode ${configRespMode} is not supported by the issuer. ` + 
+      `Supported response modes are ${issuerRespModes.sort().join(', ')}. `
+    );
   }
 
   const client = new issuer.Client({

--- a/lib/client.js
+++ b/lib/client.js
@@ -12,14 +12,6 @@ const telemetryHeader = {
   }
 };
 
-custom.setHttpOptionsDefaults({
-  headers: {
-    'User-Agent': `${pkg.name}/${pkg.version}`,
-    'Auth0-Client': Buffer.from(JSON.stringify(telemetryHeader)).toString('base64')
-  },
-  timeout: 4000
-});
-
 async function get(config) {
 
   const issuer = await Issuer.discover(config.issuerBaseURL);
@@ -71,6 +63,17 @@ async function get(config) {
       throw new Error("The issuer doesn't support session management.");
     }
   }
+
+  let httpOptions = config.httpOptions || {};
+  httpOptions.headers = Object.assign(
+    // Allow configuration to override user agent header.
+    {'User-Agent': `${pkg.name}/${pkg.version}`},
+    httpOptions.headers || {},
+    // Do not allow overriding telemetry.
+    {'Auth0-Client': Buffer.from(JSON.stringify(telemetryHeader)).toString('base64')}
+  );
+
+  custom.setHttpOptionsDefaults(httpOptions);
 
   client[custom.clock_tolerance] = config.clockTolerance;
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -21,20 +21,19 @@ custom.setHttpOptionsDefaults({
 });
 
 async function get(config) {
-  const authorizeParams = config.authorizationParams;
 
   const issuer = await Issuer.discover(config.issuerBaseURL);
 
-  if (Array.isArray(issuer.id_token_signing_alg_values_supported) &&
-    !issuer.id_token_signing_alg_values_supported.includes(config.idTokenAlg)) {
-    throw new Error(`The issuer doesn't support the ID token algorithm ${config.idTokenAlg}
-Supported types:
-- ${issuer.id_token_signing_alg_values_supported.sort().join('\n- ')}
-`);
+  const issuerTokenAlgs = Array.isArray(issuer.id_token_signing_alg_values_supported) ? 
+    issuer.id_token_signing_alg_values_supported : [];
+  if (!issuerTokenAlgs.includes(config.idTokenAlg)) {
+    throw new Error(
+      `ID token algorithm "${config.idTokenAlg}" is not supported by the issuer. ` + 
+      `Supported ID token algorithms are: "${issuerTokenAlgs.join('", "')}". `
+    );
   }
 
-  // TODO: Does not respect out-of-order response types; 'id_token code' is not respected if issuer is 'code id_token'
-  const configRespType = authorizeParams.response_type;
+  const configRespType = config.authorizationParams.response_type;
   const issuerRespTypes = Array.isArray(issuer.response_types_supported) ? issuer.response_types_supported : [];
   if (!issuerRespTypes.includes(configRespType)) {
     throw new Error(
@@ -43,9 +42,9 @@ Supported types:
     );
   }
 
-  const configRespMode = authorizeParams.response_mode;
+  const configRespMode = config.authorizationParams.response_mode;
   const issuerRespModes = Array.isArray(issuer.response_modes_supported) ? issuer.response_modes_supported : [];
-  if (configRespMode && ! issuerRespModes.includes(authorizeParams.response_mode)) {
+  if (configRespMode && ! issuerRespModes.includes(configRespMode)) {
     throw new Error(
       `Response mode "${configRespMode}" is not supported by the issuer. ` + 
       `Supported response modes are "${issuerRespModes.join('", "')}". `

--- a/lib/client.js
+++ b/lib/client.js
@@ -34,20 +34,21 @@ Supported types:
   }
 
   // TODO: Does not respect out-of-order response types; 'id_token code' is not respected if issuer is 'code id_token'
-  if (Array.isArray(issuer.response_types_supported) &&
-    !issuer.response_types_supported.includes(authorizeParams.response_type)) {
-    throw new Error(`The issuer doesn't support the response_type ${authorizeParams.response_type}
-Supported types:
-- ${issuer.response_types_supported.sort().join('\n- ')}
-`);
+  const configRespType = authorizeParams.response_type;
+  const issuerRespTypes = Array.isArray(issuer.response_types_supported) ? issuer.response_types_supported : [];
+  if (!issuerRespTypes.includes(configRespType)) {
+    throw new Error(
+      `Response type "${configRespType}" is not supported by the issuer. ` + 
+      `Supported response types are: "${issuerRespTypes.join('", "')}". `
+    );
   }
 
   const configRespMode = authorizeParams.response_mode;
   const issuerRespModes = Array.isArray(issuer.response_modes_supported) ? issuer.response_modes_supported : [];
   if (configRespMode && ! issuerRespModes.includes(authorizeParams.response_mode)) {
     throw new Error(
-      `Response mode ${configRespMode} is not supported by the issuer. ` + 
-      `Supported response modes are ${issuerRespModes.sort().join(', ')}. `
+      `Response mode "${configRespMode}" is not supported by the issuer. ` + 
+      `Supported response modes are "${issuerRespModes.join('", "')}". `
     );
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -17,6 +17,7 @@ const authorizationParamsSchema = Joi.object().keys({
 
 // const requiredParams = ['issuerBaseURL', 'baseURL', 'clientID'];
 const paramsSchema = Joi.object().keys({
+  httpOptions: Joi.object().optional(),
   issuerBaseURL: Joi.alternatives([ Joi.string().uri(), Joi.string().hostname() ]).required(),
   baseURL: Joi.string().uri().required(),
   clientID: Joi.string().required(),

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -5,6 +5,15 @@ const nock = require('nock');
 const pkg = require('../package.json');
 
 describe('client initialization', function() {
+
+  beforeEach(async function() {
+    nock('https://test.auth0.com')
+      .post('/introspection')
+      .reply(200, function() {
+        return this.req.headers;
+      });
+  });
+
   describe('default case', function() {
     const config = getConfig({
       clientID: '__test_client_id__',
@@ -16,12 +25,6 @@ describe('client initialization', function() {
     let client;
     before(async function() {
       client = await getClient(config);
-
-      nock('https://test.auth0.com')
-        .post('/introspection')
-        .reply(200, function() {
-          return this.req.headers;
-        });
     });
     
     it('should save the passed values', async function() {
@@ -46,4 +49,41 @@ describe('client initialization', function() {
     });
   });
 
+  describe('custom headers', function() {
+    const config = getConfig({
+      clientID: '__test_client_id__',
+      clientSecret: '__test_client_secret__',
+      issuerBaseURL: 'https://test.auth0.com',
+      baseURL: 'https://example.org',
+      httpOptions: {
+        headers: {
+          'User-Agent' : '__test_custom_user_agent__',
+          'X-Custom-Header' : '__test_custom_header__',
+          'Auth0-Client' : '__test_custom_telemetry__',
+        }
+      }
+    });
+
+    let client;
+    before(async function() {
+      client = await getClient(config);
+    });
+    
+    it('should send the correct default headers', async function() {
+      const headers = await client.introspect('__test_token__', '__test_hint__');
+      const headerProps = Object.getOwnPropertyNames(headers);
+      
+      // User agent header should be overridden.
+      assert.include(headerProps, 'user-agent');
+      assert.equal('__test_custom_user_agent__', headers['user-agent']);
+      
+      // Custom header should be added.
+      assert.include(headerProps, 'x-custom-header');
+      assert.equal('__test_custom_header__', headers['x-custom-header']);
+      
+      // Telemetry header should not be overridden.
+      assert.include(headerProps, 'auth0-client');
+      assert.notEqual('__test_custom_telemetry__', headers['x-custom-header']);
+    });
+  });
 });

--- a/test/invalid_id_token_alg.tests.js
+++ b/test/invalid_id_token_alg.tests.js
@@ -23,6 +23,6 @@ describe('with an invalid id token alg', function() {
   it('should return an error', async function() {
     const res = await request.get({ json: true, baseUrl, uri: '/login'});
     assert.equal(res.statusCode, 500);
-    assert.include(res.body.err.message, 'The issuer doesn\'t support the ID token algorithm');
+    assert.include(res.body.err.message, 'ID token algorithm "__invalid_alg__" is not supported by the issuer.');
   });
 });

--- a/test/invalid_response_mode.tests.js
+++ b/test/invalid_response_mode.tests.js
@@ -26,6 +26,6 @@ describe('with an invalid response_mode', function() {
   it('should return an error', async function() {
     const res = await request.get({ json: true, baseUrl, uri: '/login'});
     assert.equal(res.statusCode, 500);
-    assert.include(res.body.err.message, 'The issuer doesn\'t support the response_mode __invalid_response_mode__');
+    assert.include(res.body.err.message, 'Response mode __invalid_response_mode__ is not supported by the issuer.');
   });
 });

--- a/test/invalid_response_mode.tests.js
+++ b/test/invalid_response_mode.tests.js
@@ -26,6 +26,6 @@ describe('with an invalid response_mode', function() {
   it('should return an error', async function() {
     const res = await request.get({ json: true, baseUrl, uri: '/login'});
     assert.equal(res.statusCode, 500);
-    assert.include(res.body.err.message, 'Response mode __invalid_response_mode__ is not supported by the issuer.');
+    assert.include(res.body.err.message, 'Response mode "__invalid_response_mode__" is not supported by the issuer.');
   });
 });

--- a/test/invalid_response_type.tests.js
+++ b/test/invalid_response_type.tests.js
@@ -25,6 +25,6 @@ describe('with an invalid response type', function() {
   it('should return an error', async function() {
     const res = await request.get({ json: true, baseUrl, uri: '/login'});
     assert.equal(res.statusCode, 500);
-    assert.include(res.body.err.message, 'The issuer doesn\'t support the response_type __invalid_response_type__');
+    assert.include(res.body.err.message, 'Response type "__invalid_response_type__" is not supported by the issuer.');
   });
 });


### PR DESCRIPTION
### Description

- Add the ability to configure custom HTTP options for all HTTP calls; does not override SDK telemetry header
- Improve logic and error messages for ID token alg, response mode, and response type issuer checks

### References

- [Customizing HTTP requests in `panva/node-openid-client`](https://github.com/panva/node-openid-client/blob/master/docs/README.md#customizing-http-requests)
- [Options that can be customized in `sindresorhus/got`](https://github.com/sindresorhus/got/tree/v9.6.0#options)

### Testing

Built in v10.15.0

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks are passing
