### PR TITLE
fixed JEWDecryptionFailed error

### DIFF
--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -82,6 +82,8 @@ module.exports = (sessionConfig) => {
         assert(exp > epoch());
         req[sessionName] = JSON.parse(cleartext);
       }
+    } catch(err) {
+      // Session cookie is malformed.  Ignore it.
     } finally {
       if (!req.hasOwnProperty(sessionName) || !req[sessionName]) {
         req[sessionName] = {};

--- a/test/appSession.tests.js
+++ b/test/appSession.tests.js
@@ -45,9 +45,14 @@ describe('appSession', function() {
   describe('malformed session cookies', () => {
     const appSessionMw = appSession(defaultConfig);
     const thisReq = {get: () => 'appSession=__invalid_identity__'};
+    const result = appSessionMw(thisReq, {}, next);
 
-    it('should error with malformed appSession', function() {
-      assert.throws(() => appSessionMw(thisReq, {}, next), Error, 'JWE malformed or invalid serialization');
+    it('should call next', function() {
+      assert.ok(result);
+    });
+
+    it('should set an empty appSession', function() {
+      assert.isEmpty(thisReq.appSession);
     });
   });
 


### PR DESCRIPTION
### Description

### References

Fixes #104

### Testing

This can be tested by providing valid session cookies and invalid session cookies.  It will redirect to the login page properly when the session cookie is invalid (instead of a 500 error).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
