### PR TITLE
[SDK-1087] Fix case where APP_SESSION_SECRET is set and appSession is not

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -86,7 +86,8 @@ module.exports.get = function(params) {
     issuerBaseURL: process.env.ISSUER_BASE_URL,
     baseURL: process.env.BASE_URL,
     clientID: process.env.CLIENT_ID,
-    clientSecret: process.env.CLIENT_SECRET
+    clientSecret: process.env.CLIENT_SECRET,
+    appSession: {},
   }, config);
 
   if (process.env.APP_SESSION_SECRET && typeof config.appSession === 'object') {

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -29,6 +29,42 @@ describe('config', function() {
     });
   });
 
+  describe('simple case with environment variables', function() {
+    let config;
+    let env;
+
+    beforeEach(function() {
+      env = process.env;
+      process.env = Object.assign({}, process.env, {
+        ISSUER_BASE_URL: defaultConfig.issuerBaseURL,
+        CLIENT_ID: defaultConfig.clientID,
+        APP_SESSION_SECRET: defaultConfig.appSession.secret,
+        BASE_URL: defaultConfig.baseURL
+      });
+      config = getConfig();
+    });
+
+    afterEach(function() {
+      process.env = env;
+    });
+
+    it('should default to response_type=id_token', function() {
+      assert.equal(config.authorizationParams.response_type, 'id_token');
+    });
+
+    it('should default to response_mode=form_post', function() {
+      assert.equal(config.authorizationParams.response_mode, 'form_post');
+    });
+
+    it('should default to scope=openid profile email', function() {
+      assert.equal(config.authorizationParams.scope, 'openid profile email');
+    });
+
+    it('should default to required true', function() {
+      assert.ok(config.required);
+    });
+  });
+
   describe('when authorizationParams is response_type=code', function() {
     const customConfig = Object.assign({}, defaultConfig, {
       clientSecret: '__test_client_secret__',

--- a/test/invalid_params.tests.js
+++ b/test/invalid_params.tests.js
@@ -62,7 +62,7 @@ describe('invalid parameters', function() {
         baseURL: 'https://example.org',
         clientID: '__test_client_id__',
       });
-    }, '"appSession" is required');
+    }, '"appSession.secret" is required');
   });
 
   it('should fail when client secret is not provided and using the response type code in mode query', function() {


### PR DESCRIPTION
### Description

The simple case with env vars

```bash
# .env
ISSUER_BASE_URL=https://YOUR_DOMAIN
CLIENT_ID=YOUR_CLIENT_ID
BASE_URL=https://YOUR_APPLICATION_ROOT_URL
APP_SESSION_SECRET=LONG_RANDOM_VALUE
```

```js
const { auth } = require("express-openid-connect");
app.use(auth());
```

Was throwing `Error: "appSession" is required`

### Testing

Run the simple case with environmental variables https://github.com/auth0/express-openid-connect#getting-started

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- ~[ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs~
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
