### PR TITLE
Handle `token_endpoint_auth_method` customization.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -382,6 +382,11 @@ interface ConfigParams {
      */
     callback?: string;
   };
+
+  /**
+   * String value for the token endpoint authentication method. Default is `client_secret_basic`.
+   */
+  tokenAuthMethod?: string;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -384,9 +384,9 @@ interface ConfigParams {
   };
 
   /**
-   * String value for the token endpoint authentication method. Default is `client_secret_basic`.
+   * String value for the client's authentication method. Default is `none` when using response_type='id_token', otherwise `client_secret_basic`.
    */
-  tokenAuthMethod?: string;
+  clientAuthMethod?: string;
 }
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -84,10 +84,21 @@ async function get(config) {
     );
   }
 
+  const configTokenAuthMethod = config.tokenAuthMethod;
+  const issuerTokenAuthMethod = Array.isArray(issuer.token_endpoint_auth_methods_supported) ?
+    issuer.token_endpoint_auth_methods_supported : [];
+  if (configTokenAuthMethod && ! issuerTokenAuthMethod.includes(configTokenAuthMethod)) {
+    throw new Error(
+      `Token auth method "${configTokenAuthMethod}" is not supported by the issuer. ` +
+      `Supported token auth methods are "${issuerTokenAuthMethod.join('", "')}". `
+    );
+  }
+
   const client = new issuer.Client({
     client_id: config.clientID,
     client_secret: config.clientSecret,
     id_token_signed_response_alg: config.idTokenSigningAlg,
+    token_endpoint_auth_method: config.tokenAuthMethod,
   });
   applyHttpOptionsCustom(client);
   client[custom.clock_tolerance] = config.clockTolerance;

--- a/lib/client.js
+++ b/lib/client.js
@@ -84,16 +84,6 @@ async function get(config) {
     );
   }
 
-  const configTokenAuthMethod = config.tokenAuthMethod;
-  const issuerTokenAuthMethod = Array.isArray(issuer.token_endpoint_auth_methods_supported) ?
-    issuer.token_endpoint_auth_methods_supported : [];
-  if (configTokenAuthMethod && ! issuerTokenAuthMethod.includes(configTokenAuthMethod)) {
-    throw new Error(
-      `Token auth method "${configTokenAuthMethod}" is not supported by the issuer. ` +
-      `Supported token auth methods are "${issuerTokenAuthMethod.join('", "')}". `
-    );
-  }
-
   const client = new issuer.Client({
     client_id: config.clientID,
     client_secret: config.clientSecret,

--- a/lib/client.js
+++ b/lib/client.js
@@ -88,7 +88,7 @@ async function get(config) {
     client_id: config.clientID,
     client_secret: config.clientSecret,
     id_token_signed_response_alg: config.idTokenSigningAlg,
-    token_endpoint_auth_method: config.tokenAuthMethod,
+    token_endpoint_auth_method: config.clientAuthMethod,
   });
   applyHttpOptionsCustom(client);
   client[custom.clock_tolerance] = config.clockTolerance;

--- a/lib/config.js
+++ b/lib/config.js
@@ -148,13 +148,7 @@ const paramsSchema = Joi.object({
   })
     .default()
     .unknown(false),
-  loginPath: Joi.string().uri({relativeOnly: true}).optional().default('/login'),
-  logoutPath: Joi.string().uri({relativeOnly: true}).optional().default('/logout'),
-  postLogoutRedirectUri: Joi.string().uri({allowRelative: true}).optional().default(''),
-  redirectUriPath: Joi.string().uri({relativeOnly: true}).optional().default('/callback'),
-  required: Joi.alternatives([ Joi.function(), Joi.boolean()]).optional().default(true),
-  routes: Joi.boolean().optional().default(true),
-  tokenAuthMethod: Joi.string().optional()
+  tokenAuthMethod: Joi.string().valid('client_secret_basic', 'client_secret_post', 'none').optional().default('client_secret_basic')
 });
 
 module.exports.get = function (params) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -148,7 +148,14 @@ const paramsSchema = Joi.object({
   })
     .default()
     .unknown(false),
-  tokenAuthMethod: Joi.string().valid('client_secret_basic', 'client_secret_post', 'none').optional().default('client_secret_basic')
+  clientAuthMethod: Joi.string()
+    .valid('client_secret_basic', 'client_secret_post', 'none')
+    .optional()
+    .default((parent) => {
+      return parent.authorizationParams.response_type === 'id_token'
+        ? 'none'
+        : 'client_secret_basic';
+    }),
 });
 
 module.exports.get = function (params) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -148,6 +148,13 @@ const paramsSchema = Joi.object({
   })
     .default()
     .unknown(false),
+  loginPath: Joi.string().uri({relativeOnly: true}).optional().default('/login'),
+  logoutPath: Joi.string().uri({relativeOnly: true}).optional().default('/logout'),
+  postLogoutRedirectUri: Joi.string().uri({allowRelative: true}).optional().default(''),
+  redirectUriPath: Joi.string().uri({relativeOnly: true}).optional().default('/callback'),
+  required: Joi.alternatives([ Joi.function(), Joi.boolean()]).optional().default(true),
+  routes: Joi.boolean().optional().default(true),
+  tokenAuthMethod: Joi.string().optional()
 });
 
 module.exports.get = function (params) {

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -574,4 +574,46 @@ describe('get config', () => {
       config({ response_type: 'code id_token', response_mode: 'form_post' })
     );
   });
+
+  it('should default clientAuthMethod to none for id_token response type', () => {
+    {
+      const config = getConfig(defaultConfig);
+      assert.deepInclude(config, {
+        clientAuthMethod: 'none',
+      });
+    }
+    {
+      const config = getConfig({
+        ...defaultConfig,
+        authorizationParams: { response_type: 'id_token' },
+      });
+      assert.deepInclude(config, {
+        clientAuthMethod: 'none',
+      });
+    }
+  });
+
+  it('should default clientAuthMethod to client_secret_basic for other response types', () => {
+    {
+      const config = getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        authorizationParams: { response_type: 'code' },
+      });
+      assert.deepInclude(config, {
+        clientAuthMethod: 'client_secret_basic',
+      });
+    }
+
+    {
+      const config = getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        authorizationParams: { response_type: 'code id_token' },
+      });
+      assert.deepInclude(config, {
+        clientAuthMethod: 'client_secret_basic',
+      });
+    }
+  });
 });


### PR DESCRIPTION
### Description

Provide a way of customizing client's `token_endpoint_auth_method` using `tokenAuthMethod` option. It is then checked against Issuer's supported auth methods.
It was needed in my case because the default provided auth method was not compatible with my SSO provider. 

### Testing

Try the option `tokenAuthMethod` against any SSO.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
