### PR TITLE
Remove returnTo parameter for logout

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -105,7 +105,7 @@ class ResponseContext {
     const res = this._res;
     const config = this._config;
 
-    let returnURL = params.returnTo || req.query.returnTo || config.postLogoutRedirectUri;
+    let returnURL = params.returnTo || config.postLogoutRedirectUri;
 
     if (url.parse(returnURL).host === null) {
       returnURL = urlJoin(config.baseURL, returnURL);

--- a/test/logout.tests.js
+++ b/test/logout.tests.js
@@ -118,11 +118,6 @@ describe('logout route', function() {
         const logoutResponse = await request.get({uri: '/logout', baseUrl, jar, followRedirect: false});
         assert.equal(logoutResponse.headers.location, 'https://example.org/after-logout-in-auth-config');
       });
-
-      it('should redirect to returnTo in logout query', async function() {
-        const logoutResponse = await request.get({uri: '/logout', qs: {returnTo: '/after-logout-in-logout-query'}, baseUrl, jar, followRedirect: false});
-        assert.equal(logoutResponse.headers.location, 'https://example.org/after-logout-in-logout-query');
-      });
     });
 
     describe('should allow absolute paths', () => {
@@ -154,11 +149,6 @@ describe('logout route', function() {
       it('should redirect to postLogoutRedirectUri in auth() config', async function() {
         const logoutResponse = await request.get({uri: '/logout', baseUrl, jar, followRedirect: false});
         assert.equal(logoutResponse.headers.location, 'https://external-domain.com/after-logout-in-auth-config');
-      });
-
-      it('should redirect to returnTo in logout query', async function() {
-        const logoutResponse = await request.get({uri: '/logout', qs: {returnTo: 'https://external-domain.com/after-logout-in-logout-query'}, baseUrl, jar, followRedirect: false});
-        assert.equal(logoutResponse.headers.location, 'https://external-domain.com/after-logout-in-logout-query');
       });
     });
   });


### PR DESCRIPTION
### Description

Remove the `returnTo` parameter from the logout URL to avoid redirecting logged-in users to an externally-defined URL. 
