### PR TITLE
Fix returnTo on Login

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -55,10 +55,17 @@ class ResponseContext {
     const config = this._config;
     const client = req.openid.client;
 
-    // Set default returnTo value, allow passed-in options to override.
+    // Set default returnTo value, allow passed-in options to override or use originalUrl on GET
+    let returnTo = this._config.baseURL;
+    if (options.returnTo) {
+      returnTo = options.returnTo;
+    } else if (req.method === 'GET' && req.originalUrl) {
+      returnTo = req.originalUrl;
+    }
+
     options = {
-      returnTo: this._config.baseURL,
       authorizationParams: {},
+      returnTo,
       ...options
     };
 

--- a/test/requiresAuth.tests.js
+++ b/test/requiresAuth.tests.js
@@ -30,6 +30,12 @@ describe('requiresAuth middleware', function() {
     it('should contain a location header to the issuer', function() {
       assert.include(response.headers.location, 'https://test.auth0.com');
     });
+    it('should contain a location header with state containing return url', function() {
+      const state = (new URL(response.headers.location)).searchParams.get('state');
+      const decoded = Buffer.from(state, 'base64');
+      const parsed = JSON.parse(decoded);
+      assert.equal(parsed.returnTo, '/protected');
+    });
   });
 
   describe('when removing the auth middleware', function() {


### PR DESCRIPTION
When no returnTo is passed into the login call, it should redirect to the URL that it was called from on GET Requests.

This is in line with documentation at https://github.com/auth0/express-openid-connect/blob/master/API.md#response

