### PR TITLE
Cookie options should be applied when clearing the cookie as well as setting the cookie

### DIFF
--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -42,24 +42,23 @@ module.exports = (sessionConfig) => {
   }
 
   function setCookie (req, res, { uat = epoch(), iat = uat, exp = uat + sessionDuration }) {
+    const cookieOptions = {};
+    Object.keys(sessionConfig).filter(key => /^cookie/.test(key)).forEach(function(key) {
+      const cookieOptionKey = key.replace(/^cookie([A-Z])/, (match, p1) => p1.toLowerCase());
+      cookieOptions[cookieOptionKey] = sessionConfig[key];
+    });
+    const expires = cookieOptions.transient ? 0 : new Date(exp * 1000);
+    delete cookieOptions.transient;
+
     if ((!req[sessionName] || !Object.keys(req[sessionName]).length) && sessionName in req[COOKIES]) {
-      res.clearCookie(sessionName);
+      res.clearCookie(sessionName, cookieOptions);
       return;
     }
 
     if (req[sessionName] && Object.keys(req[sessionName]).length > 0) {
       const value = encrypt(JSON.stringify(req[sessionName]), { iat, uat, exp });
 
-      const cookieOptions = {};
-      Object.keys(sessionConfig).filter(key => /^cookie/.test(key)).forEach(function(key) {
-        const cookieOptionKey = key.replace(/^cookie([A-Z])/, (match, p1) => p1.toLowerCase());
-        cookieOptions[cookieOptionKey] = sessionConfig[key];
-      });
-
-      cookieOptions.expires = cookieOptions.transient ? 0 : new Date(exp * 1000);
-      delete cookieOptions.transient;
-
-      res.cookie(sessionName, value, cookieOptions);
+      res.cookie(sessionName, value, { expires, ...cookieOptions });
     }
   }
 

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -43,7 +43,7 @@ module.exports = (sessionConfig) => {
 
   function setCookie (req, res, { uat = epoch(), iat = uat, exp = uat + sessionDuration }) {
     const cookieOptions = {};
-    Object.keys(sessionConfig).filter(key => /^cookie/.test(key)).forEach(function(key) {
+    Object.keys(sessionConfig).filter(key => /^cookie/.test(key)).forEach((key) => {
       const cookieOptionKey = key.replace(/^cookie([A-Z])/, (match, p1) => p1.toLowerCase());
       cookieOptions[cookieOptionKey] = sessionConfig[key];
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,63 +1072,10 @@
         }
       }
     },
-    "cookie-session": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-2.0.0-rc.1.tgz",
-      "integrity": "sha512-zg80EsLe7S1J4y0XxV7SZ8Fbi90ZZoampuX2bfYDOvJfc//98sSlZC41YDzTTjtVbeU1VlVdBbldXOOyi5xzEw==",
-      "dev": true,
-      "requires": {
-        "cookies": "0.8.0",
-        "debug": "3.2.6",
-        "on-headers": "~1.0.2",
-        "safe-buffer": "5.2.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-          "dev": true
-        }
-      }
-    },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
-    },
-    "cookies": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
-      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
-      "dev": true,
-      "requires": {
-        "depd": "~2.0.0",
-        "keygrip": "~1.1.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-          "dev": true
-        }
-      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -2554,15 +2501,6 @@
       "requires": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "keygrip": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
-      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-      "dev": true,
-      "requires": {
-        "tsscmp": "1.0.6"
       }
     },
     "keyv": {
@@ -4260,12 +4198,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
-    },
-    "tsscmp": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
-      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@types/express": "^4.17.2",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "cookie-session": "^2.0.0-rc.1",
     "eslint": "^5.16.0",
     "express": "^4.17.1",
     "jsdom": "^13.2.0",

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -1,15 +1,9 @@
 const express = require('express');
-const cookieSession = require('cookie-session');
 const bodyParser = require('body-parser');
 const http = require('http');
 
-module.exports.create = function(router, protect) {
+module.exports.create = function(router, protect, path) {
   const app = express();
-
-  app.use(cookieSession({
-    name: '__test_name__',
-    secret: '__test_secret__',
-  }));
 
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(bodyParser.json());
@@ -18,6 +12,11 @@ module.exports.create = function(router, protect) {
 
   app.get('/session', (req, res) => {
     res.json(req.appSession);
+  });
+
+  app.post('/session', (req, res) => {
+    req.appSession = req.body;
+    res.json();
   });
 
   app.get('/user', (req, res) => {
@@ -36,7 +35,15 @@ module.exports.create = function(router, protect) {
       .json({ err: { message: err.message }});
   });
 
-  const server = http.createServer(app);
+  let mainApp;
+  if (path) {
+    mainApp = express();
+    mainApp.use(path, app);
+  } else {
+    mainApp = app;
+  }
+
+  const server = http.createServer(mainApp);
 
   return new Promise((resolve) => {
     server.unref();


### PR DESCRIPTION
### Description

Given I have an express-openid-connect app under a sub path '/foo'
When  I set the cookiePath to '/foo'
Then the cookie should be cleared when I logout

Currently the cookie is removed for path='/', which wont clear cookies set under a separate path

res.clearCookie should respect the config cookie options
https://github.com/auth0/express-openid-connect/blob/1d713edc25a3195bb1348805cf84c84cce9848b5/lib/appSession.js#L46

### References

https://expressjs.com/en/api.html#res.clearCookie
"Web browsers and other compliant clients will only clear the cookie if the given options is identical to those given to res.cookie(), excluding expires and maxAge"

### Testing

Create an `express-openid-connect` app under a path '/foo', set the `appSession.cookiePath` to '/foo'. Logout of the application locally, check that the session cookie has been removed

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- ~[ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs~
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
