### PR TITLE
[SDK-1466] Allow to opt-out from sending SDK Telemetry - by setting `enableTelem…

### DIFF
--- a/API.md
+++ b/API.md
@@ -34,6 +34,7 @@ Additional configuration keys that can be passed to `auth()` on initialization:
 - **`auth0Logout`** - Boolean value to enable Auth0's logout feature. Default is `false`.
 - **`authorizationParams`** - Object that describes the authorization server request. [See below](#authorization-params-key) for defaults and more details.
 - **`clockTolerance`** - Integer value for the system clock's tolerance (leeway) in seconds for ID token verification. Default is `60`.
+- **`enableTelemetry`** - Opt-in to sending the library and node version to your authorization server via the `Auth0-Client` header. Default is `true`.
 - **`errorOnRequiredAuth`** - Boolean value to throw a `Unauthorized 401` error instead of triggering the login process for routes that require authentication. Default is `false`.
 - **`getUser`** - Function that returns the profile for `req.openid.user`. This runs on each application page load for authenticated users. Default is [here](lib/hooks/getUser.js).
 - **`handleCallback`** - Function that runs on the callback route, after callback processing but before redirection. Default is [here](lib/hooks/handleCallback.js).

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -108,7 +108,7 @@ app.use(auth({
   // Setting this configuration key to false will turn off internal session handling.
   appSession: false,
   handleCallback: async function (req, res, next) {
-    // This will store the user identity claims in the session
+    // This will store the user identity claims in the session.
     req.session.userIdentity = req.openidTokens.claims();
     next();
   },

--- a/index.d.ts
+++ b/index.d.ts
@@ -65,6 +65,12 @@ interface ConfigParams {
     clockTolerance?: number;
 
     /**
+     * Opt-in to sending the library and node version to your authorization server
+     * via the `Auth0-Client` header.
+     */
+    enableTelemetry?: boolean;
+
+    /**
      * Throw a 401 error instead of triggering the login process for routes that require authentication.
      */
     errorOnRequiredAuth?: boolean;

--- a/lib/client.js
+++ b/lib/client.js
@@ -74,8 +74,8 @@ async function get(config) {
     // Allow configuration to override user agent header.
     {'User-Agent': `${pkg.name}/${pkg.version}`},
     httpOptions.headers || {},
-    // Do not allow overriding telemetry.
-    {'Auth0-Client': Buffer.from(JSON.stringify(telemetryHeader)).toString('base64')}
+    // Do not allow overriding telemetry, but allow it to be omitted.
+    config.enableTelemetry && {'Auth0-Client': Buffer.from(JSON.stringify(telemetryHeader)).toString('base64')}
   );
 
   custom.setHttpOptionsDefaults(httpOptions);

--- a/lib/client.js
+++ b/lib/client.js
@@ -78,7 +78,9 @@ async function get(config) {
     config.enableTelemetry && {'Auth0-Client': Buffer.from(JSON.stringify(telemetryHeader)).toString('base64')}
   );
 
-  custom.setHttpOptionsDefaults(httpOptions);
+  client[custom.http_options] = function(options) {
+    return Object.assign({}, options, httpOptions);
+  };
 
   client[custom.clock_tolerance] = config.clockTolerance;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -59,6 +59,7 @@ const paramsSchema = Joi.object({
     }
   ),
   clockTolerance: Joi.number().optional().default(60),
+  enableTelemetry: Joi.boolean().optional().default(true),
   errorOnRequiredAuth: Joi.boolean().optional().default(false),
   getLoginState: Joi.function().optional().default(() => getLoginState),
   getUser: Joi.function().optional().default(() => getUser),

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -90,6 +90,29 @@ describe('client initialization', function() {
     });
   });
 
+  describe('telemetry header', function() {
+    const config = getConfig({
+      appSession: {secret: '__test_session_secret__'},
+      clientID: '__test_client_id__',
+      clientSecret: '__test_client_secret__',
+      issuerBaseURL: 'https://test.auth0.com',
+      baseURL: 'https://example.org',
+      enableTelemetry: false
+    });
+
+    let client;
+    before(async function() {
+      client = await getClient(config);
+    });
+
+    it('should send the correct default headers', async function() {
+      const headers = await client.introspect('__test_token__', '__test_hint__');
+      const headerProps = Object.getOwnPropertyNames(headers);
+
+      assert.notInclude(headerProps, 'auth0-client');
+    });
+  });
+
   describe('idTokenAlg configuration is not overridden by discovery server', function() {
     const config = getConfig({
       appSession: {secret: '__test_session_secret__'},


### PR DESCRIPTION
### Description

Allow to opt-out from sending SDK Telemetry by setting `enableTelmetry: false`

This will prevent the library from sending the `Auth0-Client` header with the library and node version

### References

https://auth0team.atlassian.net/wiki/spaces/SDL/pages/588286390/express-openid-connect+SDK#Sensitive-Data-Exposure

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
