### PR TITLE
Additional allowed cookieOptions

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,7 +21,7 @@ If you are using a response type that includes `code` (typically combined with a
 
 Additional configuration keys that can be passed to `auth()` on initialization:
 
-- **`appSessionCookie`** - Object defining application session cookie attributes. Allowed keys are `domain`, `ephemeral`, `httpOnly`, `path`, `secure`, and `sameSite`. Defaults are `true` for `httpOnly` and `false` for `ephemeral`. See the [Express Response documentation](https://expressjs.com/en/api.html#res.cookie) for more information on how all properties except `ephemeral`.
+- **`appSessionCookie`** - Object defining application session cookie attributes. Allowed keys are `domain`, `ephemeral`, `httpOnly`, `path`, `secure`, and `sameSite`. Defaults are `true` for `httpOnly`, `Lax` for `sameSite`, and `false` for `ephemeral`. See the [Express Response documentation](https://expressjs.com/en/api.html#res.cookie) for more information on all properties except `ephemeral`.
 - **`appSessionDuration`** - Integer value, in seconds, for application session duration. Default is 7 days.
 - **`appSessionName`** - String value for the cookie name used for the internal session. This value must only include letters, numbers, and underscores. Default is `identity`.
 - **`auth0Logout`** - Boolean value to enable Auth0's logout feature. Default is `false`.

--- a/API.md
+++ b/API.md
@@ -21,7 +21,7 @@ If you are using a response type that includes `code` (typically combined with a
 
 Additional configuration keys that can be passed to `auth()` on initialization:
 
-- **`appSessionCookie`** - Object defining application session cookie attributes. Allowed keys are `domain`, `ephemeral`, `httpOnly`, `path`, `secure`, and `sameSite`. Defaults are `true` for `httpOnly`, `Lax` for `sameSite`, and `false` for `ephemeral`. See the [Express Response documentation](https://expressjs.com/en/api.html#res.cookie) for more information on how all properties except `ephemeral`.
+- **`appSessionCookie`** - Object defining application session cookie attributes. Allowed keys are `domain`, `ephemeral`, `httpOnly`, `path`, `secure`, and `sameSite`. Defaults are `true` for `httpOnly` and `false` for `ephemeral`. See the [Express Response documentation](https://expressjs.com/en/api.html#res.cookie) for more information on how all properties except `ephemeral`.
 - **`appSessionDuration`** - Integer value, in seconds, for application session duration. Default is 7 days.
 - **`appSessionName`** - String value for the cookie name used for the internal session. This value must only include letters, numbers, and underscores. Default is `identity`.
 - **`auth0Logout`** - Boolean value to enable Auth0's logout feature. Default is `false`.

--- a/API.md
+++ b/API.md
@@ -21,8 +21,8 @@ If you are using a response type that includes `code` (typically combined with a
 
 Additional configuration keys that can be passed to `auth()` on initialization:
 
-- **`appSessionCookie`** - Object defining application session cookie attributes. Allowed keys are `domain`, `httpOnly`, `path`, `secure`, and `sameSite`. Defaults are `true` for `httpOnly` and `Lax` for `sameSite`.
-- **`appSessionDuration`** - Integer value, in seconds, for application session duration. Set to `0` to indicate the cookie should be ephemeral (no expiration). Default is 7 days.
+- **`appSessionCookie`** - Object defining application session cookie attributes. Allowed keys are `domain`, `ephemeral`, `httpOnly`, `path`, `secure`, and `sameSite`. Defaults are `true` for `httpOnly`, `Lax` for `sameSite`, and `false` for `ephemeral`. See the [Express Response documentation](https://expressjs.com/en/api.html#res.cookie) for more information on how all properties except `ephemeral`.
+- **`appSessionDuration`** - Integer value, in seconds, for application session duration. Default is 7 days.
 - **`appSessionName`** - String value for the cookie name used for the internal session. This value must only include letters, numbers, and underscores. Default is `identity`.
 - **`auth0Logout`** - Boolean value to enable Auth0's logout feature. Default is `false`.
 - **`authorizationParams`** - Object that describes the authorization server request. [See below](#authorization-params-key) for defaults and more details.

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,9 @@
 import { AuthorizationParameters, TokenSet, UserinfoResponse } from 'openid-client';
 import { Request, Response, NextFunction, RequestHandler, ErrorRequestHandler } from 'express';
 
+/**
+ * Configuration parameters passed to the auth() middleware.
+ */
 interface ConfigParams {
     /**
      * Object defining application session cookie attributes.
@@ -131,12 +134,43 @@ interface ConfigParams {
     routes?: boolean;
 }
 
+/**
+ * Configuration parameters used in appSessionCookie.
+ *
+ * @see https://expressjs.com/en/api.html#res.cookie
+ */
 interface SessionCookieConfigParams {
+    /**
+     * Domain name for the cookie.
+     */
     domain?: string;
+
+    /**
+     * Set to true to use an ephemeral cookie.
+     * Default is false which will use appSessionDuration.
+     */
+    ephemeral?: boolean;
+
+    /**
+     * Flags the cookie to be accessible only by the web server.
+     * Set to `true` by default in lib/config.
+     */
     httpOnly?: boolean;
+
+    /**
+     * Path for the cookie.
+     */
     path?: string;
-    sameSite?: string;
+
+    /**
+     * Marks the cookie to be used with HTTPS only.
+     */
     secure?: boolean;
+
+    /**
+     * Value of the “SameSite” Set-Cookie attribute.
+     */
+    sameSite?: string;
 }
 
 export function auth(params?: ConfigParams): RequestHandler;

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,7 +147,7 @@ interface SessionCookieConfigParams {
 
     /**
      * Set to true to use an ephemeral cookie.
-     * Default is false which will use appSessionDuration.
+     * Defaults to false which will use appSessionDuration as the cookie expiration.
      */
     ephemeral?: boolean;
 

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -50,7 +50,7 @@ module.exports = ({ name, secret, duration, cookieOptions = {} }) => {
     if (req[name] && Object.keys(req[name]).length > 0) {
       const value = encrypt(JSON.stringify(req[name]), { iat, uat, exp });
 
-      let thisCookieOptions = Object.assign({}, cookieOptions);
+      const thisCookieOptions = Object.assign({}, cookieOptions);
       thisCookieOptions.expires = cookieOptions.ephemeral ? 0 : new Date(exp * 1000);
       delete thisCookieOptions.ephemeral;
 

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -49,9 +49,11 @@ module.exports = ({ name, secret, duration, cookieOptions = {} }) => {
 
     if (req[name] && Object.keys(req[name]).length > 0) {
       const value = encrypt(JSON.stringify(req[name]), { iat, uat, exp });
-      const expires = !duration ? 0 : new Date(exp * 1000);
 
-      res.cookie(name, value, {expires, ...cookieOptions});
+      cookieOptions.expires = cookieOptions.ephemeral ? 0 : new Date(exp * 1000);
+      delete cookieOptions.ephemeral;
+
+      res.cookie(name, value, cookieOptions);
     }
   }
 

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -50,10 +50,11 @@ module.exports = ({ name, secret, duration, cookieOptions = {} }) => {
     if (req[name] && Object.keys(req[name]).length > 0) {
       const value = encrypt(JSON.stringify(req[name]), { iat, uat, exp });
 
-      cookieOptions.expires = cookieOptions.ephemeral ? 0 : new Date(exp * 1000);
-      delete cookieOptions.ephemeral;
+      let thisCookieOptions = Object.assign({}, cookieOptions);
+      thisCookieOptions.expires = cookieOptions.ephemeral ? 0 : new Date(exp * 1000);
+      delete thisCookieOptions.ephemeral;
 
-      res.cookie(name, value, cookieOptions);
+      res.cookie(name, value, thisCookieOptions);
     }
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,9 +16,15 @@ const authorizationParamsSchema = Joi.object().keys({
   scope: Joi.string().required()
 }).unknown(true);
 
+const defaultAppSessionCookie = {
+  httpOnly: true,
+  sameSite: 'Lax',
+  ephemeral: false
+};
+
 const appSessionCookieSchema = Joi.object().keys({
   domain: Joi.string().optional(),
-  ephemeral: Joi.boolean().optional().default(false),
+  ephemeral: Joi.boolean().optional(),
   httpOnly: Joi.boolean().optional(),
   path: Joi.string().optional(),
   sameSite: Joi.string().valid(['Lax', 'Strict', 'None']).optional(),
@@ -91,7 +97,7 @@ If the user provides authorizationParams then
 function buildAppSessionCookieConfig(cookieConfig) {
 
   cookieConfig = cookieConfig && Object.keys(cookieConfig).length ? cookieConfig : {};
-  cookieConfig = Object.assign({ httpOnly: true }, cookieConfig);
+  cookieConfig = Object.assign({}, defaultAppSessionCookie, cookieConfig);
   const cookieConfigValidation = Joi.validate(cookieConfig, appSessionCookieSchema);
 
   if(cookieConfigValidation.error) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,6 +18,7 @@ const authorizationParamsSchema = Joi.object().keys({
 
 const appSessionCookieSchema = Joi.object().keys({
   domain: Joi.string().optional(),
+  ephemeral: Joi.boolean().optional().default(false),
   httpOnly: Joi.boolean().optional(),
   path: Joi.string().optional(),
   sameSite: Joi.string().valid(['Lax', 'Strict', 'None']).optional(),

--- a/test/appSession.tests.js
+++ b/test/appSession.tests.js
@@ -5,21 +5,20 @@ const sessionEncryption = require('./fixture/sessionEncryption');
 const defaultConfig = {
   name: 'identity',
   secret: '__test_secret__',
-  duration: 1234567890,
+  duration: 3155760000, // 100 years
   cookieOptions: {}
 };
 
 const req = {
   get: (key) => key
 };
-const res = {};
 const next = () => true;
 
 describe('appSession', function() {
 
   describe('no session cookies, no session property', () => {
     const appSessionMw = appSession(defaultConfig);
-    const result = appSessionMw(req, res, next);
+    const result = appSessionMw(req, {}, next);
 
     it('should call next', function() {
       assert.ok(result);
@@ -33,7 +32,7 @@ describe('appSession', function() {
   describe('no session cookies, existing session property', () => {
     const appSessionMw = appSession(defaultConfig);
     const thisReq = Object.assign({}, req, {identity: {sub: '__test_existing_sub__'}});
-    const result = appSessionMw(thisReq, res, next);
+    const result = appSessionMw(thisReq, {}, next);
 
     it('should call next', function() {
       assert.ok(result);
@@ -49,7 +48,7 @@ describe('appSession', function() {
     const thisReq = {get: () => 'identity=__invalid_identity__'};
 
     it('should error with malformed identity', function() {
-      assert.throws(() => appSessionMw(thisReq, res, next), Error, 'JWE malformed or invalid serialization');
+      assert.throws(() => appSessionMw(thisReq, {}, next), Error, 'JWE malformed or invalid serialization');
     });
   });
 
@@ -58,9 +57,83 @@ describe('appSession', function() {
     const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
 
     it('should set the identity on req', function() {
-      const result = appSessionMw(thisReq, res, next);
+      const result = appSessionMw(thisReq, {}, next);
       assert.ok(result);
       assert.equal(thisReq.identity.sub, '__test_sub__');
+
+    });
+  });
+
+  describe('sessioncookie options', () => {
+    let cookieArgs;
+    const thisRes = {
+      cookie: function cookie() {cookieArgs = JSON.parse(JSON.stringify(arguments)); },
+      writeHead: () => null,
+      setHeader: () => null
+    };
+
+    beforeEach(function() {
+      cookieArgs = {};
+    });
+
+    it('should set the correct cookie by default', function() {
+      const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
+      const appSessionMw = appSession(defaultConfig);
+      const result = appSessionMw(thisReq, thisRes, next);
+      thisRes.writeHead();
+
+      assert.ok(result);
+      assert.equal(cookieArgs['0'], 'identity');
+      assert.isNotEmpty(cookieArgs['1']);
+      assert.isObject(cookieArgs['2']);
+      assert.hasAllKeys(cookieArgs['2'], ['expires']);
+
+      const expDate = new Date(cookieArgs['2'].expires);
+      assert.equal( (expDate.getFullYear() - (new Date()).getFullYear()), 100);
+    });
+
+    it('should set the correct custom cookie name', function() {
+      const thisReq = {get: () => 'customName=' + sessionEncryption.encrypted};
+      const customConfig = Object.assign({}, defaultConfig, {name: 'customName'});
+      const appSessionMw = appSession(customConfig);
+      const result = appSessionMw(thisReq, thisRes, next);
+      thisRes.writeHead();
+
+      assert.ok(result);
+      assert.equal(cookieArgs['0'], 'customName');
+    });
+
+    it('should set an ephemeral cookie', function() {
+      const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
+      const customConfig = Object.assign({}, defaultConfig, {cookieOptions: {ephemeral: true}});
+      const appSessionMw = appSession(customConfig);
+      const result = appSessionMw(thisReq, thisRes, next);
+      thisRes.writeHead();
+
+      assert.ok(result);
+      assert.equal(cookieArgs['2'].expires, 0);
+    });
+
+    it('should pass custom cookie options', function() {
+      const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
+      const cookieOptConfig = {cookieOptions: {
+        domain: '__test_domain__',
+        path: '__test_path__',
+        secure: true,
+        httpOnly: false,
+        sameSite: '__test_samesite__',
+      }};
+      const customConfig = Object.assign({}, defaultConfig, cookieOptConfig);
+      const appSessionMw = appSession(customConfig);
+      const result = appSessionMw(thisReq, thisRes, next);
+      thisRes.writeHead();
+
+      assert.ok(result);
+      assert.equal(cookieArgs['2'].domain, '__test_domain__');
+      assert.equal(cookieArgs['2'].path, '__test_path__');
+      assert.equal(cookieArgs['2'].secure, true);
+      assert.equal(cookieArgs['2'].httpOnly, false);
+      assert.equal(cookieArgs['2'].sameSite, '__test_samesite__');
     });
   });
 });

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -134,7 +134,7 @@ describe('config', function() {
       assert.notExists(config.appSessionCookie.domain);
       assert.notExists(config.appSessionCookie.path);
       assert.notExists(config.appSessionCookie.secure);
-      assert.notExists(config.appSessionCookie.sameSite);
+      assert.equal(config.appSessionCookie.sameSite, 'Lax');
       assert.equal(config.appSessionCookie.httpOnly, true);
     });
   });
@@ -150,7 +150,7 @@ describe('config', function() {
         ephemeral: true,
         httpOnly: false,
         secure: true,
-        sameSite: 'Lax',
+        sameSite: 'Strict',
       }
     });
 
@@ -174,7 +174,7 @@ describe('config', function() {
       assert.equal(config.appSessionCookie.ephemeral, true);
       assert.equal(config.appSessionCookie.httpOnly, false);
       assert.equal(config.appSessionCookie.secure, true);
-      assert.equal(config.appSessionCookie.sameSite, 'Lax');
+      assert.equal(config.appSessionCookie.sameSite, 'Strict');
     });
   });
 });

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -1,14 +1,16 @@
 const { assert } = require('chai');
 const { get: getConfig } = require('../lib/config');
 
+const defaultConfig = {
+  appSessionSecret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  issuerBaseURL: 'https://test.auth0.com',
+  baseURL: 'https://example.org'
+};
+
 describe('config', function() {
   describe('simple case', function() {
-    const config = getConfig({
-      appSessionSecret: false,
-      clientID: '__test_client_id__',
-      issuerBaseURL: 'https://test.auth0.com',
-      baseURL: 'https://example.org',
-    });
+    const config = getConfig(defaultConfig);
 
     it('should default to response_type=id_token', function() {
       assert.equal(config.authorizationParams.response_type, 'id_token');
@@ -28,16 +30,13 @@ describe('config', function() {
   });
 
   describe('when authorizationParams is response_type=x', function() {
-    const config = getConfig({
-      appSessionSecret: '__test_session_secret__',
-      clientID: '__test_client_id__',
+    const customConfig = Object.assign({}, defaultConfig, {
       clientSecret: '__test_client_secret__',
-      issuerBaseURL: 'https://test.auth0.com',
-      baseURL: 'https://example.org',
       authorizationParams: {
         response_type: 'code'
       }
     });
+    const config = getConfig(customConfig);
 
     it('should default to response_type=id_token', function() {
       assert.equal(config.authorizationParams.response_type, 'code');
@@ -53,13 +52,7 @@ describe('config', function() {
   });
 
   describe('with auth0Logout', function() {
-    const config = getConfig({
-      appSessionSecret: '__test_session_secret__',
-      clientID: '__test_client_id__',
-      issuerBaseURL: 'https://test.auth0.com',
-      baseURL: 'https://example.org',
-      auth0Logout: true
-    });
+    const config = getConfig(Object.assign({}, defaultConfig, {auth0Logout: true}));
 
     it('should set idpLogout to true', function() {
       assert.equal(config.auth0Logout, true);
@@ -68,12 +61,7 @@ describe('config', function() {
   });
 
   describe('without auth0Logout nor idpLogout', function() {
-    const config = getConfig({
-      appSessionSecret: '__test_session_secret__',
-      clientID: '__test_client_id__',
-      issuerBaseURL: 'https://test.auth0.com',
-      baseURL: 'https://example.org',
-    });
+    const config = getConfig(defaultConfig);
 
     it('should set both to false', function() {
       assert.equal(config.auth0Logout, false);
@@ -82,13 +70,7 @@ describe('config', function() {
   });
 
   describe('with idpLogout', function() {
-    const config = getConfig({
-      appSessionSecret: '__test_session_secret__',
-      clientID: '__test_client_id__',
-      issuerBaseURL: 'https://test.auth0.com',
-      baseURL: 'https://example.org',
-      idpLogout: true
-    });
+    const config = getConfig(Object.assign({}, defaultConfig, {idpLogout: true}));
 
     it('should set both to false', function() {
       assert.equal(config.auth0Logout, false);
@@ -97,12 +79,7 @@ describe('config', function() {
   });
 
   describe('default auth paths', function() {
-    const config = getConfig({
-      appSessionSecret: '__test_session_secret__',
-      clientID: '__test_client_id__',
-      issuerBaseURL: 'https://test.auth0.com',
-      baseURL: 'https://example.org',
-    });
+    const config = getConfig(defaultConfig);
 
     it('should set the default callback path', function() {
       assert.equal(config.redirectUriPath, '/callback');
@@ -118,15 +95,12 @@ describe('config', function() {
   });
 
   describe('custom auth paths', function() {
-    const config = getConfig({
-      appSessionSecret: '__test_session_secret__',
-      clientID: '__test_client_id__',
-      issuerBaseURL: 'https://test.auth0.com',
-      baseURL: 'https://example.org',
+    const customConfig = Object.assign({}, defaultConfig, {
       redirectUriPath: '/custom-callback',
       loginPath: '/custom-login',
       logoutPath: '/custom-logout',
     });
+    const config = getConfig(customConfig);
 
     it('should accept the custom callback path', function() {
       assert.equal(config.redirectUriPath, '/custom-callback');
@@ -142,12 +116,7 @@ describe('config', function() {
   });
 
   describe('app session default configuration', function() {
-    const config = getConfig({
-      appSessionSecret: '__test_session_secret__',
-      clientID: '__test_client_id__',
-      issuerBaseURL: 'https://test.auth0.com',
-      baseURL: 'https://example.org'
-    });
+    const config = getConfig(defaultConfig);
 
     it('should set the app session secret', function() {
       assert.equal(config.appSessionSecret, '__test_session_secret__');
@@ -171,40 +140,41 @@ describe('config', function() {
   });
 
   describe('app session cookie configuration', function() {
-    const config = getConfig({
+    const customConfig = Object.assign({}, defaultConfig, {
       appSessionSecret: [ '__test_session_secret_1__', '__test_session_secret_2__' ],
       appSessionName: '__test_custom_session_name__',
       appSessionDuration: 1234567890,
       appSessionCookie: {
         domain: '__test_custom_domain__',
         path: '__test_custom_path__',
+        ephemeral: true,
         httpOnly: false,
         secure: true,
         sameSite: 'Lax',
-      },
-      clientID: '__test_client_id__',
-      issuerBaseURL: 'https://test.auth0.com',
-      baseURL: 'https://example.org'
+      }
     });
 
     it('should set an array of secrets', function() {
+      const config = getConfig(customConfig);
       assert.equal(config.appSessionSecret.length, 2);
       assert.equal(config.appSessionSecret[0], '__test_session_secret_1__');
       assert.equal(config.appSessionSecret[1], '__test_session_secret_2__');
     });
 
     it('should set the custom session values', function() {
+      const config = getConfig(customConfig);
       assert.equal(config.appSessionDuration, 1234567890);
       assert.equal(config.appSessionName, '__test_custom_session_name__');
     });
 
     it('should set the session cookie attributes to custom values', function() {
+      const config = getConfig(customConfig);
       assert.equal(config.appSessionCookie.domain, '__test_custom_domain__');
       assert.equal(config.appSessionCookie.path, '__test_custom_path__');
+      assert.equal(config.appSessionCookie.ephemeral, true);
       assert.equal(config.appSessionCookie.httpOnly, false);
       assert.equal(config.appSessionCookie.secure, true);
       assert.equal(config.appSessionCookie.sameSite, 'Lax');
     });
   });
-
 });


### PR DESCRIPTION
### Description

- Adds an `ephemeral` flag to `appSessionCookie` that, when true, will set the `expire` attribute for the session cookie to `0`. Default value is `false`, which will use the `appSessionDuration` to set the cookie expiration. 
- Changes the default `sameSite` value in `appSessionCookie` to `Lax`. This does not change the behavior of the `nonce` or `state` cookies.

From the documentation: 

> Object defining application session cookie attributes. Allowed keys are `domain`, `ephemeral`, `httpOnly`, `path`, `secure`, and `sameSite`. Defaults are `true` for `httpOnly`, `Lax` for `sameSite`, and `false` for `ephemeral`. See the [Express Response documentation](https://expressjs.com/en/api.html#res.cookie) for more information on all properties except `ephemeral`.

### References

- https://expressjs.com/en/api.html#res.cookie
- https://github.com/joshcanhelp/express-openid-connect/pull/1

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
