### PR TITLE
Register Express as a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Express.js middleware for OpenID Relying Party (aka OAuth 2.0 Client). Easily ad
 This library requires:
 
 - Node v10.13 or higher
-- Express v4.16 or higher
+- Express v4.17 or higher
 
 **Please Note:** This library is currently in pre-release status and has not had a complete security review. We **do not** recommend using this library in production yet. As we move towards early access, please be aware that releases may contain breaking changes. We will be monitoring the Issues queue here for feedback and questions. PRs and comments on existing PRs are welcome!
 
@@ -60,13 +60,15 @@ APP_SESSION_SECRET=LONG_RANDOM_VALUE
 ```js
 // index.js
 
-const { auth } = require('express-openid-connect');
-app.use(auth({
-  issuerBaseURL: 'https://YOUR_DOMAIN',
-  baseURL: 'https://YOUR_APPLICATION_ROOT_URL',
-  clientID: 'YOUR_CLIENT_ID',
-  appSessionKey: 'LONG_RANDOM_STRING'
-}));
+const { auth } = require("express-openid-connect");
+app.use(
+  auth({
+    issuerBaseURL: "https://YOUR_DOMAIN",
+    baseURL: "https://YOUR_APPLICATION_ROOT_URL",
+    clientID: "YOUR_CLIENT_ID",
+    appSessionSecret: "LONG_RANDOM_STRING"
+  })
+);
 ```
 
 With this basic configuration, your application will require authentication for all routes and store the user identity in an encrypted and signed cookie.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "test": "mocha",
     "test:ci": "nyc --reporter=lcov npm test"
   },
+  "peerDependencies": {
+    "express": ">= 4.17.0"
+  },
   "dependencies": {
     "@hapi/joi": "^16.1.8",
     "cb": "^0.1.0",


### PR DESCRIPTION
### Description

This PR:

* Adds Express as a peer dependency ">= 4.17.0"
* Corrects the minimum Express version in the readme
* Corrects the sample in the readme, where `appSessionKey` should be `appSessionSecret`

**Rationale**

The peer dependency of Express is useful because:

* The minimum required version of Express is 4.17, which brings in `cookie@0.4.0`, which is the minimum version of `cookie` that supports the SameSite attribute
* An app scaffolded with `express-generator` still installs `express@4.16` by default which brings in a lower version of `cookie` that does not support the SameSite attribute
* Including `express@>= 4.17.0` as a peer dependency means that at least the user will get a warning when they try to install it
* As this library is primarily used in an Express application, we can leave the local dependency on `express` in `devDependencies`

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
