### PR TITLE
Fix TS definition for appSessionSecret

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ interface ConfigParams {
      * REQUIRED. The secret(s) used to derive an encryption key for the user identity in a session cookie.
      * Can use env key APP_SESSION_SECRET instead.
      */
-    appSessionSecret: boolean | string | string[];
+    appSessionSecret?: boolean | string | string[];
 
     /**
      * Boolean value to enable Auth0's logout feature.


### PR DESCRIPTION
### Description

Fix TS definition for `appSessionSecret` config key, should be optional as it can be defined in an env var.

### References

Related to #46