### PR TITLE
Add custom callback handling

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -160,7 +160,7 @@ app.use(auth({
   handleCallback: async function (req, res, next) {
     const client = req.openid.client;
     try {
-      req.session.openidTokens.userinfo = await client.userinfo(req.session.openidTokens);
+      req.session.userinfo = await client.userinfo(req.session.openidTokens);
       next();
     } catch(e) {
       next(e);

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -150,3 +150,28 @@ app.get('/route-that-calls-an-api', async (req, res, next) => {
   });
 });
 ```
+
+## 5. Calling userinfo
+
+If your application needs to call the userinfo endpoint for the user's identity, add a `handleCallback` function during initialization that will make this call. To map the incoming claims to the user identity, also add a `getUser` function.
+
+```js
+app.use(auth({
+  handleCallback: async function (req, res, next) {
+    const client = req.openid.client;
+    try {
+      req.session.openidTokens.userinfo = await client.userinfo(req.session.openidTokens);
+      next();
+    } catch(e) {
+      next(e);
+    }
+  },
+  getUser: function(tokenSet) {
+    return tokenSet && ( tokenSet.userinfo || tokenSet.claims() );
+  },
+  authorizationParams: {
+    response_type: 'code',
+    scope: 'openid profile email'
+  }
+}));
+```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -121,7 +121,7 @@ app.get('/route-that-calls-an-api', async (req, res, next) => {
   let apiData = {};
   let tokenSet = req.openid.tokens;
 
-  if (tokenSet.expired() && tokenSet.refresh_token) {
+  if (tokenSet && tokenSet.expired() && tokenSet.refresh_token) {
     try {
       tokenSet = await req.openid.client.refresh(tokenSet);
     } catch(err) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,6 +26,7 @@ const paramsSchema = Joi.object().keys({
   authorizationParams: Joi.object().optional(),
   clockTolerance: Joi.number().optional().default(60),
   getUser: Joi.func().optional().default(getUser),
+  customCallbackProcessing: Joi.func().optional().default((req, res, next) => next()),
   required: Joi.alternatives([ Joi.func(), Joi.boolean()]).optional().default(true),
   routes: Joi.boolean().optional().default(true),
   errorOnRequiredAuth: Joi.boolean().optional().default(false),

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,8 @@
 const Joi = require('@hapi/joi');
 const clone = require('clone');
 const loadEnvs = require('./loadEnvs');
-const getUser = require('./getUser');
+const getUser = require('./hooks/getUser');
+const handleCallback = require('./hooks/handleCallback');
 
 const defaultAuthorizeParams = {
   response_type: 'id_token',
@@ -26,7 +27,7 @@ const paramsSchema = Joi.object().keys({
   authorizationParams: Joi.object().optional(),
   clockTolerance: Joi.number().optional().default(60),
   getUser: Joi.func().optional().default(getUser),
-  customCallbackProcessing: Joi.func().optional().default((req, res, next) => next()),
+  handleCallback: Joi.func().optional().default(handleCallback),
   required: Joi.alternatives([ Joi.func(), Joi.boolean()]).optional().default(true),
   routes: Joi.boolean().optional().default(true),
   errorOnRequiredAuth: Joi.boolean().optional().default(false),

--- a/lib/getUser.js
+++ b/lib/getUser.js
@@ -1,4 +1,0 @@
-//This is the default function for mapping a tokenSet to a user.
-module.exports = function(tokenSet) {
-  return tokenSet && tokenSet.claims();
-};

--- a/lib/hooks/getUser.js
+++ b/lib/hooks/getUser.js
@@ -1,0 +1,7 @@
+/**
+ * Default function for mapping a tokenSet to a user.
+ * This can be used for adjusting or augmenting profile data.
+ */
+module.exports = function(tokenSet) {
+  return tokenSet && tokenSet.claims();
+};

--- a/lib/hooks/handleCallback.js
+++ b/lib/hooks/handleCallback.js
@@ -1,0 +1,7 @@
+/**
+ * Default function for custom callback handling after receiving tokens.
+ * This can be used for handling token storage, making userinfo calls, etc.
+ */
+module.exports = function (req, res, next) {
+  next();
+};

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -109,8 +109,8 @@ module.exports = function (params) {
   },
   config.handleCallback,
   function (req, res) {
-    const returnTo = req.session.returnTo || '/';
-    delete req.session.returnTo;
+    const transientOpts = { legacySameSiteCookie: config.legacySameSiteCookie };
+    const returnTo = transient.getOnce('returnTo', req, res, transientOpts) || config.baseURL;
     res.redirect(returnTo);
   });
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -107,7 +107,7 @@ module.exports = function (params) {
       next(err);
     }
   },
-  config.customCallbackProcessing,
+  config.handleCallback,
   function (req, res) {
     const returnTo = req.session.returnTo || '/';
     delete req.session.returnTo;

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -102,13 +102,16 @@ module.exports = function (params) {
       }
 
       req.session.openidTokens = tokenSet;
-
-      const returnTo = transient.getOnce('returnTo', req, res, transientOpts) || '/';
-
-      res.redirect(returnTo);
+      next();
     } catch (err) {
       next(err);
     }
+  },
+  config.customCallbackProcessing,
+  function (req, res) {
+    const returnTo = req.session.returnTo || '/';
+    delete req.session.returnTo;
+    res.redirect(returnTo);
   });
 
   if (config.required) {

--- a/test/callback_route_form_post.tests.js
+++ b/test/callback_route_form_post.tests.js
@@ -56,6 +56,22 @@ function testCase(params) {
   };
 }
 
+function makeIdToken(payload) {
+  if (typeof payload !== 'object' ) {
+    payload = {
+      'nickname': '__test_nickname__',
+      'iss': 'https://test.auth0.com/',
+      'sub': '__test_sub__',
+      'aud': clientID,
+      'iat': Math.round(Date.now() / 1000),
+      'exp': Math.round(Date.now() / 1000) + 60000,
+      'nonce': '__test_nonce__'
+    };
+  }
+
+  return jwt.sign(payload, cert.key, { algorithm: 'RS256', header: { kid: cert.kid } });
+}
+
 //For the purpose of this test the fake SERVER returns the error message in the body directly
 //production application should have an error middleware.
 //http://expressjs.com/en/guide/error-handling.html
@@ -162,7 +178,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
     },
     body: {
       state: '__test_state__',
-      id_token: jwt.sign({sub: '__test_sub__'}, cert.key, { algorithm: 'RS256' })
+      id_token: makeIdToken({sub: '__test_sub__'})
     },
     assertions() {
       it('should return 400', function() {
@@ -182,13 +198,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
     },
     body: {
       state: '__test_state__',
-      id_token: jwt.sign({
-        'iss': 'https://test.auth0.com/',
-        'sub': '__test_sub__',
-        'aud': clientID,
-        'exp': Math.round(Date.now() / 1000) + 60000,
-        'nonce': '__test_nonce__'
-      }, cert.key, { algorithm: 'RS256', header: { kid: cert.kid } })
+      id_token: makeIdToken()
     },
     assertions() {
       it('should return the reason to the error handler', function() {
@@ -205,15 +215,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
     },
     body: {
       state: '__test_state__',
-      id_token: jwt.sign({
-        'nickname': '__test_nickname__',
-        'iss': 'https://test.auth0.com/',
-        'sub': '__test_sub__',
-        'aud': clientID,
-        'iat': Math.round(Date.now() / 1000),
-        'exp': Math.round(Date.now() / 1000) + 60000,
-        'nonce': '__test_nonce__'
-      }, cert.key, { algorithm: 'RS256', header: { kid: cert.kid } })
+      id_token: makeIdToken()
     },
     assertions() {
       it('should return 302', function() {
@@ -275,14 +277,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
     },
     body: {
       state: '__test_state__',
-      id_token: jwt.sign({
-        'iss': 'https://test.auth0.com/',
-        'sub': '__test_sub__',
-        'aud': clientID,
-        'iat': Math.round(Date.now() / 1000),
-        'exp': Math.round(Date.now() / 1000) + 60000,
-        'nonce': '__test_nonce__'
-      }, cert.key, { algorithm: 'RS256', header: { kid: cert.kid } })
+      id_token: makeIdToken()
     },
     assertions() {
       it('throws an error from the custom handler', function() {

--- a/test/callback_route_form_post.tests.js
+++ b/test/callback_route_form_post.tests.js
@@ -201,7 +201,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
     cookies: {
       _state: '__test_state__',
       _nonce: '__test_nonce__',
-      returnTo: '/return-to'
+      _returnTo: '/return-to'
     },
     body: {
       state: '__test_state__',


### PR DESCRIPTION
### Description

Add the ability to do custom callback handling. Used to store/process incoming authorization artifacts or other login-time transactions. See EXAMPLES.md for how to use this option.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
