### PR TITLE
fix: don't throw when encountering session encrypted with an old secret

### DIFF
--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -1,5 +1,5 @@
 const { strict: assert } = require('assert');
-const { JWK, JWKS, JWE } = require('jose');
+const { JWK, JWKS, JWE, errors: { JWEDecryptionFailed } } = require('jose');
 const onHeaders = require('on-headers');
 const cookie = require('cookie');
 const hkdf = require('futoin-hkdf');
@@ -75,12 +75,15 @@ module.exports = (sessionConfig) => {
     let exp;
 
     try {
-
       if (req[COOKIES].hasOwnProperty(sessionName)) {
         const { protected: header, cleartext } = decrypt(req[COOKIES][sessionName]);
         ({ iat, exp } = header);
         assert(exp > epoch());
         req[sessionName] = JSON.parse(cleartext);
+      }
+    } catch (err) {
+      if (!(err instanceof JWEDecryptionFailed)) {
+        throw err;
       }
     } finally {
       if (!req.hasOwnProperty(sessionName) || !req[sessionName]) {


### PR DESCRIPTION
resolves #104
closes #105

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

This makes it so that if an encountered session is encrypted with a secret that's no longer in rotation that it is handled as if the session didn't exist instead of throwing.

### References

#104 #105

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
