### PR TITLE
Update EXAMPLES.md

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -44,11 +44,11 @@ app.use(auth({
 }));
 
 // Anyone can access the homepage
-app.use('/', (req, res) => res.render('home'));
+app.get('/', (req, res) => res.render('home'));
 
 // Require routes under the /admin/ prefix to check authentication.
-app.use('/admin/users', requiresAuth(), (req, res) => res.render('admin-users'));
-app.use('/admin/posts', requiresAuth(), (req, res) => res.render('admin-posts'));
+app.get('/admin/users', requiresAuth(), (req, res) => res.render('admin-users'));
+app.get('/admin/posts', requiresAuth(), (req, res) => res.render('admin-posts'));
 ```
 
 Another way to configure this scenario:


### PR DESCRIPTION
`app.use` will apply to all routes that start with the given prefix, meaning the example will only serve the '/' route

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
