### PR TITLE
[SDK-1467] Fix cookie options case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ typings/
 .fusebox/
 
 # End of https://www.gitignore.io/api/node
+
+.idea

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -52,7 +52,7 @@ module.exports = (sessionConfig) => {
 
       const cookieOptions = {};
       Object.keys(sessionConfig).filter(key => /^cookie/.test(key)).forEach(function(key) {
-        const cookieOptionKey = key.replace('cookie', '').toLowerCase();
+        const cookieOptionKey = key.replace(/^cookie([A-Z])/, (match, p1) => p1.toLowerCase());
         cookieOptions[cookieOptionKey] = sessionConfig[key];
       });
 

--- a/test/appSession.tests.js
+++ b/test/appSession.tests.js
@@ -131,8 +131,8 @@ describe('appSession', function() {
       assert.equal(cookieArgs['2'].domain, '__test_domain__');
       assert.equal(cookieArgs['2'].path, '__test_path__');
       assert.equal(cookieArgs['2'].secure, true);
-      assert.equal(cookieArgs['2'].httponly, false);
-      assert.equal(cookieArgs['2'].samesite, '__test_samesite__');
+      assert.equal(cookieArgs['2'].httpOnly, false);
+      assert.equal(cookieArgs['2'].sameSite, '__test_samesite__');
     });
   });
 });


### PR DESCRIPTION
### Description

issue with the latest version of experss-oidc-connect the appSession cookie properties (`SameSite`, `HttpOnly`) aren’t being correctly applied since b5cf021709a70bb70bad1ed6a15fae60d6478bc3 The offending line is https://github.com/auth0/express-openid-connect/blob/b5cf021709a70bb70bad1ed6a15fae60d6478bc3/lib/appSession.js#L55  converting `cookieSameSite` to `samesite` when it should be `sameSite`

### References

https://github.com/jshttp/cookie#samesite

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
