### PR TITLE
Add custom state handling

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -236,28 +236,27 @@ app.use(auth({
 
 If your application needs to keep track of the request state before redirecting to log in, you can use the built-in state handling. By default, this library stores the post-callback redirect URL in a state object (along with a generated nonce) that is converted to a string, base64 encoded, and verified during callback (see [our documentation](https://auth0.com/docs/protocols/oauth2/oauth-state) for general information about this parameter). This state object can be added to and used during callback.
 
-You can define a `getLoginState` configuration key set to a function that takes an Express `RequestHandler` and an options object and returns a URL-safe string representation:
+You can define a `getLoginState` configuration key set to a function that takes an Express `RequestHandler` and an options object and returns a plain object:
 
 ```js
-const crypto = require('crypto');
-
 app.use(auth({
   getLoginState: function (req, options) {
-    const state = {
+    // This object will be stringified and base64 URL-safe encoded.
+    return {
       // Property used by the library for redirecting after logging in.
       returnTo: '/custom-return-path',
-      // Required to make sure the state parameter can't be replayed.
-      nonce: crypto.randomBytes(32).toString('hex');
       // Additional properties as needed.
       customProperty: req.someProperty,
     };
-    // This value will be sent in a URL parameter so it should be transfer-safe.
-    return req.openid.encodeState(state);
   },
   handleCallback: function (req, res, next) {
-    const decodedState = req.openid.decodeState(eq.openidState);
-    // The decodedState.customProperty is now available to use.
-    // Call next() to redirect to decodedState.returnTo.
+    // The req.openidState.customProperty is now available to use.
+    if ( req.openidState.customProperty ) {
+      // Do something ...
+    }
+
+    // Call next() to redirect to req.openidState.returnTo.
+    next();
   }
 }));
 ```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -231,3 +231,31 @@ app.use(auth({
   }
 }));
 ```
+
+## 8. Custom state handling
+
+If your application needs to keep track of the request state before redirecting to log in, you can use the built-in state handling. By default, this library stores the post-callback redirect URL in a state object (along with a generated nonce) that is converted to a string, base64 encoded, and verified during callback (see [our documentation](https://auth0.com/docs/protocols/oauth2/oauth-state) for general information about this parameter).
+
+You can define a `getLoginState` configuration key set to a function that takes an Express `RequestHandler` and an options object and returned a URL-safe string representation:
+
+```js
+const crypto = require('crypto');
+
+app.use(auth({
+  getLoginState: function (req, options) {
+    const state = {
+      // Property used by the library for redirecting after logging in.
+      returnTo: '/custom-return-path',
+      // Required to make sure the state parameter can't be replayed.
+      nonce: crypto.randomBytes(32).toString('hex');
+      // Additional properties as needed.
+      customProperty: req.someProperty,
+    };
+    return req.openid.encodeState(state);
+  },
+  handleCallback: function (req, res, next) {
+    const decodedState = req.openid.decodeState(eq.openidState);
+    // decodedState.customProperty now available to use.
+  }
+}));
+```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -234,9 +234,9 @@ app.use(auth({
 
 ## 8. Custom state handling
 
-If your application needs to keep track of the request state before redirecting to log in, you can use the built-in state handling. By default, this library stores the post-callback redirect URL in a state object (along with a generated nonce) that is converted to a string, base64 encoded, and verified during callback (see [our documentation](https://auth0.com/docs/protocols/oauth2/oauth-state) for general information about this parameter).
+If your application needs to keep track of the request state before redirecting to log in, you can use the built-in state handling. By default, this library stores the post-callback redirect URL in a state object (along with a generated nonce) that is converted to a string, base64 encoded, and verified during callback (see [our documentation](https://auth0.com/docs/protocols/oauth2/oauth-state) for general information about this parameter). This state object can be added to and used during callback.
 
-You can define a `getLoginState` configuration key set to a function that takes an Express `RequestHandler` and an options object and returned a URL-safe string representation:
+You can define a `getLoginState` configuration key set to a function that takes an Express `RequestHandler` and an options object and returns a URL-safe string representation:
 
 ```js
 const crypto = require('crypto');
@@ -251,11 +251,13 @@ app.use(auth({
       // Additional properties as needed.
       customProperty: req.someProperty,
     };
+    // This value will be sent in a URL parameter so it should be transfer-safe.
     return req.openid.encodeState(state);
   },
   handleCallback: function (req, res, next) {
     const decodedState = req.openid.decodeState(eq.openidState);
-    // decodedState.customProperty now available to use.
+    // The decodedState.customProperty is now available to use.
+    // Call next() to redirect to decodedState.returnTo.
   }
 }));
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,7 +69,7 @@ interface ConfigParams {
     errorOnRequiredAuth?: boolean;
 
     /**
-     * Function that returns a transient state value for `res.openid.login()`.
+     * Function that returns a URL-safe state value for `res.openid.login()`.
      */
     getLoginState?: (req: Request, config: object) => string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,11 @@ interface ConfigParams {
     errorOnRequiredAuth?: boolean;
 
     /**
+     * Function that returns a transient state value for `res.openid.login()`.
+     */
+    getLoginState?: (req: Request, config: object) => string;
+
+    /**
      * Function that returns the profile for `req.openid.user`.
      */
     getUser?: (req: Request, config: ConfigParams) => undefined | UserinfoResponse;

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,7 @@ interface ConfigParams {
     /**
      * Function that returns a URL-safe state value for `res.openid.login()`.
      */
-    getLoginState?: (req: Request, config: object) => string;
+    getLoginState?: (req: Request, config: object) => object;
 
     /**
      * Function that returns the profile for `req.openid.user`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,6 @@
 const Joi = require('@hapi/joi');
 const clone = require('clone');
+const { generate: getLoginState } = require('./hooks/getLoginState');
 const getUser = require('./hooks/getUser');
 const handleCallback = require('./hooks/handleCallback');
 
@@ -54,6 +55,7 @@ const paramsSchema = Joi.object({
   ),
   clockTolerance: Joi.number().optional().default(60),
   errorOnRequiredAuth: Joi.boolean().optional().default(false),
+  getLoginState: Joi.function().optional().default(() => getLoginState),
   getUser: Joi.function().optional().default(() => getUser),
   handleCallback: Joi.function().optional().default(() => handleCallback),
   httpOptions: Joi.object().optional(),

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,6 @@
 const Joi = require('@hapi/joi');
 const clone = require('clone');
-const { generate: getLoginState } = require('./hooks/getLoginState');
+const { defaultState: getLoginState } = require('./hooks/getLoginState');
 const getUser = require('./hooks/getUser');
 const handleCallback = require('./hooks/handleCallback');
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -46,37 +46,38 @@ class ResponseContext {
     return urlJoin(this._config.baseURL, this._config.redirectUriPath);
   }
 
-  async login(params = {}) {
+  async login(options = {}) {
     const next = cb(this._next).once();
     const req = this._req;
     const res = this._res;
     const config = this._config;
-
     const client = req.openid.client;
-    const authorizeParams = config.authorizationParams;
+
+    // Determine landing page after login callback.
+    let returnTo = this._config.baseURL;
+    if (options.returnTo) {
+      returnTo = options.returnTo;
+    } else if (req.method === 'GET' && req.originalUrl) {
+      returnTo = req.originalUrl;
+    }
+
     const transientOpts = {
       legacySameSiteCookie: config.legacySameSiteCookie,
       sameSite: config.authorizationParams.response_mode === 'form_post' ? 'None' : 'Lax'
     };
 
     try {
-      let returnTo;
-      if (params.returnTo) {
-        returnTo = params.returnTo;
-      } else if (req.method === 'GET') {
-        returnTo = req.originalUrl;
-      } else {
-        returnTo = this._config.baseURL;
-      }
-
-      // TODO: Store this in state
       transient.store('returnTo', res, Object.assign({value: returnTo}, transientOpts));
 
-      const authParams = Object.assign({
-        nonce: transient.store('nonce', res, transientOpts),
-        state: transient.store('state', res, transientOpts),
-        redirect_uri: this.getRedirectUri()
-      }, authorizeParams, params.authorizationParams || {});
+      const authParams = Object.assign(
+        {
+          nonce: transient.store('nonce', res, transientOpts),
+          state: transient.store('state', res, transientOpts),
+          redirect_uri: this.getRedirectUri()
+        },
+        config.authorizationParams,
+        options.authorizationParams || {}
+      );
 
       const authorizationUrl = client.authorizationUrl(authParams);
       res.redirect(authorizationUrl);
@@ -91,11 +92,11 @@ class ResponseContext {
     const res = this._res;
 
     let returnURL = params.returnTo || req.query.returnTo || this._config.postLogoutRedirectUri;
-    
+
     if (url.parse(returnURL).host === null) {
       returnURL = urlJoin(this._config.baseURL, returnURL);
     }
-    
+
     if (!req.isAuthenticated()) {
       return res.redirect(returnURL);
     }

--- a/lib/context.js
+++ b/lib/context.js
@@ -2,10 +2,10 @@ const cb = require('cb');
 const url = require('url');
 const urlJoin = require('url-join');
 const { TokenSet } = require('openid-client');
-const { encode: base64encode, decode: base64decode } = require('base64url');
 
 const transient = require('./transientHandler');
 const { get: getClient } =  require('./client');
+const { encodeState } = require('../lib/hooks/getLoginState');
 
 class RequestContext {
   constructor(config, req, res, next) {
@@ -29,24 +29,6 @@ class RequestContext {
     }
 
     this.user = await this._config.getUser(this._req, this._config);
-  }
-
-  /**
-   * Prepare a state object to send.
-   *
-   * @param {object} stateObject
-   */
-  encodeState(stateObject) {
-    return base64encode(JSON.stringify(stateObject));
-  }
-
-  /**
-   * Decode a state value.
-   *
-   * @param {string} state
-   */
-  decodeState(state) {
-    return JSON.parse(base64decode(state));
   }
 }
 
@@ -73,12 +55,14 @@ class ResponseContext {
     const config = this._config;
     const client = req.openid.client;
 
+    // Set default returnTo value, allow passed-in options to override.
     options = {
       returnTo: this._config.baseURL,
       authorizationParams: {},
       ...options
     };
 
+    // Ensure a redirect_uri, merge in configuration options, then passed-in options.
     options.authorizationParams = {
       redirect_uri: this.getRedirectUri(),
       ...config.authorizationParams,
@@ -90,9 +74,12 @@ class ResponseContext {
       sameSite: options.authorizationParams.response_mode === 'form_post' ? 'None' : 'Lax'
     };
 
+    let stateValue = config.getLoginState(req, options);
+    stateValue.nonce = transient.createNonce();
+
     const stateTransientOpts = {
       ...transientOpts,
-      value: config.getLoginState(req, options)
+      value: encodeState(stateValue)
     };
 
     try {

--- a/lib/context.js
+++ b/lib/context.js
@@ -74,7 +74,10 @@ class ResponseContext {
       sameSite: options.authorizationParams.response_mode === 'form_post' ? 'None' : 'Lax'
     };
 
-    let stateValue = config.getLoginState(req, options);
+    let stateValue = await config.getLoginState(req, options);
+    if ( typeof stateValue !== 'object' ) {
+      next(new Error( 'Custom state value must be an object.' ));
+    }
     stateValue.nonce = transient.createNonce();
 
     const stateTransientOpts = {

--- a/lib/context.js
+++ b/lib/context.js
@@ -2,6 +2,7 @@ const cb = require('cb');
 const url = require('url');
 const urlJoin = require('url-join');
 const { TokenSet } = require('openid-client');
+const { encode: base64encode, decode: base64decode } = require('base64url');
 
 const transient = require('./transientHandler');
 const { get: getClient } =  require('./client');
@@ -28,6 +29,24 @@ class RequestContext {
     }
 
     this.user = await this._config.getUser(this._req, this._config);
+  }
+
+  /**
+   * Prepare a state object to send.
+   *
+   * @param {object} stateObject
+   */
+  encodeState(stateObject) {
+    return base64encode(JSON.stringify(stateObject));
+  }
+
+  /**
+   * Decode a state value.
+   *
+   * @param {string} state
+   */
+  decodeState(state) {
+    return JSON.parse(base64decode(state));
   }
 }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -73,26 +73,34 @@ class ResponseContext {
     const config = this._config;
     const client = req.openid.client;
 
-    options = Object.assign({returnTo: this._config.baseURL, authorizationParams: {}}, options);
-    options.authorizationParams = Object.assign({}, config.authorizationParams, options.authorizationParams);
+    options = {
+      returnTo: this._config.baseURL,
+      authorizationParams: {},
+      ...options
+    };
+
+    options.authorizationParams = {
+      redirect_uri: this.getRedirectUri(),
+      ...config.authorizationParams,
+      ...options.authorizationParams
+    };
 
     const transientOpts = {
       legacySameSiteCookie: config.legacySameSiteCookie,
       sameSite: options.authorizationParams.response_mode === 'form_post' ? 'None' : 'Lax'
     };
 
-    const stateTransientOpts = Object.assign({}, transientOpts, {value: config.getLoginState(req, options)});
+    const stateTransientOpts = {
+      ...transientOpts,
+      value: config.getLoginState(req, options)
+    };
 
     try {
-
-      const authParams = Object.assign(
-        {
-          nonce: transient.store('nonce', res, transientOpts),
-          state: transient.store('state', res, stateTransientOpts),
-          redirect_uri: this.getRedirectUri()
-        },
-        options.authorizationParams
-      );
+      const authParams = {
+        ...options.authorizationParams,
+        nonce: transient.store('nonce', res, transientOpts),
+        state: transient.store('state', res, stateTransientOpts)
+      };
 
       const authorizationUrl = client.authorizationUrl(authParams);
       res.redirect(authorizationUrl);

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,9 +1,10 @@
 const cb = require('cb');
 const url = require('url');
 const urlJoin = require('url-join');
+const { TokenSet } = require('openid-client');
+
 const transient = require('./transientHandler');
 const { get: getClient } =  require('./client');
-const { TokenSet } = require('openid-client');
 
 class RequestContext {
   constructor(config, req, res, next) {
@@ -53,30 +54,25 @@ class ResponseContext {
     const config = this._config;
     const client = req.openid.client;
 
-    // Determine landing page after login callback.
-    let returnTo = this._config.baseURL;
-    if (options.returnTo) {
-      returnTo = options.returnTo;
-    } else if (req.method === 'GET' && req.originalUrl) {
-      returnTo = req.originalUrl;
-    }
+    options = Object.assign({returnTo: this._config.baseURL, authorizationParams: {}}, options);
+    options.authorizationParams = Object.assign({}, config.authorizationParams, options.authorizationParams);
 
     const transientOpts = {
       legacySameSiteCookie: config.legacySameSiteCookie,
-      sameSite: config.authorizationParams.response_mode === 'form_post' ? 'None' : 'Lax'
+      sameSite: options.authorizationParams.response_mode === 'form_post' ? 'None' : 'Lax'
     };
 
+    const stateTransientOpts = Object.assign({}, transientOpts, {value: config.getLoginState(req, options)});
+
     try {
-      transient.store('returnTo', res, Object.assign({value: returnTo}, transientOpts));
 
       const authParams = Object.assign(
         {
           nonce: transient.store('nonce', res, transientOpts),
-          state: transient.store('state', res, transientOpts),
+          state: transient.store('state', res, stateTransientOpts),
           redirect_uri: this.getRedirectUri()
         },
-        config.authorizationParams,
-        options.authorizationParams || {}
+        options.authorizationParams
       );
 
       const authorizationUrl = client.authorizationUrl(authParams);

--- a/lib/hooks/getLoginState.js
+++ b/lib/hooks/getLoginState.js
@@ -1,0 +1,43 @@
+const { createNonce } = require('../transientHandler');
+const { encode: base64encode, decode: base64decode } = require('base64url');
+
+module.exports.generate = generateLoginState;
+module.exports.prepare = prepareLoginState;
+module.exports.decode = decodeLoginState;
+
+/**
+ * Generate a unique state value for use during login transactions.
+ *
+ * @param {RequestHandler} req
+ * @param {object} options
+ */
+function generateLoginState(req, options) {
+  let state = {
+    returnTo: options.returnTo,
+    nonce: createNonce()
+  };
+
+  if (req.method === 'GET' && req.originalUrl) {
+    state.returnTo = req.originalUrl;
+  }
+
+  return prepareLoginState(state);
+}
+
+/**
+ * Prepare a state object to send.
+ *
+ * @param {object} stateObject
+ */
+function prepareLoginState(stateObject) {
+  return base64encode(JSON.stringify(stateObject));
+}
+
+/**
+ * Decode a state value.
+ *
+ * @param {string} state
+ */
+function decodeLoginState(state) {
+  return JSON.parse(base64decode(state));
+}

--- a/lib/hooks/getLoginState.js
+++ b/lib/hooks/getLoginState.js
@@ -12,14 +12,10 @@ module.exports.decode = decodeLoginState;
  * @param {object} options
  */
 function generateLoginState(req, options) {
-  let state = {
-    returnTo: options.returnTo,
+  const state = {
+    returnTo: options.returnTo || req.originalUrl,
     nonce: createNonce()
   };
-
-  if (req.method === 'GET' && req.originalUrl) {
-    state.returnTo = req.originalUrl;
-  }
 
   return prepareLoginState(state);
 }

--- a/lib/hooks/getLoginState.js
+++ b/lib/hooks/getLoginState.js
@@ -1,9 +1,6 @@
 const { createNonce } = require('../transientHandler');
-const { encode: base64encode, decode: base64decode } = require('base64url');
 
 module.exports.generate = generateLoginState;
-module.exports.prepare = prepareLoginState;
-module.exports.decode = decodeLoginState;
 
 /**
  * Generate a unique state value for use during login transactions.
@@ -17,23 +14,5 @@ function generateLoginState(req, options) {
     nonce: createNonce()
   };
 
-  return prepareLoginState(state);
-}
-
-/**
- * Prepare a state object to send.
- *
- * @param {object} stateObject
- */
-function prepareLoginState(stateObject) {
-  return base64encode(JSON.stringify(stateObject));
-}
-
-/**
- * Decode a state value.
- *
- * @param {string} state
- */
-function decodeLoginState(state) {
-  return JSON.parse(base64decode(state));
+  return req.openid.encodeState(state);
 }

--- a/lib/hooks/getLoginState.js
+++ b/lib/hooks/getLoginState.js
@@ -1,6 +1,6 @@
 const { encode: base64encode, decode: base64decode } = require('base64url');
 
-module.exports.generate = generateLoginState;
+module.exports.defaultState = defaultState;
 module.exports.encodeState = encodeState;
 module.exports.decodeState = decodeState;
 
@@ -12,7 +12,7 @@ module.exports.decodeState = decodeState;
  *
  * @return {object}
  */
-function generateLoginState(req, options) {
+function defaultState(req, options) {
   return {
     returnTo: options.returnTo || req.originalUrl
   };

--- a/lib/hooks/getLoginState.js
+++ b/lib/hooks/getLoginState.js
@@ -1,18 +1,41 @@
-const { createNonce } = require('../transientHandler');
+const { encode: base64encode, decode: base64decode } = require('base64url');
 
 module.exports.generate = generateLoginState;
+module.exports.encodeState = encodeState;
+module.exports.decodeState = decodeState;
 
 /**
  * Generate a unique state value for use during login transactions.
  *
  * @param {RequestHandler} req
  * @param {object} options
+ *
+ * @return {object}
  */
 function generateLoginState(req, options) {
-  const state = {
-    returnTo: options.returnTo || req.originalUrl,
-    nonce: createNonce()
+  return {
+    returnTo: options.returnTo || req.originalUrl
   };
+}
 
-  return req.openid.encodeState(state);
+/**
+ * Prepare a state object to send.
+ *
+ * @param {object} stateObject
+ *
+ * @return {string}
+ */
+function encodeState(stateObject) {
+  return base64encode(JSON.stringify(stateObject));
+}
+
+/**
+ * Decode a state value.
+ *
+ * @param {string} stateValue
+ *
+ * @return {object}
+ */
+function decodeState(stateValue) {
+  return JSON.parse(base64decode(stateValue));
 }

--- a/lib/transientHandler.js
+++ b/lib/transientHandler.js
@@ -1,5 +1,9 @@
 const crypto = require('crypto');
 
+exports.store = store;
+exports.getOnce = getOnce;
+exports.createNonce = createNonce;
+
 /**
  * Set a cookie with a value or a generated nonce.
  *
@@ -84,7 +88,3 @@ function createNonce() {
 function deleteCookie(name, res) {
   res.cookie(name, '', {maxAge: 0});
 }
-
-exports.store = store;
-exports.getOnce = getOnce;
-exports.createNonce = createNonce;

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -126,8 +126,7 @@ module.exports = function (params) {
         stateDecoded = {};
       }
 
-      const returnTo = stateDecoded.returnTo || config.baseURL;
-      res.redirect(returnTo);
+      res.redirect(stateDecoded.returnTo || config.baseURL);
     }
   );
 

--- a/test/callback_route_form_post.tests.js
+++ b/test/callback_route_form_post.tests.js
@@ -9,6 +9,7 @@ const expressOpenid = require('..');
 const server = require('./fixture/server');
 const cert = require('./fixture/cert');
 const clientID = '__test_client_id__';
+const expectedDefaultState = Buffer('{returnTo:"https://example.org"}').toString('base64');
 
 function testCase(params) {
   return () => {
@@ -184,8 +185,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
 
   describe('when nonce is missing from cookies', testCase({
     cookies: {
-      state: '__test_state__',
-      returnTo: '/return-to'
+      state: '__test_state__'
     },
     body: {
       state: '__test_state__',
@@ -200,12 +200,11 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
 
   describe('when id_token is valid', testCase({
     cookies: {
-      _state: '__test_state__',
-      _nonce: '__test_nonce__',
-      _returnTo: '/return-to'
+      _state: expectedDefaultState,
+      _nonce: '__test_nonce__'
     },
     body: {
-      state: '__test_state__',
+      state: expectedDefaultState,
       id_token: makeIdToken()
     },
     assertions() {
@@ -214,7 +213,7 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
       });
 
       it('should redirect to the intended url', function() {
-        assert.equal(this.response.headers['location'], '/return-to');
+        assert.equal(this.response.headers['location'], 'https://example.org');
       });
 
       it('should contain the claims in the current session', function() {

--- a/test/callback_route_form_post.tests.js
+++ b/test/callback_route_form_post.tests.js
@@ -5,11 +5,12 @@ const request = require('request-promise-native').defaults({
   resolveWithFullResponse: true
 });
 
+const { encodeState } = require('../lib/hooks/getLoginState');
 const expressOpenid = require('..');
 const server = require('./fixture/server');
 const cert = require('./fixture/cert');
 const clientID = '__test_client_id__';
-const expectedDefaultState = Buffer('{returnTo:"https://example.org"}').toString('base64');
+const expectedDefaultState = encodeState({ returnTo: 'https://example.org' });
 
 function testCase(params) {
   return () => {
@@ -272,11 +273,11 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
       }
     },
     cookies: {
-      _state: '__test_state__',
+      _state: expectedDefaultState,
       _nonce: '__test_nonce__'
     },
     body: {
-      state: '__test_state__',
+      state: expectedDefaultState,
       id_token: makeIdToken()
     },
     assertions() {
@@ -291,11 +292,11 @@ describe('callback routes response_type: id_token, response_mode: form_post', fu
       identityClaimFilter: []
     },
     cookies: {
-      _state: '__test_state__',
+      _state: expectedDefaultState,
       _nonce: '__test_nonce__'
     },
     body: {
-      state: '__test_state__',
+      state: expectedDefaultState,
       id_token: makeIdToken()
     },
     assertions() {


### PR DESCRIPTION
### Description

- Adds the ability to define a custom state value using the configuration key `getLoginState` set to a function. See EXAMPLES.md in this PR for a how-to.  
- Removes the ability to define `nonce` and `state` in the options object passed to `req.openid.login()`
- Adds `req.openid.encodeState()` and `req.openid.decodeState()`

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
