### PR TITLE
[SDK-1468] Add a note on hiding error details from the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ See the [examples](EXAMPLES.md) for route-specific authentication, custom applic
 
 See the [API documentation](API.md) for additional configuration possibilities and provided methods.
 
+## A note on error handling
+
+Errors raised by this library are handled by the [default Express error handler](https://expressjs.com/en/guide/error-handling.html#the-default-error-handler) which, in the interests of security, does not include the stack trace in the production environment.
+
+But you may want to go one step further and hide additional error details from client, like the error message. To do this see the Express documentation on writing [Custom error handlers](https://expressjs.com/en/guide/error-handling.html#writing-error-handlers)
+
 ## Contributing
 
 We appreciate feedback and contribution to this repo! Before you get started, please see the following:


### PR DESCRIPTION
### Description

The library issues fairly detailed error messages, and while it's best practice to handle errors centrally, (not within an Express MW) It's worth adding a note that developers may want to strip the error message from the response to the client, in production mode.

### References

https://auth0team.atlassian.net/wiki/spaces/SDL/pages/588286390/express-openid-connect+SDK?focusedCommentId=611713843#comment-611713843

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
