### PR TITLE
App session settings

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ Please see the [Getting Started section of the README](https://github.com/auth0/
 
 The `auth()` middleware has a few configuration keys that are required for initialization.
 
-- **`appSessionSecret`** - The secret used to derive an encryption key for the user identity in a session cookie.  It must be a string, an array of strings, or `false` to skip this internal storage and provide your own session mechanism in `getUser`. When array is provided the first member is used for signing and other members can be used for decrypting old cookies, this is to enable appSessionSecret rotation. This can be set automatically with an `APP_SESSION_SECRET` variable in your environment.
+- **`appSession.secret`** - The secret used to derive an encryption key for the user identity in a session cookie. It must be a string or an array of strings to use the built-in encrypted cookie session. When an array is provided, the first member is used for signing and other members can be used for decrypting old cookies, this is to enable secret rotation. This can be set automatically with an `APP_SESSION_SECRET` variable in your environment.
 - **`baseURL`** - The root URL for the application router. This can be set automatically with a `BASE_URL` variable in your environment.
 - **`clientID`** - The Client ID for your application. This can be set automatically with a `CLIENT_ID`  variable in your environment.
 - **`issuerBaseURL`** - The root URL for the token issuer with no trailing slash. In Auth0, this is your Application's **Domain** prepended with `https://`. This can be set automatically with an `ISSUER_BASE_URL` variable in your environment.
@@ -21,9 +21,15 @@ If you are using a response type that includes `code` (typically combined with a
 
 Additional configuration keys that can be passed to `auth()` on initialization:
 
-- **`appSessionCookie`** - Object defining application session cookie attributes. Allowed keys are `domain`, `ephemeral`, `httpOnly`, `path`, `secure`, and `sameSite`. Defaults are `true` for `httpOnly`, `Lax` for `sameSite`, and `false` for `ephemeral`. See the [Express Response documentation](https://expressjs.com/en/api.html#res.cookie) for more information on all properties except `ephemeral`.
-- **`appSessionDuration`** - Integer value, in seconds, for application session duration. Default is 7 days.
-- **`appSessionName`** - String value for the cookie name used for the internal session. This value must only include letters, numbers, and underscores. Default is `identity`.
+- **`appSession`** - Object defining application session configuration. If this is set to `false`, the internal storage will not be used (see [this example](https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md#4-custom-user-session-handling) for how to provide your own session mechanism). Otherwise, the `secret` key is required (see above).
+  - **`appSession.duration`** - Integer value, in seconds, for application session duration. Default is 7 days.
+  - **`appSession.name`** - String value for the cookie name used for the internal session. This value must only include letters, numbers, and underscores. Default is `identity`.
+  - **`appSession.cookieTransient`** - Sets the application session cookie expiration to `0` to create a transient cookie.
+  - **`appSession.cookieDomain`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `domain`.
+  - **`appSession.cookieHttpOnly`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `httponly`. Set to `true` by default.
+  - **`appSession.cookiePath`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `path`.
+  - **`appSession.cookieSecure`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `secure`.
+  - **`appSession.cookieSecure`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `samesite`. Set to `"Lax"` by default.
 - **`auth0Logout`** - Boolean value to enable Auth0's logout feature. Default is `false`.
 - **`authorizationParams`** - Object that describes the authorization server request. [See below](#authorization-params-key) for defaults and more details.
 - **`clockTolerance`** - Integer value for the system clock's tolerance (leeway) in seconds for ID token verification. Default is `60`.

--- a/API.md
+++ b/API.md
@@ -8,7 +8,7 @@ Please see the [Getting Started section of the README](https://github.com/auth0/
 
 The `auth()` middleware has a few configuration keys that are required for initialization.
 
-- **`appSession.secret`** - The secret used to derive an encryption key for the user identity in a session cookie. It must be a string or an array of strings to use the built-in encrypted cookie session. When an array is provided, the first member is used for signing and other members can be used for decrypting old cookies, this is to enable secret rotation. This can be set automatically with an `APP_SESSION_SECRET` variable in your environment.
+- **`appSession.secret`** - The secret used to derive an encryption key for the user identity in a session cookie. It must be a string or an array of strings to use the built-in encrypted cookie session. When an array is provided, the first member is used for signing and other members can be used for decrypting old cookies (to enable secret rotation). This can be set automatically with an `APP_SESSION_SECRET` variable in your environment.
 - **`baseURL`** - The root URL for the application router. This can be set automatically with a `BASE_URL` variable in your environment.
 - **`clientID`** - The Client ID for your application. This can be set automatically with a `CLIENT_ID`  variable in your environment.
 - **`issuerBaseURL`** - The root URL for the token issuer with no trailing slash. In Auth0, this is your Application's **Domain** prepended with `https://`. This can be set automatically with an `ISSUER_BASE_URL` variable in your environment.
@@ -22,14 +22,15 @@ If you are using a response type that includes `code` (typically combined with a
 Additional configuration keys that can be passed to `auth()` on initialization:
 
 - **`appSession`** - Object defining application session configuration. If this is set to `false`, the internal storage will not be used (see [this example](https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md#4-custom-user-session-handling) for how to provide your own session mechanism). Otherwise, the `secret` key is required (see above).
+  - **`appSession.secret`** - See the **Required Keys** section above.
   - **`appSession.duration`** - Integer value, in seconds, for application session duration. Default is 7 days.
-  - **`appSession.name`** - String value for the cookie name used for the internal session. This value must only include letters, numbers, and underscores. Default is `identity`.
-  - **`appSession.cookieTransient`** - Sets the application session cookie expiration to `0` to create a transient cookie.
+  - **`appSession.name`** - String value for the cookie name used for the internal session. This value must only include letters, numbers, and underscores. Default is `appSession`.
+  - **`appSession.cookieTransient`** - Sets the application session cookie expiration to `0` to create a transient cookie. Set to `false` by default.
   - **`appSession.cookieDomain`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `domain`.
   - **`appSession.cookieHttpOnly`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `httponly`. Set to `true` by default.
   - **`appSession.cookiePath`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `path`.
   - **`appSession.cookieSecure`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `secure`.
-  - **`appSession.cookieSecure`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `samesite`. Set to `"Lax"` by default.
+  - **`appSession.cookieSameSite`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `samesite`. Set to `"Lax"` by default.
 - **`auth0Logout`** - Boolean value to enable Auth0's logout feature. Default is `false`.
 - **`authorizationParams`** - Object that describes the authorization server request. [See below](#authorization-params-key) for defaults and more details.
 - **`clockTolerance`** - Integer value for the system clock's tolerance (leeway) in seconds for ID token verification. Default is `60`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 This release includes important changes to user session and token handling which will require an update for all applications.
 
-First, a new, required configuration key - `appSessionSecret`- has been added. The value here will be used to generate keys which are in turn used to encrypt the user identity returned from the identity provider. This encrypted and signed identity is stored in a cookie and used to populate the `req.openid.user` property, as before. This key should be set to either a secure, random value to use this built-in session or `false` to provide [your own custom application session handling](https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md#4-custom-user-session-handling). A value for this can be generated with `openssl` like so:
+First, a new, required configuration key - `appSessionSecret` (changed to `appSession.secret`) - has been added. The value here will be used to generate keys which are in turn used to encrypt the user identity returned from the identity provider. This encrypted and signed identity is stored in a cookie and used to populate the `req.openid.user` property, as before. This key should be set to either a secure, random value to use this built-in session or `false` to provide [your own custom application session handling](https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md#4-custom-user-session-handling). A value for this can be generated with `openssl` like so:
 
 ```
 ❯ openssl rand -hex 32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 This release includes important changes to user session and token handling which will require an update for all applications.
 
-First, a new, required configuration key - `appSessionSecret` (changed to `appSession.secret`) - has been added. The value here will be used to generate keys which are in turn used to encrypt the user identity returned from the identity provider. This encrypted and signed identity is stored in a cookie and used to populate the `req.openid.user` property, as before. This key should be set to either a secure, random value to use this built-in session or `false` to provide [your own custom application session handling](https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md#4-custom-user-session-handling). A value for this can be generated with `openssl` like so:
+First, a new, required configuration key - `appSessionSecret` (changed to `appSession.secret` in v0.8.0) - has been added. The value here will be used to generate keys which are in turn used to encrypt the user identity returned from the identity provider. This encrypted and signed identity is stored in a cookie and used to populate the `req.openid.user` property, as before. This key should be set to either a secure, random value to use this built-in session or `false` to provide [your own custom application session handling](https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md#4-custom-user-session-handling). A value for this can be generated with `openssl` like so:
 
 ```
 ❯ openssl rand -hex 32

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -106,7 +106,7 @@ app.use(session({
 
 app.use(auth({
   // Setting this configuration key to false will turn off internal session handling.
-  appSessionSecret: false,
+  appSession: false,
   handleCallback: async function (req, res, next) {
     // This will store the user identity claims in the session
     req.session.userIdentity = req.openidTokens.claims();
@@ -206,7 +206,7 @@ app.get('/route-that-calls-an-api', async (req, res, next) => {
     req.session.openidTokens = tokenSet;
 
     // You can also refresh the session with a returned ID token.
-    // The req property below is the same as appSessionName, which defaults to "identity".
+    // The req property below is the same as appSession.name, which defaults to "identity".
     // If you're using custom session handling, the claims might be stored elsewhere.
     req.identity.claims = tokenSet.claims();
   }
@@ -217,7 +217,7 @@ app.get('/route-that-calls-an-api', async (req, res, next) => {
 
 ## 7. Calling userinfo
 
-If your application needs to call the userinfo endpoint for the user's identity instead of the ID token used by default, add a `handleCallback` function during initialization that will make this call. Save the claims retrieved from the userinfo endpoint to the `appSessionName` on the request object (default is `identity`):
+If your application needs to call the userinfo endpoint for the user's identity instead of the ID token used by default, add a `handleCallback` function during initialization that will make this call. Save the claims retrieved from the userinfo endpoint to the `appSession.name` on the request object (default is `identity`):
 
 ```js
 app.use(auth({

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -206,9 +206,9 @@ app.get('/route-that-calls-an-api', async (req, res, next) => {
     req.session.openidTokens = tokenSet;
 
     // You can also refresh the session with a returned ID token.
-    // The req property below is the same as appSession.name, which defaults to "identity".
+    // The req property below is the same as appSession.name, which defaults to "appSession".
     // If you're using custom session handling, the claims might be stored elsewhere.
-    req.identity.claims = tokenSet.claims();
+    req.appSession.claims = tokenSet.claims();
   }
 
   // Check for and use tokenSet.access_token for the API call ...
@@ -217,15 +217,15 @@ app.get('/route-that-calls-an-api', async (req, res, next) => {
 
 ## 7. Calling userinfo
 
-If your application needs to call the userinfo endpoint for the user's identity instead of the ID token used by default, add a `handleCallback` function during initialization that will make this call. Save the claims retrieved from the userinfo endpoint to the `appSession.name` on the request object (default is `identity`):
+If your application needs to call the userinfo endpoint for the user's identity instead of the ID token used by default, add a `handleCallback` function during initialization that will make this call. Save the claims retrieved from the userinfo endpoint to the `appSession.name` on the request object (default is `appSession`):
 
 ```js
 app.use(auth({
   handleCallback: async function (req, res, next) {
     const client = req.openid.client;
-    req.identity = req.identity || {};
+    req.appSession = req.appSession || {};
     try {
-      req.identity.claims = await client.userinfo(req.openidTokens);
+      req.appSession.claims = await client.userinfo(req.openidTokens);
       next();
     } catch(e) {
       next(e);

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ app.use(
     issuerBaseURL: "https://YOUR_DOMAIN",
     baseURL: "https://YOUR_APPLICATION_ROOT_URL",
     clientID: "YOUR_CLIENT_ID",
-    appSessionSecret: "LONG_RANDOM_STRING"
+    appSession: {
+      secret: "LONG_RANDOM_STRING"
+    }
   })
 );
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,24 +28,7 @@ interface ConfigParams {
     /**
      * Object defining application session cookie attributes.
      */
-    appSessionCookie?: SessionCookieConfigParams;
-
-    /**
-     * Integer value, in seconds, for application session duration.
-     */
-    appSessionDuration?: number;
-
-    /**
-     * String value for the cookie name used for the internal session.
-     */
-    appSessionName?: string;
-
-    /**
-     * REQUIRED. The secret(s) used to derive an encryption key for the user identity in a session cookie.
-     * Use a single string key or array of keys for an encrypted session cookie or false to skip.
-     * Can use env key APP_SESSION_SECRET instead.
-     */
-    appSessionSecret?: boolean | string | string[];
+    appSession: AppSessionConfigParams;
 
     /**
      * Boolean value to enable Auth0's logout feature.
@@ -166,42 +149,61 @@ interface ConfigParams {
 }
 
 /**
- * Configuration parameters used in appSessionCookie.
- *
- * @see https://expressjs.com/en/api.html#res.cookie
+ * Configuration parameters used for the application session.
  */
-interface SessionCookieConfigParams {
+interface AppSessionConfigParams {
+    /**
+     * REQUIRED. The secret(s) used to derive an encryption key for the user identity in a session cookie.
+     * Use a single string key or array of keys for an encrypted session cookie.
+     * Can use env key APP_SESSION_SECRET instead.
+     */
+    secret?: string | Array<string>;
+
+    /**
+     * String value for the cookie name used for the internal session.
+     * This value must only include letters, numbers, and underscores.
+     * Default is `appSession`.
+     */
+    name?: string;
+
+    /**
+     * Integer value, in seconds, for application session duration.
+     * Default is 604800 seconds (7 days).
+     */
+    duration?: number
+
     /**
      * Domain name for the cookie.
      */
-    domain?: string;
+    cookieDomain?: string;
 
     /**
-     * Set to true to use an ephemeral cookie.
-     * Defaults to false which will use appSessionDuration as the cookie expiration.
+     * Set to true to use a transient cookie (cookie without an explicit expiration).
+     * Defaults to `false` which will use appSessionDuration as the cookie expiration.
      */
-    ephemeral?: boolean;
+    cookieTransient?: boolean;
 
     /**
      * Flags the cookie to be accessible only by the web server.
-     * Set to `true` by default in lib/config.
+     * Defaults to `true`.
      */
-    httpOnly?: boolean;
+    cookieHttpOnly?: boolean;
 
     /**
      * Path for the cookie.
      */
-    path?: string;
+    cookiePath?: string;
 
     /**
-     * Marks the cookie to be used with HTTPS only.
+     * Marks the cookie to be used over secure channels only.
      */
-    secure?: boolean;
+    cookieSecure?: boolean;
 
     /**
-     * Value of the “SameSite” Set-Cookie attribute.
+     * Value of the SameSite Set-Cookie attribute.
+     * Defaults to "Lax" but will be adjusted based on response_type.
      */
-    sameSite?: string;
+    cookieSameSite?: string;
 }
 
 export function auth(params?: ConfigParams): RequestHandler;

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ interface ConfigParams {
     /**
      * Object defining application session cookie attributes.
      */
-    appSession: AppSessionConfigParams;
+    appSession: boolean | AppSessionConfigParams;
 
     /**
      * Boolean value to enable Auth0's logout feature.
@@ -179,7 +179,7 @@ interface AppSessionConfigParams {
 
     /**
      * Set to true to use a transient cookie (cookie without an explicit expiration).
-     * Defaults to `false` which will use appSessionDuration as the cookie expiration.
+     * Defaults to `false` which will use appSession.duration as the cookie expiration.
      */
     cookieTransient?: boolean;
 

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -8,7 +8,7 @@ const hkdf = require('futoin-hkdf');
 const deriveKey = (secret) => hkdf(secret, 32, { info: 'JWE CEK', hash: 'SHA-256' });
 const epoch = () => Date.now() / 1000 | 0;
 
-module.exports = ({ name, secret, duration, cookieOptions = {} }) => {
+module.exports = (sessionConfig) => {
   let current;
 
   const COOKIES = Symbol('cookies');
@@ -17,11 +17,11 @@ module.exports = ({ name, secret, duration, cookieOptions = {} }) => {
 
   let keystore = new JWKS.KeyStore();
 
-  if (!Array.isArray(secret)) {
-    secret = [secret];
+  if (!Array.isArray(sessionConfig.secret)) {
+    sessionConfig.secret = [sessionConfig.secret];
   }
 
-  secret.forEach((secretString, i) => {
+  sessionConfig.secret.forEach((secretString, i) => {
     const key = JWK.asKey(deriveKey(secretString));
     if (i === 0) {
       current = key;
@@ -41,20 +41,24 @@ module.exports = ({ name, secret, duration, cookieOptions = {} }) => {
     return JWE.decrypt(jwe, keystore, { complete: true, algorithms: [enc] });
   }
 
-  function setCookie (req, res, { uat = epoch(), iat = uat, exp = uat + duration }) {
-    if ((!req[name] || !Object.keys(req[name]).length) && name in req[COOKIES]) {
-      res.clearCookie(name);
+  function setCookie (req, res, { uat = epoch(), iat = uat, exp = uat + sessionConfig.duration }) {
+    if ((!req[sessionConfig.name] || !Object.keys(req[sessionConfig.name]).length) && sessionConfig.name in req[COOKIES]) {
+      res.clearCookie(sessionConfig.name);
       return;
     }
 
-    if (req[name] && Object.keys(req[name]).length > 0) {
-      const value = encrypt(JSON.stringify(req[name]), { iat, uat, exp });
+    if (req[sessionConfig.name] && Object.keys(req[sessionConfig.name]).length > 0) {
+      const value = encrypt(JSON.stringify(req[sessionConfig.name]), { iat, uat, exp });
 
-      const thisCookieOptions = Object.assign({}, cookieOptions);
-      thisCookieOptions.expires = cookieOptions.ephemeral ? 0 : new Date(exp * 1000);
-      delete thisCookieOptions.ephemeral;
+      const cookieOptions = {};
+      Object.keys(sessionConfig).filter(key => /^cookie/.test(key)).forEach(function(key) {
+        cookieOptions[key.replace('cookie', '').toLowerCase()] = sessionConfig[key];
+      });
 
-      res.cookie(name, value, thisCookieOptions);
+      cookieOptions.expires = cookieOptions.transient ? 0 : new Date(exp * 1000);
+      delete cookieOptions.transient;
+
+      res.cookie(sessionConfig.name, value, cookieOptions);
     }
   }
 
@@ -63,7 +67,7 @@ module.exports = ({ name, secret, duration, cookieOptions = {} }) => {
       req[COOKIES] = cookie.parse(req.get('cookie') || '');
     }
 
-    if (req.hasOwnProperty(name)) {
+    if (req.hasOwnProperty(sessionConfig.name)) {
       return next();
     }
 
@@ -72,15 +76,15 @@ module.exports = ({ name, secret, duration, cookieOptions = {} }) => {
 
     try {
 
-      if (req[COOKIES].hasOwnProperty(name)) {
-        const { protected: header, cleartext } = decrypt(req[COOKIES][name]);
+      if (req[COOKIES].hasOwnProperty(sessionConfig.name)) {
+        const { protected: header, cleartext } = decrypt(req[COOKIES][sessionConfig.name]);
         ({ iat, exp } = header);
         assert(exp > epoch());
-        req[name] = JSON.parse(cleartext);
+        req[sessionConfig.name] = JSON.parse(cleartext);
       }
     } finally {
-      if (!req.hasOwnProperty(name) || !req[name]) {
-        req[name] = {};
+      if (!req.hasOwnProperty(sessionConfig.name) || !req[sessionConfig.name]) {
+        req[sessionConfig.name] = {};
       }
     }
 

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -1,9 +1,10 @@
 const { strict: assert } = require('assert');
-
 const { JWK, JWKS, JWE } = require('jose');
 const onHeaders = require('on-headers');
 const cookie = require('cookie');
 const hkdf = require('futoin-hkdf');
+
+const { sessionNameDefault, sessionDurationDefault } = require('./config');
 
 const deriveKey = (secret) => hkdf(secret, 32, { info: 'JWE CEK', hash: 'SHA-256' });
 const epoch = () => Date.now() / 1000 | 0;
@@ -14,14 +15,13 @@ module.exports = (sessionConfig) => {
   const COOKIES = Symbol('cookies');
   const alg = 'dir';
   const enc = 'A256GCM';
+  const sessionSecrets = Array.isArray(sessionConfig.secret) ? sessionConfig.secret : [sessionConfig.secret];
+  const sessionName = sessionConfig.name || sessionNameDefault;
+  const sessionDuration = sessionConfig.duration || sessionDurationDefault;
 
   let keystore = new JWKS.KeyStore();
 
-  if (!Array.isArray(sessionConfig.secret)) {
-    sessionConfig.secret = [sessionConfig.secret];
-  }
-
-  sessionConfig.secret.forEach((secretString, i) => {
+  sessionSecrets.forEach((secretString, i) => {
     const key = JWK.asKey(deriveKey(secretString));
     if (i === 0) {
       current = key;
@@ -41,24 +41,25 @@ module.exports = (sessionConfig) => {
     return JWE.decrypt(jwe, keystore, { complete: true, algorithms: [enc] });
   }
 
-  function setCookie (req, res, { uat = epoch(), iat = uat, exp = uat + sessionConfig.duration }) {
-    if ((!req[sessionConfig.name] || !Object.keys(req[sessionConfig.name]).length) && sessionConfig.name in req[COOKIES]) {
-      res.clearCookie(sessionConfig.name);
+  function setCookie (req, res, { uat = epoch(), iat = uat, exp = uat + sessionDuration }) {
+    if ((!req[sessionName] || !Object.keys(req[sessionName]).length) && sessionName in req[COOKIES]) {
+      res.clearCookie(sessionName);
       return;
     }
 
-    if (req[sessionConfig.name] && Object.keys(req[sessionConfig.name]).length > 0) {
-      const value = encrypt(JSON.stringify(req[sessionConfig.name]), { iat, uat, exp });
+    if (req[sessionName] && Object.keys(req[sessionName]).length > 0) {
+      const value = encrypt(JSON.stringify(req[sessionName]), { iat, uat, exp });
 
       const cookieOptions = {};
       Object.keys(sessionConfig).filter(key => /^cookie/.test(key)).forEach(function(key) {
-        cookieOptions[key.replace('cookie', '').toLowerCase()] = sessionConfig[key];
+        const cookieOptionKey = key.replace('cookie', '').toLowerCase();
+        cookieOptions[cookieOptionKey] = sessionConfig[key];
       });
 
       cookieOptions.expires = cookieOptions.transient ? 0 : new Date(exp * 1000);
       delete cookieOptions.transient;
 
-      res.cookie(sessionConfig.name, value, cookieOptions);
+      res.cookie(sessionName, value, cookieOptions);
     }
   }
 
@@ -67,7 +68,7 @@ module.exports = (sessionConfig) => {
       req[COOKIES] = cookie.parse(req.get('cookie') || '');
     }
 
-    if (req.hasOwnProperty(sessionConfig.name)) {
+    if (req.hasOwnProperty(sessionName)) {
       return next();
     }
 
@@ -76,15 +77,15 @@ module.exports = (sessionConfig) => {
 
     try {
 
-      if (req[COOKIES].hasOwnProperty(sessionConfig.name)) {
-        const { protected: header, cleartext } = decrypt(req[COOKIES][sessionConfig.name]);
+      if (req[COOKIES].hasOwnProperty(sessionName)) {
+        const { protected: header, cleartext } = decrypt(req[COOKIES][sessionName]);
         ({ iat, exp } = header);
         assert(exp > epoch());
-        req[sessionConfig.name] = JSON.parse(cleartext);
+        req[sessionName] = JSON.parse(cleartext);
       }
     } finally {
-      if (!req.hasOwnProperty(sessionConfig.name) || !req[sessionConfig.name]) {
-        req[sessionConfig.name] = {};
+      if (!req.hasOwnProperty(sessionName) || !req[sessionName]) {
+        req[sessionName] = {};
       }
     }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,9 @@ const { defaultState: getLoginState } = require('./hooks/getLoginState');
 const getUser = require('./hooks/getUser');
 const handleCallback = require('./hooks/handleCallback');
 
+const sessionDurationDefault = (7 * 24 * 60 * 60); // 7 days
+const sessionNameDefault = 'appSession';
+
 const paramsSchema = Joi.object({
   appSession: Joi.alternatives([
     Joi.boolean().valid(false),
@@ -12,8 +15,8 @@ const paramsSchema = Joi.object({
         Joi.string().min(8),
         Joi.array().items(Joi.string().min(8))
       ]).required(),
-      duration: Joi.number().integer().optional().default(7 * 24 * 60 * 60), // 604800 seconds, 7 days
-      name: Joi.string().token().optional().default('appSession'),
+      duration: Joi.number().integer().optional().default(sessionDurationDefault),
+      name: Joi.string().token().optional().default(sessionNameDefault),
       cookieDomain: Joi.string().optional(),
       cookieTransient: Joi.boolean().optional().default(false),
       cookieHttpOnly: Joi.boolean().optional().default(true),
@@ -97,3 +100,6 @@ module.exports.get = function(params) {
 
   return paramsValidation.value;
 };
+
+module.exports.sessionDurationDefault = sessionDurationDefault;
+module.exports.sessionNameDefault = sessionNameDefault;

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,20 +8,12 @@ const paramsSchema = Joi.object({
   appSession: Joi.alternatives([
     Joi.boolean().valid(false),
     Joi.object({
-      // TODO: Rename from appSessionSecret in docs
       secret: Joi.alternatives([
         Joi.string().min(8),
         Joi.array().items(Joi.string().min(8))
       ]).required(),
-
-      // TODO: Rename from appSessionDuration
       duration: Joi.number().integer().optional().default(7 * 24 * 60 * 60),
-
-      // TODO: Change default name
-      // TODO: Rename from appSessionName in docs
       name: Joi.string().token().optional().default('identity'),
-
-      // Rename from appSessionCookie in docs
       cookieDomain: Joi.string().optional(),
       cookieTransient: Joi.boolean().optional().default(false),
       cookieHttpOnly: Joi.boolean().optional().default(true),

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,20 +5,32 @@ const getUser = require('./hooks/getUser');
 const handleCallback = require('./hooks/handleCallback');
 
 const paramsSchema = Joi.object({
-  appSessionCookie: Joi.object({
-    domain: Joi.string().optional(),
-    ephemeral: Joi.boolean().optional().default(false),
-    httpOnly: Joi.boolean().optional().default(true),
-    path: Joi.string().optional(),
-    sameSite: Joi.string().valid('Lax', 'Strict', 'None').optional().default('Lax'),
-    secure: Joi.boolean().optional()
-  }).optional().unknown(false).default(),
-  appSessionDuration: Joi.number().integer().optional().default(7 * 24 * 60 * 60),
-  appSessionName: Joi.string().token().optional().default('identity'),
-  appSessionSecret: Joi.alternatives([
-    Joi.string(),
-    Joi.array().items(Joi.string()),
-    Joi.boolean().valid(false)
+  appSession: Joi.alternatives([
+    Joi.boolean().valid(false),
+    Joi.object({
+      // TODO: Rename from appSessionSecret in docs
+      secret: Joi.alternatives([
+        Joi.string().min(8),
+        Joi.array().items(Joi.string().min(8))
+      ]).required(),
+
+      // TODO: Rename from appSessionDuration
+      duration: Joi.number().integer().optional().default(7 * 24 * 60 * 60),
+
+      // TODO: Change default name
+      // TODO: Rename from appSessionName in docs
+      name: Joi.string().token().optional().default('identity'),
+
+      // TODO: Prefix with `cookie`
+      // TODO: ephemeral -> transient
+      // Rename from appSessionCookie in docs
+      domain: Joi.string().optional(),
+      ephemeral: Joi.boolean().optional().default(false),
+      httpOnly: Joi.boolean().optional().default(true),
+      path: Joi.string().optional(),
+      sameSite: Joi.string().valid('Lax', 'Strict', 'None').optional().default('Lax'),
+      secure: Joi.boolean().optional()
+    }).unknown(false)
   ]).required(),
   auth0Logout: Joi.boolean().optional().default(false),
   authorizationParams: Joi.object({
@@ -81,9 +93,12 @@ module.exports.get = function(params) {
     issuerBaseURL: process.env.ISSUER_BASE_URL,
     baseURL: process.env.BASE_URL,
     clientID: process.env.CLIENT_ID,
-    clientSecret: process.env.CLIENT_SECRET,
-    appSessionSecret: process.env.APP_SESSION_SECRET,
+    clientSecret: process.env.CLIENT_SECRET
   }, config);
+
+  if (process.env.APP_SESSION_SECRET && typeof config.appSession === 'object') {
+    config.appSession.secret = config.appSession.secret || process.env.APP_SESSION_SECRET;
+  }
 
   const paramsValidation = paramsSchema.validate(config);
   if (paramsValidation.error) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,15 +21,13 @@ const paramsSchema = Joi.object({
       // TODO: Rename from appSessionName in docs
       name: Joi.string().token().optional().default('identity'),
 
-      // TODO: Prefix with `cookie`
-      // TODO: ephemeral -> transient
       // Rename from appSessionCookie in docs
-      domain: Joi.string().optional(),
-      ephemeral: Joi.boolean().optional().default(false),
-      httpOnly: Joi.boolean().optional().default(true),
-      path: Joi.string().optional(),
-      sameSite: Joi.string().valid('Lax', 'Strict', 'None').optional().default('Lax'),
-      secure: Joi.boolean().optional()
+      cookieDomain: Joi.string().optional(),
+      cookieTransient: Joi.boolean().optional().default(false),
+      cookieHttpOnly: Joi.boolean().optional().default(true),
+      cookiePath: Joi.string().optional(),
+      cookieSameSite: Joi.string().valid('Lax', 'Strict', 'None').optional().default('Lax'),
+      cookieSecure: Joi.boolean().optional()
     }).unknown(false)
   ]).required(),
   auth0Logout: Joi.boolean().optional().default(false),

--- a/lib/config.js
+++ b/lib/config.js
@@ -12,7 +12,7 @@ const paramsSchema = Joi.object({
         Joi.string().min(8),
         Joi.array().items(Joi.string().min(8))
       ]).required(),
-      duration: Joi.number().integer().optional().default(7 * 24 * 60 * 60),
+      duration: Joi.number().integer().optional().default(7 * 24 * 60 * 60), // 604800 seconds, 7 days
       name: Joi.string().token().optional().default('appSession'),
       cookieDomain: Joi.string().optional(),
       cookieTransient: Joi.boolean().optional().default(false),

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,7 @@ const paramsSchema = Joi.object({
         Joi.array().items(Joi.string().min(8))
       ]).required(),
       duration: Joi.number().integer().optional().default(7 * 24 * 60 * 60),
-      name: Joi.string().token().optional().default('identity'),
+      name: Joi.string().token().optional().default('appSession'),
       cookieDomain: Joi.string().optional(),
       cookieTransient: Joi.boolean().optional().default(false),
       cookieHttpOnly: Joi.boolean().optional().default(true),

--- a/lib/context.js
+++ b/lib/context.js
@@ -103,24 +103,27 @@ class ResponseContext {
     const next = cb(this._next).once();
     const req = this._req;
     const res = this._res;
+    const config = this._config;
 
-    let returnURL = params.returnTo || req.query.returnTo || this._config.postLogoutRedirectUri;
+    let returnURL = params.returnTo || req.query.returnTo || config.postLogoutRedirectUri;
 
     if (url.parse(returnURL).host === null) {
-      returnURL = urlJoin(this._config.baseURL, returnURL);
+      returnURL = urlJoin(config.baseURL, returnURL);
     }
 
     if (!req.isAuthenticated()) {
       return res.redirect(returnURL);
     }
 
-    req[this._config.appSessionName] = undefined;
+    if (config.appSession) {
+      req[config.appSession.name] = undefined;
+    }
 
-    if (!this._config.idpLogout) {
+    if (!config.idpLogout) {
       return res.redirect(returnURL);
     }
 
-    const client = this._req.openid.client;
+    const client = req.openid.client;
     try {
       returnURL = client.endSessionUrl({
         post_logout_redirect_uri: returnURL,

--- a/lib/hooks/getUser.js
+++ b/lib/hooks/getUser.js
@@ -4,9 +4,9 @@
  */
 module.exports = function(req, config) {
 
-  if (!req[config.appSessionName] || !req[config.appSessionName].claims) {
+  if (!config.appSession || !req[config.appSession.name] || !req[config.appSession.name].claims) {
     return null;
   }
 
-  return req[config.appSessionName].claims;
+  return req[config.appSession.name].claims;
 };

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -30,12 +30,7 @@ module.exports = function (params) {
 
   // Only use the internal cookie-based session if appSession secret is provided.
   if (useAppSession) {
-    router.use(appSession({
-      name: config.appSession.name,
-      secret: config.appSession.secret,
-      duration: config.appSession.duration
-      // TODO: Add back cookie options
-    }));
+    router.use(appSession(config.appSession));
   }
 
   // Express context and OpenID Issuer discovery.

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -26,14 +26,15 @@ module.exports = function (params) {
   const config = getConfig(params);
   const authorizeParams = config.authorizationParams;
   const router = express.Router();
+  const useAppSession = config.appSession && config.appSession.secret;
 
-  // Only use the internal cookie-based session if appSessionSecret is provided.
-  if (config.appSessionSecret) {
+  // Only use the internal cookie-based session if appSession secret is provided.
+  if (useAppSession) {
     router.use(appSession({
-      name: config.appSessionName,
-      secret: config.appSessionSecret,
-      duration: config.appSessionDuration,
-      cookieOptions: config.appSessionCookie
+      name: config.appSession.name,
+      secret: config.appSession.secret,
+      duration: config.appSession.duration
+      // TODO: Add back cookie options
     }));
   }
 
@@ -101,14 +102,14 @@ module.exports = function (params) {
         req.openidState = decodeState(returnedState);
         req.openidTokens = tokenSet;
 
-        if (config.appSessionSecret) {
+        if (useAppSession) {
           let identityClaims = tokenSet.claims();
 
           config.identityClaimFilter.forEach(claim => {
             delete identityClaims[claim];
           });
 
-          req[config.appSessionName].claims = identityClaims;
+          req[config.appSession.name].claims = identityClaims;
         }
 
         next();

--- a/test/appSession.tests.js
+++ b/test/appSession.tests.js
@@ -3,7 +3,7 @@ const appSession = require('../lib/appSession');
 const sessionEncryption = require('./fixture/sessionEncryption');
 
 const defaultConfig = {
-  name: 'identity',
+  name: 'appSession',
   secret: '__test_secret__',
   duration: 3155760000, // 100 years
 };
@@ -23,42 +23,42 @@ describe('appSession', function() {
       assert.ok(result);
     });
 
-    it('should set an empty identity', function() {
-      assert.isEmpty(req.identity);
+    it('should set an empty appSession', function() {
+      assert.isEmpty(req.appSession);
     });
   });
 
   describe('no session cookies, existing session property', () => {
     const appSessionMw = appSession(defaultConfig);
-    const thisReq = Object.assign({}, req, {identity: {sub: '__test_existing_sub__'}});
+    const thisReq = Object.assign({}, req, {appSession: {sub: '__test_existing_sub__'}});
     const result = appSessionMw(thisReq, {}, next);
 
     it('should call next', function() {
       assert.ok(result);
     });
 
-    it('should keep existing identity', function() {
-      assert.equal(thisReq.identity.sub, '__test_existing_sub__');
+    it('should keep existing appSession', function() {
+      assert.equal(thisReq.appSession.sub, '__test_existing_sub__');
     });
   });
 
   describe('malformed session cookies', () => {
     const appSessionMw = appSession(defaultConfig);
-    const thisReq = {get: () => 'identity=__invalid_identity__'};
+    const thisReq = {get: () => 'appSession=__invalid_identity__'};
 
-    it('should error with malformed identity', function() {
+    it('should error with malformed appSession', function() {
       assert.throws(() => appSessionMw(thisReq, {}, next), Error, 'JWE malformed or invalid serialization');
     });
   });
 
   describe('existing session cookies', () => {
     const appSessionMw = appSession(defaultConfig);
-    const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
+    const thisReq = {get: () => 'appSession=' + sessionEncryption.encrypted};
 
-    it('should set the identity on req', function() {
+    it('should set the appSession on req', function() {
       const result = appSessionMw(thisReq, {}, next);
       assert.ok(result);
-      assert.equal(thisReq.identity.sub, '__test_sub__');
+      assert.equal(thisReq.appSession.sub, '__test_sub__');
 
     });
   });
@@ -76,13 +76,13 @@ describe('appSession', function() {
     });
 
     it('should set the correct cookie by default', function() {
-      const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
+      const thisReq = {get: () => 'appSession=' + sessionEncryption.encrypted};
       const appSessionMw = appSession(defaultConfig);
       const result = appSessionMw(thisReq, thisRes, next);
       thisRes.writeHead();
 
       assert.ok(result);
-      assert.equal(cookieArgs['0'], 'identity');
+      assert.equal(cookieArgs['0'], 'appSession');
       assert.isNotEmpty(cookieArgs['1']);
       assert.isObject(cookieArgs['2']);
       assert.hasAllKeys(cookieArgs['2'], ['expires']);
@@ -103,7 +103,7 @@ describe('appSession', function() {
     });
 
     it('should set an ephemeral cookie', function() {
-      const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
+      const thisReq = {get: () => 'appSession=' + sessionEncryption.encrypted};
       const customConfig = Object.assign({}, defaultConfig, {cookieTransient: true});
       const appSessionMw = appSession(customConfig);
       const result = appSessionMw(thisReq, thisRes, next);
@@ -114,7 +114,7 @@ describe('appSession', function() {
     });
 
     it('should pass custom cookie options', function() {
-      const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
+      const thisReq = {get: () => 'appSession=' + sessionEncryption.encrypted};
       const cookieOptConfig = {
         cookieDomain: '__test_domain__',
         cookiePath: '__test_path__',

--- a/test/appSession.tests.js
+++ b/test/appSession.tests.js
@@ -6,7 +6,6 @@ const defaultConfig = {
   name: 'identity',
   secret: '__test_secret__',
   duration: 3155760000, // 100 years
-  cookieOptions: {}
 };
 
 const req = {
@@ -105,7 +104,7 @@ describe('appSession', function() {
 
     it('should set an ephemeral cookie', function() {
       const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
-      const customConfig = Object.assign({}, defaultConfig, {cookieOptions: {ephemeral: true}});
+      const customConfig = Object.assign({}, defaultConfig, {cookieTransient: true});
       const appSessionMw = appSession(customConfig);
       const result = appSessionMw(thisReq, thisRes, next);
       thisRes.writeHead();
@@ -116,13 +115,13 @@ describe('appSession', function() {
 
     it('should pass custom cookie options', function() {
       const thisReq = {get: () => 'identity=' + sessionEncryption.encrypted};
-      const cookieOptConfig = {cookieOptions: {
-        domain: '__test_domain__',
-        path: '__test_path__',
-        secure: true,
-        httpOnly: false,
-        sameSite: '__test_samesite__',
-      }};
+      const cookieOptConfig = {
+        cookieDomain: '__test_domain__',
+        cookiePath: '__test_path__',
+        cookieSecure: true,
+        cookieHttpOnly: false,
+        cookieSameSite: '__test_samesite__',
+      };
       const customConfig = Object.assign({}, defaultConfig, cookieOptConfig);
       const appSessionMw = appSession(customConfig);
       const result = appSessionMw(thisReq, thisRes, next);
@@ -132,8 +131,8 @@ describe('appSession', function() {
       assert.equal(cookieArgs['2'].domain, '__test_domain__');
       assert.equal(cookieArgs['2'].path, '__test_path__');
       assert.equal(cookieArgs['2'].secure, true);
-      assert.equal(cookieArgs['2'].httpOnly, false);
-      assert.equal(cookieArgs['2'].sameSite, '__test_samesite__');
+      assert.equal(cookieArgs['2'].httponly, false);
+      assert.equal(cookieArgs['2'].samesite, '__test_samesite__');
     });
   });
 });

--- a/test/auth.tests.js
+++ b/test/auth.tests.js
@@ -33,7 +33,7 @@ const getCookieFromResponse = (res, cookieName) => {
 };
 
 const defaultConfig = {
-  appSessionSecret: '__test_session_secret__',
+  appSession: {secret: '__test_session_secret__'},
   clientID: '__test_client_id__',
   baseURL: 'https://example.org',
   issuerBaseURL: 'https://test.auth0.com',

--- a/test/callback_route_form_post.tests.js
+++ b/test/callback_route_form_post.tests.js
@@ -15,7 +15,7 @@ const expectedDefaultState = encodeState({ returnTo: 'https://example.org' });
 function testCase(params) {
   return () => {
     const authOpts = Object.assign({}, {
-      appSessionSecret: '__test_session_secret__',
+      appSession: {secret: '__test_session_secret__'},
       clientID: clientID,
       baseURL: 'https://example.org',
       issuerBaseURL: 'https://test.auth0.com',

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -16,7 +16,7 @@ describe('client initialization', function() {
 
   describe('default case', function() {
     const config = getConfig({
-      appSessionSecret: '__test_session_secret__',
+      appSession: {secret: '__test_session_secret__'},
       clientID: '__test_client_id__',
       clientSecret: '__test_client_secret__',
       issuerBaseURL: 'https://test.auth0.com',
@@ -52,7 +52,7 @@ describe('client initialization', function() {
 
   describe('custom headers', function() {
     const config = getConfig({
-      appSessionSecret: '__test_session_secret__',
+      appSession: {secret: '__test_session_secret__'},
       clientID: '__test_client_id__',
       clientSecret: '__test_client_secret__',
       issuerBaseURL: 'https://test.auth0.com',

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -2,7 +2,7 @@ const { assert } = require('chai');
 const { get: getConfig } = require('../lib/config');
 
 const defaultConfig = {
-  appSessionSecret: '__test_session_secret__',
+  appSession: {secret: '__test_session_secret__'},
   clientID: '__test_client_id__',
   issuerBaseURL: 'https://test.auth0.com',
   baseURL: 'https://example.org'
@@ -133,32 +133,32 @@ describe('config', function() {
     const config = getConfig(defaultConfig);
 
     it('should set the app session secret', function() {
-      assert.equal(config.appSessionSecret, '__test_session_secret__');
+      assert.equal(config.appSession.secret, '__test_session_secret__');
     });
 
     it('should set the session length to 7 days by default', function() {
-      assert.equal(config.appSessionDuration, 604800);
+      assert.equal(config.appSession.duration, 604800);
     });
 
     it('should set the session name to "identity" by default', function() {
-      assert.equal(config.appSessionName, 'identity');
+      assert.equal(config.appSession.name, 'identity');
     });
 
     it('should set the session cookie attributes to correct defaults', function() {
-      assert.notExists(config.appSessionCookie.domain);
-      assert.notExists(config.appSessionCookie.path);
-      assert.notExists(config.appSessionCookie.secure);
-      assert.equal(config.appSessionCookie.sameSite, 'Lax');
-      assert.equal(config.appSessionCookie.httpOnly, true);
+      assert.notExists(config.appSession.domain);
+      assert.notExists(config.appSession.path);
+      assert.notExists(config.appSession.secure);
+      assert.equal(config.appSession.sameSite, 'Lax');
+      assert.equal(config.appSession.httpOnly, true);
     });
   });
 
   describe('app session cookie configuration', function() {
     const customConfig = Object.assign({}, defaultConfig, {
-      appSessionSecret: [ '__test_session_secret_1__', '__test_session_secret_2__' ],
-      appSessionName: '__test_custom_session_name__',
-      appSessionDuration: 1234567890,
-      appSessionCookie: {
+      appSession: {
+        secret: [ '__test_session_secret_1__', '__test_session_secret_2__' ],
+        name: '__test_custom_session_name__',
+        duration: 1234567890,
         domain: '__test_custom_domain__',
         path: '__test_custom_path__',
         ephemeral: true,
@@ -170,25 +170,26 @@ describe('config', function() {
 
     it('should set an array of secrets', function() {
       const config = getConfig(customConfig);
-      assert.equal(config.appSessionSecret.length, 2);
-      assert.equal(config.appSessionSecret[0], '__test_session_secret_1__');
-      assert.equal(config.appSessionSecret[1], '__test_session_secret_2__');
+      assert.equal(config.appSession.secret.length, 2);
+      assert.equal(config.appSession.secret[0], '__test_session_secret_1__');
+      assert.equal(config.appSession.secret[1], '__test_session_secret_2__');
     });
 
     it('should set the custom session values', function() {
       const config = getConfig(customConfig);
-      assert.equal(config.appSessionDuration, 1234567890);
-      assert.equal(config.appSessionName, '__test_custom_session_name__');
+      assert.equal(config.appSession.duration, 1234567890);
+      assert.equal(config.appSession.name, '__test_custom_session_name__');
     });
 
-    it('should set the session cookie attributes to custom values', function() {
-      const config = getConfig(customConfig);
-      assert.equal(config.appSessionCookie.domain, '__test_custom_domain__');
-      assert.equal(config.appSessionCookie.path, '__test_custom_path__');
-      assert.equal(config.appSessionCookie.ephemeral, true);
-      assert.equal(config.appSessionCookie.httpOnly, false);
-      assert.equal(config.appSessionCookie.secure, true);
-      assert.equal(config.appSessionCookie.sameSite, 'Strict');
-    });
+    // TODO: Fix me
+    // it('should set the session cookie attributes to custom values', function() {
+    //   const config = getConfig(customConfig);
+    //   assert.equal(config.appSession.domain, '__test_custom_domain__');
+    //   assert.equal(config.appSession.path, '__test_custom_path__');
+    //   assert.equal(config.appSession.ephemeral, true);
+    //   assert.equal(config.appSession.httpOnly, false);
+    //   assert.equal(config.appSession.secure, true);
+    //   assert.equal(config.appSession.sameSite, 'Strict');
+    // });
   });
 });

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -145,11 +145,11 @@ describe('config', function() {
     });
 
     it('should set the session cookie attributes to correct defaults', function() {
-      assert.notExists(config.appSession.domain);
-      assert.notExists(config.appSession.path);
-      assert.notExists(config.appSession.secure);
-      assert.equal(config.appSession.sameSite, 'Lax');
-      assert.equal(config.appSession.httpOnly, true);
+      assert.notExists(config.appSession.cookieDomain);
+      assert.notExists(config.appSession.cookiePath);
+      assert.notExists(config.appSession.cookieSecure);
+      assert.equal(config.appSession.cookieSameSite, 'Lax');
+      assert.equal(config.appSession.cookieHttpOnly, true);
     });
   });
 
@@ -159,12 +159,12 @@ describe('config', function() {
         secret: [ '__test_session_secret_1__', '__test_session_secret_2__' ],
         name: '__test_custom_session_name__',
         duration: 1234567890,
-        domain: '__test_custom_domain__',
-        path: '__test_custom_path__',
-        ephemeral: true,
-        httpOnly: false,
-        secure: true,
-        sameSite: 'Strict',
+        cookieDomain: '__test_custom_domain__',
+        cookiePath: '__test_custom_path__',
+        cookieTransient: true,
+        cookieHttpOnly: false,
+        cookieSecure: true,
+        cookieSameSite: 'Strict',
       }
     });
 
@@ -181,15 +181,14 @@ describe('config', function() {
       assert.equal(config.appSession.name, '__test_custom_session_name__');
     });
 
-    // TODO: Fix me
-    // it('should set the session cookie attributes to custom values', function() {
-    //   const config = getConfig(customConfig);
-    //   assert.equal(config.appSession.domain, '__test_custom_domain__');
-    //   assert.equal(config.appSession.path, '__test_custom_path__');
-    //   assert.equal(config.appSession.ephemeral, true);
-    //   assert.equal(config.appSession.httpOnly, false);
-    //   assert.equal(config.appSession.secure, true);
-    //   assert.equal(config.appSession.sameSite, 'Strict');
-    // });
+    it('should set the session cookie attributes to custom values', function() {
+      const config = getConfig(customConfig);
+      assert.equal(config.appSession.cookieDomain, '__test_custom_domain__');
+      assert.equal(config.appSession.cookiePath, '__test_custom_path__');
+      assert.equal(config.appSession.cookieTransient, true);
+      assert.equal(config.appSession.cookieHttpOnly, false);
+      assert.equal(config.appSession.cookieSecure, true);
+      assert.equal(config.appSession.cookieSameSite, 'Strict');
+    });
   });
 });

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -140,8 +140,8 @@ describe('config', function() {
       assert.equal(config.appSession.duration, 604800);
     });
 
-    it('should set the session name to "identity" by default', function() {
-      assert.equal(config.appSession.name, 'identity');
+    it('should set the session name to "appSession" by default', function() {
+      assert.equal(config.appSession.name, 'appSession');
     });
 
     it('should set the session cookie attributes to correct defaults', function() {

--- a/test/custom_redirect_uri.tests.js
+++ b/test/custom_redirect_uri.tests.js
@@ -20,7 +20,7 @@ describe('auth with redirectUriPath', function() {
 
     before(async function() {
       router = expressOpenid.auth({
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         clientID: '__test_client_id__',
         baseURL: 'https://example.org',
         issuerBaseURL: 'https://test.auth0.com',

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -17,7 +17,7 @@ module.exports.create = function(router, protect) {
   app.use(router);
 
   app.get('/session', (req, res) => {
-    res.json(req.identity);
+    res.json(req.appSession);
   });
 
   app.get('/user', (req, res) => {

--- a/test/invalid_id_token_alg.tests.js
+++ b/test/invalid_id_token_alg.tests.js
@@ -9,7 +9,7 @@ const request = require('request-promise-native').defaults({
 describe('with an invalid id token alg', function() {
 
   const router = expressOpenid.auth({
-    appSessionSecret: '__test_session_secret__',
+    appSession: {secret: '__test_session_secret__'},
     clientID: '123',
     baseURL: 'https://example.org',
     issuerBaseURL: 'https://test.auth0.com',

--- a/test/invalid_params.tests.js
+++ b/test/invalid_params.tests.js
@@ -90,8 +90,7 @@ describe('invalid parameters', function() {
       expressOpenid.auth(getTestConfig({
         appSession: {
           secret: '__test_session_secret__',
-          duration: 3.14159,
-          httpOnly: '__invalid_httponly__'
+          duration: 3.14159
         }
       }));
     }, '"appSession.duration" must be an integer');
@@ -108,10 +107,10 @@ describe('invalid parameters', function() {
       expressOpenid.auth(getTestConfig({
         appSession: {
           secret: '__test_session_secret__',
-          httpOnly: '__invalid_httponly__'
+          cookieHttpOnly: '__invalid_httponly__'
         }
       }));
-    }, '"appSession.httpOnly" must be a boolean');
+    }, '"appSession.cookieHttpOnly" must be a boolean');
   });
 
   it('should fail when app session cookie secure is not a boolean', function() {
@@ -119,10 +118,10 @@ describe('invalid parameters', function() {
       expressOpenid.auth(getTestConfig({
         appSession: {
           secret: '__test_session_secret__',
-          secure: '__invalid_secure__'
+          cookieSecure: '__invalid_secure__'
         }
       }));
-    }, '"appSession.secure" must be a boolean');
+    }, '"appSession.cookieSecure" must be a boolean');
   });
 
   it('should fail when app session cookie sameSite is invalid', function() {
@@ -130,10 +129,10 @@ describe('invalid parameters', function() {
       expressOpenid.auth(getTestConfig({
         appSession: {
           secret: '__test_session_secret__',
-          sameSite: '__invalid_samesite__'
+          cookieSameSite: '__invalid_samesite__'
         }
       }));
-    }, '"appSession.sameSite" must be one of [Lax, Strict, None]');
+    }, '"appSession.cookieSameSite" must be one of [Lax, Strict, None]');
   });
 
   it('should fail when app session cookie domain is invalid', function() {
@@ -141,10 +140,10 @@ describe('invalid parameters', function() {
       expressOpenid.auth(getTestConfig({
         appSession: {
           secret: '__test_session_secret__',
-          domain: false
+          cookieDomain: false
         }
       }));
-    }, '"appSession.domain" must be a string');
+    }, '"appSession.cookieDomain" must be a string');
   });
 
   it('should fail when app session cookie sameSite is an invalid value', function() {
@@ -152,9 +151,9 @@ describe('invalid parameters', function() {
       expressOpenid.auth(getTestConfig({
         appSession: {
           secret: '__test_session_secret__',
-          path: 123
+          cookiePath: 123
         }
       }));
-    }, '"appSession.path" must be a string');
+    }, '"appSession.cookiePath" must be a string');
   });
 });

--- a/test/invalid_params.tests.js
+++ b/test/invalid_params.tests.js
@@ -2,7 +2,7 @@ const { assert } = require('chai');
 const expressOpenid = require('..');
 
 const validConfiguration = {
-  appSessionSecret: '__test_session_secret__',
+  appSession: {secret: '__test_session_secret__'},
   issuerBaseURL: 'https://test.auth0.com',
   baseURL: 'https://example.org',
   clientID: '__test_client_id__',
@@ -16,7 +16,7 @@ describe('invalid parameters', function() {
   it('should fail when the issuerBaseURL is invalid', function() {
     assert.throws(() => {
       expressOpenid.auth({
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         baseURL: 'https://example.org',
         issuerBaseURL: '__invalid_url__',
         clientID: '__test_client_id__'
@@ -27,7 +27,7 @@ describe('invalid parameters', function() {
   it('should fail when the baseURL is invalid', function() {
     assert.throws(() => {
       expressOpenid.auth({
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         baseURL: '__invalid_url__',
         issuerBaseURL: 'https://test.auth0.com',
         clientID: '__test_client_id__'
@@ -38,7 +38,7 @@ describe('invalid parameters', function() {
   it('should fail when the clientID is not provided', function() {
     assert.throws(() => {
       expressOpenid.auth({
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         baseURL: 'https://example.org',
         issuerBaseURL: 'https://test.auth0.com',
       });
@@ -48,27 +48,27 @@ describe('invalid parameters', function() {
   it('should fail when the baseURL is not provided', function() {
     assert.throws(() => {
       expressOpenid.auth({
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         issuerBaseURL: 'https://test.auth0.com',
         clientID: '__test_client_id__',
       });
     }, '"baseURL" is required');
   });
 
-  it('should fail when the appSessionSecret is not provided', function() {
+  it('should fail when the appSession.secret is not provided', function() {
     assert.throws(() => {
       expressOpenid.auth({
         issuerBaseURL: 'https://test.auth0.com',
         baseURL: 'https://example.org',
         clientID: '__test_client_id__',
       });
-    }, '"appSessionSecret" is required');
+    }, '"appSession" is required');
   });
 
   it('should fail when client secret is not provided and using the response type code in mode query', function() {
     assert.throws(() => {
       expressOpenid.auth({
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         issuerBaseURL: 'https://test.auth0.com',
         baseURL: 'https://example.org',
         clientID: '__test_client_id__',
@@ -87,63 +87,74 @@ describe('invalid parameters', function() {
 
   it('should fail when app session length is not an integer', function() {
     assert.throws(() => {
-      expressOpenid.auth(getTestConfig({appSessionDuration: 3.14159}));
-    }, '"appSessionDuration" must be an integer');
+      expressOpenid.auth(getTestConfig({
+        appSession: {
+          secret: '__test_session_secret__',
+          duration: 3.14159,
+          httpOnly: '__invalid_httponly__'
+        }
+      }));
+    }, '"appSession.duration" must be an integer');
   });
 
   it('should fail when app session secret is invalid', function() {
     assert.throws(() => {
-      expressOpenid.auth(getTestConfig({appSessionSecret: {key: '__test_session_secret__'}}));
-    }, '"appSessionSecret" must be one of [string, array, false]');
+      expressOpenid.auth(getTestConfig({appSession: {secret: {key: '__test_session_secret__'}}}));
+    }, '"appSession.secret" must be one of [string, array]');
   });
 
   it('should fail when app session cookie httpOnly is not a boolean', function() {
     assert.throws(() => {
       expressOpenid.auth(getTestConfig({
-        appSessionCookie: {
+        appSession: {
+          secret: '__test_session_secret__',
           httpOnly: '__invalid_httponly__'
         }
       }));
-    }, '"appSessionCookie.httpOnly" must be a boolean');
+    }, '"appSession.httpOnly" must be a boolean');
   });
 
   it('should fail when app session cookie secure is not a boolean', function() {
     assert.throws(() => {
       expressOpenid.auth(getTestConfig({
-        appSessionCookie: {
+        appSession: {
+          secret: '__test_session_secret__',
           secure: '__invalid_secure__'
         }
       }));
-    }, '"appSessionCookie.secure" must be a boolean');
+    }, '"appSession.secure" must be a boolean');
   });
 
   it('should fail when app session cookie sameSite is invalid', function() {
     assert.throws(() => {
       expressOpenid.auth(getTestConfig({
-        appSessionCookie: {
+        appSession: {
+          secret: '__test_session_secret__',
           sameSite: '__invalid_samesite__'
         }
       }));
-    }, '"appSessionCookie.sameSite" must be one of [Lax, Strict, None]');
+    }, '"appSession.sameSite" must be one of [Lax, Strict, None]');
   });
 
   it('should fail when app session cookie domain is invalid', function() {
     assert.throws(() => {
       expressOpenid.auth(getTestConfig({
-        appSessionCookie: {
+        appSession: {
+          secret: '__test_session_secret__',
           domain: false
         }
       }));
-    }, '"appSessionCookie.domain" must be a string');
+    }, '"appSession.domain" must be a string');
   });
 
   it('should fail when app session cookie sameSite is an invalid value', function() {
     assert.throws(() => {
       expressOpenid.auth(getTestConfig({
-        appSessionCookie: {
+        appSession: {
+          secret: '__test_session_secret__',
           path: 123
         }
       }));
-    }, '"appSessionCookie.path" must be a string');
+    }, '"appSession.path" must be a string');
   });
 });

--- a/test/invalid_response_mode.tests.js
+++ b/test/invalid_response_mode.tests.js
@@ -9,7 +9,7 @@ const request = require('request-promise-native').defaults({
 describe('with an invalid response_mode', function() {
 
   const router = expressOpenid.auth({
-    appSessionSecret: '__test_session_secret__',
+    appSession: {secret: '__test_session_secret__'},
     clientID: '__test_client_id__',
     baseURL: 'https://example.org',
     issuerBaseURL: 'https://test.auth0.com',

--- a/test/invalid_response_type.tests.js
+++ b/test/invalid_response_type.tests.js
@@ -9,7 +9,7 @@ const request = require('request-promise-native').defaults({
 describe('with an invalid response type', function() {
 
   const router = expressOpenid.auth({
-    appSessionSecret: '__test_session_secret__',
+    appSession: {secret: '__test_session_secret__'},
     clientID: '__test_client_id__',
     baseURL: 'https://example.org',
     issuerBaseURL: 'https://test.auth0.com',

--- a/test/logout.tests.js
+++ b/test/logout.tests.js
@@ -20,7 +20,7 @@ describe('logout route', function() {
         clientID: '__test_client_id__',
         baseURL: 'https://example.org',
         issuerBaseURL: 'https://test.auth0.com',
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         required: false
       });
       baseUrl = await server.create(middleware);
@@ -59,7 +59,7 @@ describe('logout route', function() {
         clientID: '__test_client_id__',
         baseURL: 'https://example.org',
         issuerBaseURL: 'https://test.auth0.com',
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         required: false
       });
       baseUrl = await server.create(middleware);
@@ -98,7 +98,7 @@ describe('logout route', function() {
           clientID: '__test_client_id__',
           baseURL: 'https://example.org',
           issuerBaseURL: 'https://test.auth0.com',
-          appSessionSecret: '__test_session_secret__',
+          appSession: {secret: '__test_session_secret__'},
           postLogoutRedirectUri: '/after-logout-in-auth-config',
           required: false,
         });
@@ -135,7 +135,7 @@ describe('logout route', function() {
           clientID: '__test_client_id__',
           baseURL: 'https://example.org',
           issuerBaseURL: 'https://test.auth0.com',
-          appSessionSecret: '__test_session_secret__',
+          appSession: {secret: '__test_session_secret__'},
           postLogoutRedirectUri: 'https://external-domain.com/after-logout-in-auth-config',
           required: false,
         });

--- a/test/requiresAuth.tests.js
+++ b/test/requiresAuth.tests.js
@@ -14,7 +14,7 @@ describe('requiresAuth middleware', function() {
 
     before(async function() {
       const router = auth({
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         clientID: '__test_client_id__',
         baseURL: 'https://example.org',
         issuerBaseURL: 'https://test.auth0.com',
@@ -53,7 +53,7 @@ describe('requiresAuth middleware', function() {
 
     before(async function() {
       const router = auth({
-        appSessionSecret: '__test_session_secret__',
+        appSession: {secret: '__test_session_secret__'},
         clientID: '__test_client_id__',
         baseURL: 'https://example.org',
         issuerBaseURL: 'https://test.auth0.com',


### PR DESCRIPTION
### Description

**This is a breaking change in configuration for all applications!**

This PR merges existing application session configuration into a single object. Specific changes:

- Add a required `appSession` configuration key that can be an object (described below) or `false` to skip the internally-generated cookie-based session.
- Change the default session name to `appSession` from `identity`
- Changed config key `appSessionSecret` to `appSession.secret`. If the `appSession` object is provided then this needs to have a string value 8 characters or greater, an array of string values 8 characters or greater, or an `APP_SESSION_SECRET` defined in `process.env`.
- Changed config key `appSessionName` to `appSession.name`.
- Changed config key `appSessionDuration` to `appSession.duration`.
- Merged config key `appSessionCookie` with the new `appSession` object. Cookie options are:
  - `cookieDomain`: Works the name as `appSessionCookie.domain` previously 
  - `cookieTransient`: Same functionality as `appSessionCookie.ephemeral` in v0.7.0, sets cookie expiration to `0`
  - `cookieHttpOnly`: Works the name as `appSessionCookie.httpOnly` previously 
  - `cookiePath`: Works the name as `appSessionCookie.path` previously 
  - `cookieSameSite`: Works the name as `appSessionCookie.sameSite` previously 
  - `cookieSecure`: Works the name as `appSessionCookie.secure` previously 
- TS: Removed `SessionCookieConfigParams` and added `AppSessionConfigParams`

An application configuration in 0.7.0 like this:

```js
// TS type here would be `SessionCookieConfigParams`
const appSessionCookieConfig = {
  domain: 'localhost',
  transient: false,
  httpOnly: true,
  path: '/',
  sameSite: 'Strict',
  secure: true
};

// TS type here would be `ConfigParams`
const oidcConfig: ConfigParams = {
  appSessionCookie: appSessionCookieConfig,
  appSessionSecret: process.env.APP_SESSION_SECRET,
  appSessionDuration: 234567890,
  appSessionName: 'customSession',
  baseURL: process.env.BASE_URL,
  clientID: process.env.CLIENT_ID,
  issuerBaseURL: process.env.ISSUER_BASE_URL
};
```

Would now need to look like:

```js
// TS type here would be `AppSessionConfigParams`
const appSessionConfig = {
  secret: process.env.APP_SESSION_SECRET,
  duration: 234567890,
  name: 'customSession',
  cookieDomain: 'localhost',
  cookieTransient: false,
  cookieHttpOnly: true,
  cookiePath: '/',
  cookieSameSite: 'Strict',
  cookieSecure: true
};

// TS type here would still be `ConfigParams`
const oidcConfig: ConfigParams = {
  appSession: appSessionConfig,
  baseURL: process.env.BASE_URL,
  clientID: process.env.CLIENT_ID,
  issuerBaseURL: process.env.ISSUER_BASE_URL
};
```

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
