### PR TITLE
Check idTokenAlg configuration is not overridden by discover server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -880,6 +880,15 @@
         "type-detect": "^4.0.5"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@types/express": "^4.17.2",
     "chai": "^4.2.0",
+    "chai-as-promised": "^7.1.1",
     "cookie-session": "^2.0.0-rc.1",
     "eslint": "^5.16.0",
     "express": "^4.17.1",


### PR DESCRIPTION
### Description

Check idTokenAlg configuration is not overridden when discover server returns 'none' for id token algorithm

### References

https://auth0team.atlassian.net/wiki/spaces/SDL/pages/588286390/express-openid-connect+SDK?focusedCommentId=593206158#comment-593206158

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- ~[ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs~
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
