### PR TITLE
Fix openidTokens casing in examples and fix type for unauthorizedHandler

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -109,7 +109,7 @@ app.use(auth({
   appSessionSecret: false,
   handleCallback: async function (req, res, next) {
     // This will store the user identity claims in the session
-    req.session.userIdentity = req.openIdTokens.claims();
+    req.session.userIdentity = req.openidTokens.claims();
     next();
   },
   getUser: async function (req) {
@@ -141,7 +141,7 @@ app.use(auth({
     scope: 'openid profile email read:reports'
   },
   handleCallback: async function (req, res, next) {
-    req.session.openIdTokens = req.openIdTokens;
+    req.session.openidTokens = req.openidTokens;
     next();
   }
 }));
@@ -152,7 +152,7 @@ On a route that needs to use the access token, pull the token data from the stor
 ```js
 app.get('/route-that-calls-an-api', async (req, res, next) => {
 
-  const tokenSet = req.openid.makeTokenSet(req.session.openIdTokens);
+  const tokenSet = req.openid.makeTokenSet(req.session.openidTokens);
   let apiData = {};
 
   // Check for and use tokenSet.access_token for the API call ...
@@ -188,7 +188,7 @@ app.get('/route-that-calls-an-api', async (req, res, next) => {
   let apiData = {};
 
   // How the tokenSet is created will depend on how the tokens are stored.
-  let tokenSet = req.openid.makeTokenSet(req.session.openIdTokens);
+  let tokenSet = req.openid.makeTokenSet(req.session.openidTokens);
   let refreshToken = tokenSet.refresh_token;
 
   if (tokenSet && tokenSet.expired() && refreshToken) {
@@ -202,7 +202,7 @@ app.get('/route-that-calls-an-api', async (req, res, next) => {
     tokenSet.refresh_token = tokenSet.refresh_token ?? refreshToken;
 
     // Where you store the refreshed tokenSet will depend on how the tokens are stored.
-    req.session.openIdTokens = tokenSet;
+    req.session.openidTokens = tokenSet;
   }
 
   // Check for and use tokenSet.access_token for the API call ...

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for express-openid-connect
 
 import { AuthorizationParameters, TokenSet, UserinfoResponse } from 'openid-client';
-import { Request, Response, NextFunction, RequestHandler } from 'express';
+import { Request, Response, NextFunction, RequestHandler, ErrorRequestHandler } from 'express';
 
 interface ConfigParams {
     /**
@@ -141,4 +141,4 @@ interface SessionCookieConfigParams {
 
 export function auth(params?: ConfigParams): RequestHandler;
 export function requiresAuth(): RequestHandler;
-export function unauthorizedHandler(): RequestHandler;
+export function unauthorizedHandler(): ErrorRequestHandler;


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
The casing in Examples.md was off for `openidTokens`. In examples, we were using `openIdTokens` (capital `i`), but in code, we are using `openidTokens`. 

The typing for unauthorizedHandler was using RequestHandler, but in code it is a RequestErrorHandler. 

* openIdToken -> openidToken
* unauthorizedHandler typing: RequestHandler -> ErrorRequestHandler


### References

No References

### Testing

No Testing needed.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
