### PR TITLE
Add SameSite support

### DIFF
--- a/API.md
+++ b/API.md
@@ -27,6 +27,7 @@ Additional configuration keys that can be passed to `auth()` on initialization:
 - **`errorOnRequiredAuth`** - Boolean value to throw a `Unauthorized 401` error instead of triggering the login process for routes that require authentication. Default is `false`.
 - **`httpOptions`** - Default options object used for all HTTP calls made by the library ([possible options](https://github.com/sindresorhus/got/tree/v9.6.0#options)). Default is empty.
 - **`idpLogout`** - Boolean value to log the user out from the identity provider on application logout. Requires the issuer to provide a `end_session_endpoint` value. Default is `false`.
+- **`legacySameSiteCookie`** - Set a fallback cookie with no SameSite attribute when `authorizationParams.response_mode` is `form_post`. Default is `true`.
 - **`loginPath`** - Relative path to application login. Default is `/login`.
 - **`logoutPath`** - Relative path to application logout. Default is `/logout`.
 - **`redirectUriPath`** - Relative path to the application callback to process the response from the authorization server. This value is combined with the `baseUrl` and sent to the authorize endpoint as the `redirectUri` parameter. Default is `/callback`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -33,6 +33,7 @@ const paramsSchema = Joi.object().keys({
   redirectUriPath: Joi.string().optional().default('/callback'),
   loginPath: Joi.string().optional().default('/login'),
   logoutPath: Joi.string().optional().default('/logout'),
+  legacySameSiteCookie: Joi.boolean().optional().default(true),
   idpLogout: Joi.boolean().optional().default(false)
     .when('auth0Logout', { is: true, then: Joi.boolean().optional().default(true) })
 });

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,6 +1,6 @@
 const cb = require('cb');
 const urlJoin = require('url-join');
-const crypto = require('crypto');
+const transient =  require('./transientHandler');
 const { get: getClient } =  require('./client');
 const { TokenSet } = require('openid-client');
 
@@ -57,30 +57,28 @@ class ResponseContext {
     const next = cb(this._next).once();
     const req = this._req;
     const res = this._res;
-    const authorizeParams = this._config.authorizationParams;
+    const config = this._config;
+
+    const client = req.openid.client;
+    const authorizeParams = config.authorizationParams;
 
     try {
-      const redirect_uri = this.getRedirectUri();
-      if (typeof req.session === 'undefined') {
-        return next(new Error('This router needs the session middleware'));
-      }
-      const client = this._req.openid.client;
-
-      req.session.nonce = crypto.randomBytes(8).toString('hex');
-      req.session.state = crypto.randomBytes(10).toString('hex');
-
-      if(params.returnTo) {
-        req.session.returnTo = params.returnTo;
+      let returnTo;
+      if (params.returnTo) {
+        returnTo = params.returnTo;
       } else if (req.method === 'GET') {
-        req.session.returnTo = req.originalUrl;
+        returnTo = req.originalUrl;
       } else {
-        req.session.returnTo = this._config.baseURL;
+        returnTo = this._config.baseURL;
       }
+
+      // TODO: Store this in state
+      transient.store('returnTo', res, {value: returnTo});
 
       const authParams = Object.assign({
-        nonce: req.session.nonce,
-        state: req.session.state,
-        redirect_uri
+        nonce: transient.store('nonce', res),
+        state: transient.store('state', res),
+        redirect_uri: this.getRedirectUri()
       }, authorizeParams, params.authorizationParams || {});
 
       const authorizationUrl = client.authorizationUrl(authParams);

--- a/lib/context.js
+++ b/lib/context.js
@@ -61,6 +61,10 @@ class ResponseContext {
 
     const client = req.openid.client;
     const authorizeParams = config.authorizationParams;
+    const transientOpts = {
+      legacySameSiteCookie: config.legacySameSiteCookie,
+      sameSite: config.authorizationParams.response_mode === 'form_post' ? 'None' : 'Lax'
+    };
 
     try {
       let returnTo;
@@ -73,11 +77,11 @@ class ResponseContext {
       }
 
       // TODO: Store this in state
-      transient.store('returnTo', res, {value: returnTo});
+      transient.store('returnTo', res, Object.assign({value: returnTo}, transientOpts));
 
       const authParams = Object.assign({
-        nonce: transient.store('nonce', res),
-        state: transient.store('state', res),
+        nonce: transient.store('nonce', res, transientOpts),
+        state: transient.store('state', res, transientOpts),
         redirect_uri: this.getRedirectUri()
       }, authorizeParams, params.authorizationParams || {});
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,6 +1,6 @@
 const cb = require('cb');
 const urlJoin = require('url-join');
-const transient =  require('./transientHandler');
+const transient = require('./transientHandler');
 const { get: getClient } =  require('./client');
 const { TokenSet } = require('openid-client');
 

--- a/lib/transientHandler.js
+++ b/lib/transientHandler.js
@@ -4,10 +4,14 @@ const crypto = require('crypto');
  * Set a cookie with a value or a generated nonce.
  *
  * @param {String} key Cookie name to use.
- * @param {Object} res Current Express reponse object.
- * @param {Object} opts Options for cookie setting.
+ * @param {Object} res Express Response object.
+ * @param {Object} opts Options object.
+ * @param {String} opts.sameSite SameSite attribute of "None," "Lax," or "Strict". Default is "None."
+ * @param {String} opts.value Cookie value. Omit this key to store a generated value.
+ * @param {Boolean} opts.legacySameSiteCookie Should a fallback cookie be set? Default is true.
+ * @param {Boolean} opts.maxAge Cookie MaxAge value, in microseconds. Default is 600000 (10 minutes).
  *
- * @return {String}
+ * @return {String} Cookie value that was set.
  */
 function store(key, res, opts = {}) {
   const sameSiteAttr = opts.sameSite || 'None';
@@ -20,9 +24,11 @@ function store(key, res, opts = {}) {
     maxAge: 'maxAge' in opts ? parseInt(opts.maxAge, 10) : 600 * 1000 // 10 minutes
   };
 
+  // Set the cookie with the SameSite attribute and, if needed, the Secure flag.
   res.cookie(key, value, Object.assign({}, basicAttr, {sameSite: sameSiteAttr, secure: isSameSiteNone}));
 
   if (isSameSiteNone && fallbackCookie) {
+    // Set the fallback cookie with no SameSite or Secure attributes.
     res.cookie('_' + key, value, basicAttr);
   }
 
@@ -33,8 +39,12 @@ function store(key, res, opts = {}) {
  * Get a cookie value then delete it.
  *
  * @param {String} key Cookie name to use.
- * @param {Object} req Current Express request object.
- * @param {Object} opts Options for cookie setting.
+ * @param {Object} req Express Request object.
+ * @param {Object} res Express Response object.
+ * @param {Object} opts Options object.
+ * @param {Boolean} opts.legacySameSiteCookie Should a fallback cookie be checked? Default is true.
+ *
+ * @return {String|undefined} Cookie value or undefined if cookie was not found.
  */
 function getOnce(key, req, res, opts = {}) {
 
@@ -57,6 +67,8 @@ function getOnce(key, req, res, opts = {}) {
 }
 
 /**
+ * Generates a nonce value.
+ *
  * @return {String}
  */
 function createNonce() {
@@ -64,10 +76,13 @@ function createNonce() {
 }
 
 /**
- * @return {String}
+ * Sets a blank value and zero max age cookie.
+ *
+ * @param {String} name Cookie name
+ * @param {Object} res Express Response object
  */
-function deleteCookie(key, res) {
-  res.cookie(key, '', {maxAge: 0});
+function deleteCookie(name, res) {
+  res.cookie(name, '', {maxAge: 0});
 }
 
 exports.store = store;

--- a/lib/transientHandler.js
+++ b/lib/transientHandler.js
@@ -13,11 +13,11 @@ function store(key, res, opts = {}) {
   const sameSiteAttr = opts.sameSite || 'None';
   const isSameSiteNone = sameSiteAttr === 'None';
   const value = opts.value || createNonce();
-  const fallbackCookie = opts.legacySameSiteCookie || true;
+  const fallbackCookie = 'legacySameSiteCookie' in opts ? opts.legacySameSiteCookie : true;
 
   const basicAttr = {
     httpOnly: true,
-    maxAge: opts.maxAge || 600 * 1000
+    maxAge: 'maxAge' in opts ? parseInt(opts.maxAge, 10) : 600 * 1000 // 10 minutes
   };
 
   res.cookie(key, value, Object.assign({}, basicAttr, {sameSite: sameSiteAttr, secure: isSameSiteNone}));
@@ -38,17 +38,18 @@ function store(key, res, opts = {}) {
  */
 function getOnce(key, req, res, opts = {}) {
 
-  if (!req.cookies && !req.cookies[key]) {
+  if (!req.cookies) {
     return undefined;
   }
 
   let value = req.cookies[key];
+  delete req.cookies[key];
   deleteCookie(key, res);
 
-  const fallbackCookie = opts.legacySameSiteCookie || true;
-  if (fallbackCookie) {
+  if ('legacySameSiteCookie' in opts ? opts.legacySameSiteCookie : true) {
     const fallbackKey = '_' + key;
     value = value || req.cookies[fallbackKey];
+    delete req.cookies[fallbackKey];
     deleteCookie(fallbackKey, res);
   }
 

--- a/lib/transientHandler.js
+++ b/lib/transientHandler.js
@@ -1,0 +1,74 @@
+const crypto = require('crypto');
+
+/**
+ * Set a cookie with a value or a generated nonce.
+ *
+ * @param {String} key Cookie name to use.
+ * @param {Object} res Current Express reponse object.
+ * @param {Object} opts Options for cookie setting.
+ *
+ * @return {String}
+ */
+function store(key, res, opts = {}) {
+  const sameSiteAttr = opts.sameSite || 'None';
+  const isSameSiteNone = sameSiteAttr === 'None';
+  const value = opts.value || createNonce();
+  const fallbackCookie = opts.legacySameSiteCookie || true;
+
+  const basicAttr = {
+    httpOnly: true,
+    maxAge: opts.maxAge || 600 * 1000
+  };
+
+  res.cookie(key, value, Object.assign({}, basicAttr, {sameSite: sameSiteAttr, secure: isSameSiteNone}));
+
+  if (isSameSiteNone && fallbackCookie) {
+    res.cookie('_' + key, value, basicAttr);
+  }
+
+  return value;
+}
+
+/**
+ * Get a cookie value then delete it.
+ *
+ * @param {String} key Cookie name to use.
+ * @param {Object} req Current Express request object.
+ * @param {Object} opts Options for cookie setting.
+ */
+function getOnce(key, req, res, opts = {}) {
+
+  if (!req.cookies && !req.cookies[key]) {
+    return undefined;
+  }
+
+  let value = req.cookies[key];
+  deleteCookie(key, res);
+
+  const fallbackCookie = opts.legacySameSiteCookie || true;
+  if (fallbackCookie) {
+    const fallbackKey = '_' + key;
+    value = value || req.cookies[fallbackKey];
+    deleteCookie(fallbackKey, res);
+  }
+
+  return value;
+}
+
+/**
+ * @return {String}
+ */
+function createNonce() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+/**
+ * @return {String}
+ */
+function deleteCookie(key, res) {
+  res.cookie(key, '', {maxAge: 0});
+}
+
+exports.store = store;
+exports.getOnce = getOnce;
+exports.createNonce = createNonce;

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -87,14 +87,15 @@ module.exports = function (params) {
 
       const redirect_uri = res.openid.getRedirectUri();
       const client = req.openid.client;
+      const transientOpts = {legacySameSiteCookie: config.legacySameSiteCookie};
 
       let tokenSet;
 
       try {
         const callbackParams = client.callbackParams(req);
         tokenSet = await client.callback(redirect_uri, callbackParams, {
-          nonce: transient.getOnce('nonce', req, res),
-          state: transient.getOnce('state', req, res),
+          nonce: transient.getOnce('nonce', req, res, transientOpts),
+          state: transient.getOnce('state', req, res, transientOpts),
           response_type: authorizeParams.response_type,
         });
       } catch (err) {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -86,10 +86,7 @@ module.exports = function (params) {
     try {
       const redirect_uri = res.openid.getRedirectUri();
       const client = req.openid.client;
-      const transientOpts = {
-        legacySameSiteCookie: config.legacySameSiteCookie,
-        sameSite: config.authorizationParams.response_mode === 'form_post' ? 'None' : 'Lax'
-      };
+      const transientOpts = { legacySameSiteCookie: config.legacySameSiteCookie };
 
       let tokenSet;
 
@@ -106,7 +103,7 @@ module.exports = function (params) {
 
       req.session.openidTokens = tokenSet;
 
-      const returnTo = transient.getOnce('returnTo', req, res) || '/';
+      const returnTo = transient.getOnce('returnTo', req, res, transientOpts) || '/';
 
       res.redirect(returnTo);
     } catch (err) {

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -84,10 +84,12 @@ module.exports = function (params) {
   router[callbackMethod](config.redirectUriPath, express.urlencoded({ extended: false }), cookieParser(), async (req, res, next) => {
     next = cb(next).once();
     try {
-
       const redirect_uri = res.openid.getRedirectUri();
       const client = req.openid.client;
-      const transientOpts = {legacySameSiteCookie: config.legacySameSiteCookie};
+      const transientOpts = {
+        legacySameSiteCookie: config.legacySameSiteCookie,
+        sameSite: config.authorizationParams.response_mode === 'form_post' ? 'None' : 'Lax'
+      };
 
       let tokenSet;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -675,6 +675,22 @@
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
       "dev": true
     },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+        }
+      }
+    },
     "cookie-session": {
       "version": "2.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.0.0-beta.3.tgz",
@@ -701,8 +717,7 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
-      "dev": true
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookies": {
       "version": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.1",
-    "body-parser": "^1.19.0",
     "chai": "^4.2.0",
     "cookie-session": "^2.0.0-beta.3",
     "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@hapi/joi": "^14.5.0",
     "cb": "^0.1.0",
     "clone": "^2.1.2",
+    "cookie-parser": "^1.4.4",
     "http-errors": "^1.7.3",
     "openid-client": "^3.7.3",
     "p-memoize": "^3.1.0",

--- a/test/auth.tests.js
+++ b/test/auth.tests.js
@@ -110,7 +110,7 @@ describe('auth', function() {
       let router;
 
       before(async function() {
-        router = router = expressOpenid.auth({
+        router = expressOpenid.auth({
           clientID: '__test_client_id__',
           clientSecret: '__test_client_secret__',
           baseURL: 'https://example.org',
@@ -140,6 +140,19 @@ describe('auth', function() {
         assert.equal(parsed.query.redirect_uri, 'https://example.org/callback');
         assert.property(parsed.query, 'nonce');
         assert.property(parsed.query, 'state');
+        assert.property(res.headers, 'set-cookie');
+
+        // ccookieJar is not respecting cookies set with SameSite
+        const cookieHeaders = res.headers['set-cookie'];
+
+        assert.equal(
+          cookieHeaders.filter(header => header.substring(0,6) === 'nonce=')[0].split('; ')[0].split('=')[1],
+          parsed.query.nonce
+        );
+        assert.equal(
+          cookieHeaders.filter(header => header.substring(0,6) === 'state=')[0].split('; ')[0].split('=')[1],
+          parsed.query.state
+        );
       });
 
       it('should contain a callback route', function() {
@@ -152,7 +165,7 @@ describe('auth', function() {
       let baseUrl;
 
       before(async function() {
-        router = router = expressOpenid.auth({
+        router = expressOpenid.auth({
           clientID: '__test_client_id__',
           baseURL: 'https://example.org',
           issuerBaseURL: 'https://test.auth0.com',

--- a/test/auth.tests.js
+++ b/test/auth.tests.js
@@ -49,7 +49,6 @@ describe('auth', function() {
       assert.equal(parsed.hostname, 'test.auth0.com');
       assert.equal(parsed.pathname, '/authorize');
       assert.equal(parsed.query.client_id, '__test_client_id__');
-
       assert.equal(parsed.query.scope, 'openid profile email');
       assert.equal(parsed.query.response_type, 'id_token');
       assert.equal(parsed.query.response_mode, 'form_post');
@@ -57,9 +56,10 @@ describe('auth', function() {
       assert.property(parsed.query, 'nonce');
       assert.property(parsed.query, 'state');
 
-      const session = (await request.get('/session', { jar, baseUrl, json: true })).body;
-      assert.equal(session.nonce, parsed.query.nonce);
-      assert.equal(session.state, parsed.query.state);
+      const cookies = jar.getCookies(baseUrl + '/login');
+
+      assert.equal(cookies.filter(cookie => cookie.key === '_nonce')[0].value, parsed.query.nonce);
+      assert.equal(cookies.filter(cookie => cookie.key === '_state')[0].value, parsed.query.state);
     });
 
   });

--- a/test/auth.tests.js
+++ b/test/auth.tests.js
@@ -13,6 +13,22 @@ const filterRoute = (method, path) => {
               r.route.methods[method.toLowerCase()];
 };
 
+const getCookieFromResponse = (res, cookieName) => {
+  const cookieHeaders = res.headers['set-cookie'];
+
+  const foundHeader = cookieHeaders.filter(header => header.substring(0,6) === cookieName + '=')[0];
+  if (!foundHeader) {
+    return false;
+  }
+
+  const cookieValuePart = foundHeader.split('; ')[0];
+  if (!cookieValuePart) {
+    return false;
+  }
+
+  return cookieValuePart.split('=')[1];
+};
+
 describe('auth', function() {
   describe('default', () => {
 
@@ -142,17 +158,8 @@ describe('auth', function() {
         assert.property(parsed.query, 'state');
         assert.property(res.headers, 'set-cookie');
 
-        // ccookieJar is not respecting cookies set with SameSite
-        const cookieHeaders = res.headers['set-cookie'];
-
-        assert.equal(
-          cookieHeaders.filter(header => header.substring(0,6) === 'nonce=')[0].split('; ')[0].split('=')[1],
-          parsed.query.nonce
-        );
-        assert.equal(
-          cookieHeaders.filter(header => header.substring(0,6) === 'state=')[0].split('; ')[0].split('=')[1],
-          parsed.query.state
-        );
+        assert.equal(getCookieFromResponse(res, 'nonce'), parsed.query.nonce);
+        assert.equal(getCookieFromResponse(res, 'state'), parsed.query.state);
       });
 
       it('should contain a callback route', function() {

--- a/test/callback_route_form_post.tests.js
+++ b/test/callback_route_form_post.tests.js
@@ -26,10 +26,12 @@ function testCase(params) {
     before(async function() {
       this.jar = jar;
       this.baseUrl = baseUrl = await server.create(router);
-      await request.post({
-        uri: '/session',
-        baseUrl, jar,
-        json: params.session
+
+      Object.keys(params.cookies).forEach(function(cookieName) {
+        jar.setCookie(
+          `${cookieName}=${params.cookies[cookieName]}; Max-Age=3600; Path=/; HttpOnly;`,
+          baseUrl + '/callback',
+        );
       });
     });
 
@@ -60,7 +62,7 @@ function testCase(params) {
 
 describe('callback routes response_type: id_token, response_mode: form_post', function() {
   describe('when body is empty', testCase({
-    session: {
+    cookies: {
       nonce: '__test_nonce__',
       state: '__test_state__'
     },
@@ -77,7 +79,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
   }));
 
   describe("when state doesn't match", testCase({
-    session: {
+    cookies: {
       nonce: '__test_nonce__',
       state: '__valid_state__'
     },
@@ -96,7 +98,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
   }));
 
   describe("when id_token can't be parsed", testCase({
-    session: {
+    cookies: {
       nonce: '__test_nonce__',
       state: '__test_state__'
     },
@@ -116,7 +118,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
   }));
 
   describe('when id_token has invalid alg', testCase({
-    session: {
+    cookies: {
       nonce: '__test_nonce__',
       state: '__test_state__'
     },
@@ -136,7 +138,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
   }));
 
   describe('when id_token is missing issuer', testCase({
-    session: {
+    cookies: {
       nonce: '__test_nonce__',
       state: '__test_state__'
     },
@@ -156,7 +158,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
   }));
 
   describe('when id_token is valid', testCase({
-    session: {
+    cookies: {
       state: '__test_state__',
       nonce: '__test_nonce__',
       returnTo: '/return-to'

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -20,11 +20,6 @@ module.exports.create = function(router, protect) {
     res.json(req.session);
   });
 
-  app.post('/session', (req, res) => {
-    req.session = req.body;
-    res.json(req.body);
-  });
-
   app.get('/user', (req, res) => {
     res.json(req.openid.user);
   });

--- a/test/transientHandler.tests.js
+++ b/test/transientHandler.tests.js
@@ -1,0 +1,138 @@
+const { assert } = require('chai');
+const transientHandler = require('../lib/transientHandler');
+
+class ResultMock {
+  constructor() {
+    this.resetArgs();
+  }
+
+  cookie() {
+    this.args.push(arguments);
+  }
+
+  resetArgs() {
+    this.args = [];
+  }
+}
+
+describe('transientHandler', function() {
+
+  let res = new ResultMock();
+
+  beforeEach(async function() {
+    res.resetArgs();
+  });
+
+  describe('store()', function() {
+    it('should use the passed-in key to set the cookie', function() {
+      transientHandler.store('test_key', res);
+
+      assert.equal('test_key', res.args[0][0]); // Main cookie
+      assert.equal('_test_key', res.args[1][0]); // Fallback cookie
+    });
+
+    it('should return the same nonce as the cookie value', function() {
+      const value = transientHandler.store('test_key', res, {});
+      assert.equal(value, res.args[0][1]); // Main cookie
+      assert.equal(value, res.args[1][1]); // Fallback cookie
+    });
+
+    it('should set SameSite=None, secure, and fallback cookie by default', function() {
+      transientHandler.store('test_key', res);
+
+      assert.equal('None', res.args[0][2].sameSite); // Main cookie
+      assert.equal(true, res.args[0][2].secure); // Main cookie
+      assert.equal(true, res.args[0][2].httpOnly); // Main cookie
+      assert.equal(600000, res.args[0][2].maxAge); // Main cookie
+
+      assert.equal('_test_key', res.args[1][0]); // Fallback cookie
+      assert.equal(true, res.args[1][2].httpOnly); // Fallback cookie
+      assert.equal(600000, res.args[1][2].maxAge); // Fallback cookie
+      assert.equal(undefined, res.args[1][2].sameSite); // Fallback cookie
+      assert.equal(undefined, res.args[1][2].secure); // Fallback cookie
+    });
+
+    it('should turn off fallback', function() {
+      transientHandler.store('test_key', res, {legacySameSiteCookie: false});
+
+      assert.equal('test_key', res.args[0][0]); // Main cookie
+      assert.equal(undefined, res.args[1]); // Fallback cookie
+    });
+
+    it('should set custom SameSite with no fallback', function() {
+      transientHandler.store('test_key', res, {sameSite: 'Lax'});
+
+      assert.equal('Lax', res.args[0][2].sameSite); // Main cookie
+      assert.equal(false, res.args[0][2].secure); // Main cookie
+
+      assert.equal(undefined, res.args[1]); // Fallback cookie
+    });
+
+    it('should use the passed-in value', function() {
+      const value = transientHandler.store('test_key', res, {value: '__test_value__'});
+      assert.equal('__test_value__', value);
+      assert.equal(value, res.args[0][1]); // Main cookie
+      assert.equal(value, res.args[1][1]); // Fallback cookie
+    });
+
+    it('should set a custom maxAge', function() {
+      transientHandler.store('test_key', res, {maxAge: 123456789});
+
+      assert.equal(123456789, res.args[0][2].maxAge); // Main cookie
+      assert.equal(123456789, res.args[1][2].maxAge); // Fallback cookie
+    });
+  });
+
+  describe('getOnce()', function() {
+    it('should return undefined if there are no cookies', function() {
+      assert.equal(transientHandler.getOnce('test_key', {cookies: undefined}, res), undefined);
+    });
+
+    it('should return main value and delete both cookies by default', function() {
+      const req = {cookies: {test_key: '__test_value__', _test_key: '__test_fallback_value__'}};
+      const value = transientHandler.getOnce('test_key', req, res);
+
+      assert.equal(value, '__test_value__');
+
+      assert.equal('test_key', res.args[0][0]); // Main cookie
+      assert.equal('', res.args[0][1]); // Main cookie
+      assert.equal(0, res.args[0][2].maxAge); // Main cookie
+      assert.equal(undefined, req.cookies.test_key); // Main cookie
+
+      assert.equal('_test_key', res.args[1][0]); // Fallback cookie
+      assert.equal('', res.args[1][1]); // Fallback cookie
+      assert.equal(0, res.args[1][2].maxAge); // Fallback cookie
+      assert.equal(undefined, req.cookies._test_key); // Fallback cookie
+    });
+
+    it('should return fallback value and delete both cookies if main value not present', function() {
+      const req = {cookies: {_test_key: '__test_fallback_value__'}};
+      const value = transientHandler.getOnce('test_key', req, res);
+
+      assert.equal(value, '__test_fallback_value__');
+
+      assert.equal('test_key', res.args[0][0]); // Main cookie
+      assert.equal('', res.args[0][1]); // Main cookie
+      assert.equal(0, res.args[0][2].maxAge); // Main cookie
+
+      assert.equal('_test_key', res.args[1][0]); // Fallback cookie
+      assert.equal('', res.args[1][1]); // Fallback cookie
+      assert.equal(0, res.args[1][2].maxAge); // Fallback cookie
+      assert.equal(undefined, req.cookies._test_key); // Fallback cookie
+    });
+
+    it('should not delete fallback cookie if legacy support is off', function() {
+      const req = {cookies: {test_key: '__test_value__', _test_key: '__test_fallback_value__'}};
+      const value = transientHandler.getOnce('test_key', req, res, {legacySameSiteCookie: false});
+
+      assert.equal(value, '__test_value__');
+
+      assert.equal('test_key', res.args[0][0]); // Main cookie
+      assert.equal('', res.args[0][1]); // Main cookie
+      assert.equal(0, res.args[0][2].maxAge); // Main cookie
+
+      assert.equal(undefined, res.args[1]); // Fallback cookie
+      assert.equal('__test_fallback_value__', req.cookies._test_key); // Fallback cookie
+    });
+  });
+});


### PR DESCRIPTION
### Description

When merged, this PR will add SameSite cookie support for required authentication values. Both the `nonce` (checked against the value in the ID token during callback) and `state` (checked against the value returned from the authorization server during callback) values will move from session storage to cookie storage. This allows a SameSite attribute of `None` to be added, as well as a Secure flag, when the `response_type` of `form_post` is used (this is the default configuration). 

By default, a legacy support cookie with **no** SameSite attribute and **no** Secure flag will be set as well (this can be turned off with the `legacySameSiteCookie` attribute passed to the `auth()` configuration). This is done to support browsers that do not handle SameSite cookies set to `None` but has the added benefit of allowing insecure local applications to function without SSL/TLS in the interim.

**Please note:** The browser changes unexplained in the Web.dev article below will **require** all applications (including local ones) using the `response_mode` of `form_post` (default for this library) to be served over HTTPS. 

#### Changes to follow

There are a few more changes that need to happen in this library to fully support SameSite. These will come in [a] separate PR[s]:

- This library should not require session management to be setup by developers. Instead, we will use our own internal session, which will be cookies by default but configurable. This authentication session will use SameSite=Lax and will not provide a public API to change/add.
- We will continue using separate cookies for the transient `state` and `nonce` values (as introduced here).
- We need to add support for `max_age` (have an internal task tracking that).

### References 

[Web.dev: SameSite cookies explained](https://web.dev/samesite-cookies-explained/)

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
