### PR TITLE
[ESD-5519] Fix issue where authz header was overridden in code exchange

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -78,9 +78,7 @@ async function get(config) {
     config.enableTelemetry && {'Auth0-Client': Buffer.from(JSON.stringify(telemetryHeader)).toString('base64')}
   );
 
-  client[custom.http_options] = function(options) {
-    return Object.assign({}, options, httpOptions);
-  };
+  custom.setHttpOptionsDefaults(httpOptions);
 
   client[custom.clock_tolerance] = config.clockTolerance;
 

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -61,7 +61,7 @@ describe('client initialization', function() {
       });
       const headerProps = Object.getOwnPropertyNames(JSON.parse(response.body));
 
-      assert.include( headerProps, 'authorization');
+      assert.include(headerProps, 'authorization');
     });
   });
 
@@ -119,11 +119,11 @@ describe('client initialization', function() {
       await getClient(config);
     });
 
-    after(async function() {
+    after(function() {
       openidClient.custom.setHttpOptionsDefaults.restore();
     });
 
-    it('should set the correct default headers', async function() {
+    it('should set the correct default headers', function() {
       assert.doesNotHaveAnyKeys(
         openidClient.custom.setHttpOptionsDefaults.firstCall.args[0].headers,
         ['auth0-client']

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -51,6 +51,18 @@ describe('client initialization', function() {
       assert.include( headerProps, 'user-agent');
       assert.equal( `express-openid-connect/${pkg.version}`, headers['user-agent']);
     });
+
+    it('should not strip new headers', async function() {
+      const response = await client.requestResource('https://test.auth0.com/introspection', 'token', {
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer foo',
+        }
+      });
+      const headerProps = Object.getOwnPropertyNames(JSON.parse(response.body));
+
+      assert.include( headerProps, 'authorization');
+    });
   });
 
   describe('custom headers', function() {


### PR DESCRIPTION
### Description

Revert https://github.com/auth0/express-openid-connect/pull/78/commits/82f1a0d0e90752247eb17d94b525e091709f824e which was overriding the Authz header and fix tests

### Testing

~~I'll raise a separate story to come up with a way to regression test issues like these.~~ Added a simple unit test

### Checklist

- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
