### PR TITLE
Change the default session duration to 1 day

### DIFF
--- a/API.md
+++ b/API.md
@@ -23,7 +23,7 @@ Additional configuration keys that can be passed to `auth()` on initialization:
 
 - **`appSession`** - Object defining application session configuration. If this is set to `false`, the internal storage will not be used (see [this example](https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md#4-custom-user-session-handling) for how to provide your own session mechanism). Otherwise, the `secret` key is required (see above).
   - **`appSession.secret`** - See the **Required Keys** section above.
-  - **`appSession.duration`** - Integer value, in seconds, for application session duration. Default is 7 days.
+  - **`appSession.duration`** - Integer value, in seconds, for application session duration. Default is 1 day.
   - **`appSession.name`** - String value for the cookie name used for the internal session. This value must only include letters, numbers, and underscores. Default is `appSession`.
   - **`appSession.cookieTransient`** - Sets the application session cookie expiration to `0` to create a transient cookie. Set to `false` by default.
   - **`appSession.cookieDomain`** - Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `domain`.

--- a/index.d.ts
+++ b/index.d.ts
@@ -174,7 +174,7 @@ interface AppSessionConfigParams {
 
     /**
      * Integer value, in seconds, for application session duration.
-     * Default is 604800 seconds (7 days).
+     * Default is 86400 seconds (1 day).
      */
     duration?: number
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,7 @@ const { defaultState: getLoginState } = require('./hooks/getLoginState');
 const getUser = require('./hooks/getUser');
 const handleCallback = require('./hooks/handleCallback');
 
-const sessionDurationDefault = (7 * 24 * 60 * 60); // 7 days
+const sessionDurationDefault = (24 * 60 * 60); // 1 day
 const sessionNameDefault = 'appSession';
 
 const paramsSchema = Joi.object({

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -172,8 +172,8 @@ describe('config', function() {
       assert.equal(config.appSession.secret, '__test_session_secret__');
     });
 
-    it('should set the session length to 7 days by default', function() {
-      assert.equal(config.appSession.duration, 604800);
+    it('should set the session length to 1 day by default', function() {
+      assert.equal(config.appSession.duration, 86400);
     });
 
     it('should set the session name to "appSession" by default', function() {


### PR DESCRIPTION
### Description

Our security review suggested that 7 days for the app session cookie to expire is perhaps a little long for a default.

I had a look around, well just at `auth0-spa-js`, and noticed that uses 1 day.

Since the auth server handles the underlying session, it shouldn't noticeably effect user experience.

### References

https://auth0team.atlassian.net/wiki/spaces/SDL/pages/588286390/express-openid-connect+SDK#Security-Misconfiguration

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
