### PR TITLE
attemptSilentLogin feature

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -140,7 +140,7 @@ interface ResponseContext {
    * });
    * ```
    */
-  login: (opts: LoginOptions) => Promise<void>;
+  login: (opts?: LoginOptions) => Promise<void>;
 
   /**
    * Provided by default via the `/logout` route. Call this to override or have other
@@ -152,7 +152,7 @@ interface ResponseContext {
    * });
    * ```
    */
-  logout: (opts: LogoutOptions) => Promise<void>;
+  logout: (opts?: LogoutOptions) => Promise<void>;
 }
 
 /**
@@ -295,6 +295,16 @@ interface ConfigParams {
    * Default is `false`
    */
   errorOnRequiredAuth?: boolean;
+
+  /**
+   * Attempt silent login (`prompt: 'none'`) on the first unauthenticated route the user visits.
+   * For protected routes this can be useful if your Identity Provider does not default to
+   * `prompt: 'none'` and you'd like to attempt this before requiring the user to interact with a login prompt.
+   * For unprotected routes this can be useful if you want to check the user's logged in state on their IDP, to
+   * show them a login/logout button for example.
+   * Default is `false`
+   */
+  attemptSilentLogin?: boolean;
 
   /**
    * Function that returns an object with URL-safe state values for `res.oidc.login()`.
@@ -558,3 +568,21 @@ export function claimIncludes(
 export function claimCheck(
   checkFn: (req: OpenidRequest, claims: IdTokenClaims) => boolean
 ): RequestHandler;
+
+/**
+ * Use this MW to attempt silent login (`prompt=none`) but not require authentication.
+ *
+ * See {@link ConfigParams.attemptSilentLogin attemptSilentLogin}
+ *
+ * ```js
+ * const { attemptSilentLogin } = require('express-openid-connect');
+ *
+ * app.get('/', attemptSilentLogin(), (req, res) => {
+ *   res.render('homepage', {
+ *     isAuthenticated: req.isAuthenticated() // show a login or logout button
+ *   });
+ * });
+ *
+ * ```
+ */
+export function attemptSilentLogin(): RequestHandler;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 const auth = require('./middleware/auth');
 const requiresAuth = require('./middleware/requiresAuth');
+const attemptSilentLogin = require('./middleware/attemptSilentLogin');
 
 module.exports = {
   auth,
   ...requiresAuth,
+  attemptSilentLogin,
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -103,7 +103,7 @@ const paramsSchema = Joi.object({
   clockTolerance: Joi.number().optional().default(60),
   enableTelemetry: Joi.boolean().optional().default(true),
   errorOnRequiredAuth: Joi.boolean().optional().default(false),
-  // TODO: attemptSilentLogin: Joi.boolean().optional().default(false),
+  attemptSilentLogin: Joi.boolean().optional().default(false),
   getLoginState: Joi.function()
     .optional()
     .default(() => getLoginState),

--- a/lib/context.js
+++ b/lib/context.js
@@ -8,9 +8,7 @@ const { strict: assert } = require('assert');
 const debug = require('./debug')('context');
 const { get: getClient } = require('./client');
 const { encodeState } = require('../lib/hooks/getLoginState');
-const {
-  cancelSilentLoginAttempts,
-} = require('../middleware/attemptSilentLogin');
+const { cancelSilentLogin } = require('../middleware/attemptSilentLogin');
 const weakRef = require('./weakCache');
 
 function isExpired() {
@@ -239,7 +237,7 @@ class ResponseContext {
       returnURL = urlJoin(config.baseURL, returnURL);
     }
 
-    cancelSilentLoginAttempts(req, res);
+    cancelSilentLogin(req, res);
 
     if (!req.oidc.isAuthenticated()) {
       debug('end-user already logged out, redirecting to %s', returnURL);

--- a/lib/context.js
+++ b/lib/context.js
@@ -8,6 +8,9 @@ const { strict: assert } = require('assert');
 const debug = require('./debug');
 const { get: getClient } = require('./client');
 const { encodeState } = require('../lib/hooks/getLoginState');
+const {
+  cancelSilentLoginAttempts,
+} = require('../middleware/attemptSilentLogin');
 const weakRef = require('./weakCache');
 
 function isExpired() {
@@ -127,6 +130,13 @@ class ResponseContext {
     return urlJoin(config.baseURL, config.routes.callback);
   }
 
+  silentLogin(options) {
+    return this.login({
+      ...options,
+      prompt: 'none',
+    });
+  }
+
   async login(options = {}) {
     let { config, req, res, next, transient } = weakRef(this);
     next = cb(next).once();
@@ -226,6 +236,8 @@ class ResponseContext {
     if (url.parse(returnURL).host === null) {
       returnURL = urlJoin(config.baseURL, returnURL);
     }
+
+    cancelSilentLoginAttempts(req, res);
 
     if (!req.oidc.isAuthenticated()) {
       return res.redirect(returnURL);

--- a/middleware/attemptSilentLogin.js
+++ b/middleware/attemptSilentLogin.js
@@ -1,0 +1,36 @@
+const debug = require('../lib/debug');
+const COOKIES = require('../lib/cookies');
+
+const COOKIE_NAME = 'silentLoginAttempted';
+
+const cancelSilentLoginAttempts = (req, res) =>
+  res.cookie(COOKIE_NAME, true, {
+    httpOnly: true,
+    secure: req.secure,
+  });
+
+module.exports = function attemptSilentLogin() {
+  return (req, res, next) => {
+    if (!req.oidc) {
+      next(
+        new Error('req.oidc is not found, did you include the auth middleware?')
+      );
+      return;
+    }
+
+    const silentLoginAttempted = !!(req[COOKIES] || {})[COOKIE_NAME];
+
+    if (
+      !silentLoginAttempted &&
+      !req.oidc.isAuthenticated() &&
+      req.accepts('html')
+    ) {
+      debug.trace('Attempting silent login');
+      cancelSilentLoginAttempts(req, res);
+      return res.oidc.silentLogin();
+    }
+    next();
+  };
+};
+
+module.exports.cancelSilentLoginAttempts = cancelSilentLoginAttempts;

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -6,6 +6,7 @@ const debug = require('../lib/debug');
 const { get: getConfig } = require('../lib/config');
 const { get: getClient } = require('../lib/client');
 const { requiresAuth } = require('./requiresAuth');
+const attemptSilentLogin = require('./attemptSilentLogin');
 const TransientCookieHandler = require('../lib/transientHandler');
 const { RequestContext, ResponseContext } = require('../lib/context');
 const appSession = require('../lib/appSession');
@@ -147,6 +148,10 @@ module.exports = function (params) {
       'authentication is not required for any of the routes this middleware is applied to ' +
         'see and apply `requiresAuth` middlewares to your protected resources'
     );
+  }
+  if (config.attemptSilentLogin) {
+    debug.trace("silent login will be attempted on user's initial request");
+    router.use(attemptSilentLogin());
   }
 
   return router;

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -117,6 +117,8 @@ module.exports = function (params) {
             expires_at: tokenSet.expires_at,
           });
 
+          attemptSilentLogin.resumeSilentLogin(req, res);
+
           next();
         } catch (err) {
           next(err);
@@ -147,7 +149,7 @@ module.exports = function (params) {
     );
   }
   if (config.attemptSilentLogin) {
-    debug.trace("silent login will be attempted on user's initial request");
+    debug("silent login will be attempted on end-user's initial HTML request");
     router.use(attemptSilentLogin());
   }
 

--- a/middleware/requiresAuth.js
+++ b/middleware/requiresAuth.js
@@ -17,7 +17,7 @@ async function requiresLoginMiddleware(requiresLoginCheck, req, res, next) {
   }
 
   if (requiresLoginCheck(req)) {
-    if (!res.oidc.errorOnRequiredAuth) {
+    if (!res.oidc.errorOnRequiredAuth && req.accepts('html')) {
       debug.trace(
         'Authentication requirements not met with errorOnRequiredAuth() returning false, calling res.oidc.login()'
       );

--- a/test/attemptSilentLogin.tests.js
+++ b/test/attemptSilentLogin.tests.js
@@ -51,7 +51,7 @@ describe('attemptSilentLogin', () => {
 
     assert.equal(response.statusCode, 302);
     assert.include(jar.getCookies(baseUrl)[0], {
-      key: 'silentLoginAttempted',
+      key: 'skipSilentLogin',
       value: 'true',
       httpOnly: true,
     });

--- a/test/attemptSilentLogin.tests.js
+++ b/test/attemptSilentLogin.tests.js
@@ -1,0 +1,158 @@
+const { assert } = require('chai');
+const { create: createServer } = require('./fixture/server');
+const { makeIdToken } = require('./fixture/cert');
+const { auth, attemptSilentLogin } = require('./..');
+const request = require('request-promise-native').defaults({
+  simple: false,
+  resolveWithFullResponse: true,
+  followRedirect: false,
+});
+
+const baseUrl = 'http://localhost:3000';
+
+const defaultConfig = {
+  secret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  baseURL: 'https://example.org',
+  issuerBaseURL: 'https://op.example.com',
+};
+
+const login = async (claims) => {
+  const jar = request.jar();
+  await request.post('/session', {
+    baseUrl,
+    jar,
+    json: {
+      id_token: makeIdToken(claims),
+    },
+  });
+  return jar;
+};
+
+describe('attemptSilentLogin', () => {
+  let server;
+
+  afterEach(async () => {
+    if (server) {
+      server.close();
+    }
+  });
+
+  it("should attempt silent login on user's first route", async () => {
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        authRequired: false,
+      }),
+      attemptSilentLogin()
+    );
+    const jar = request.jar();
+    const response = await request({ baseUrl, jar, url: '/protected' });
+
+    assert.equal(response.statusCode, 302);
+    assert.include(jar.getCookies(baseUrl)[0], {
+      key: 'silentLoginAttempted',
+      value: 'true',
+      httpOnly: true,
+    });
+  });
+
+  it('should not attempt silent login for non html requests', async () => {
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        authRequired: false,
+      }),
+      attemptSilentLogin()
+    );
+    const jar = request.jar();
+    const response = await request({
+      baseUrl,
+      jar,
+      url: '/protected',
+      json: true,
+    });
+
+    assert.equal(response.statusCode, 200);
+  });
+
+  it("should not attempt silent login on user's subsequent routes", async () => {
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        authRequired: false,
+      }),
+      attemptSilentLogin()
+    );
+    const jar = request.jar();
+    const response = await request({ baseUrl, jar, url: '/protected' });
+    assert.equal(response.statusCode, 302);
+    const response2 = await request({ baseUrl, jar, url: '/protected' });
+    assert.equal(response2.statusCode, 200);
+    const response3 = await request({ baseUrl, jar, url: '/protected' });
+    assert.equal(response3.statusCode, 200);
+  });
+
+  it('should not attempt silent login for authenticated user', async () => {
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        authRequired: false,
+      }),
+      attemptSilentLogin()
+    );
+    const jar = await login();
+    const response = await request({ baseUrl, jar, url: '/protected' });
+    assert.equal(response.statusCode, 200);
+  });
+
+  it('should not attempt silent login after first anonymous request after logout', async () => {
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        authRequired: false,
+      }),
+      attemptSilentLogin()
+    );
+    const jar = await login();
+    await request({ baseUrl, jar, url: '/protected' });
+    await request.get({
+      uri: '/logout',
+      baseUrl,
+      jar,
+      followRedirect: false,
+    });
+    const response = await request({ baseUrl, jar, url: '/protected' });
+    assert.equal(response.statusCode, 200);
+  });
+
+  it('should not attempt silent login after first request is to logout', async () => {
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        authRequired: false,
+      }),
+      attemptSilentLogin()
+    );
+    const jar = await login();
+    await request.get({
+      uri: '/logout',
+      baseUrl,
+      jar,
+      followRedirect: false,
+    });
+    const response = await request({ baseUrl, jar, url: '/protected' });
+    assert.equal(response.statusCode, 200);
+  });
+
+  it("should throw when there's no auth middleware", async () => {
+    server = await createServer(attemptSilentLogin());
+    const {
+      body: { err },
+    } = await request({ baseUrl, url: '/protected', json: true });
+    assert.equal(
+      err.message,
+      'req.oidc is not found, did you include the auth middleware?'
+    );
+  });
+});

--- a/test/login.tests.js
+++ b/test/login.tests.js
@@ -110,6 +110,21 @@ describe('auth', () => {
     assert.equal(res.statusCode, 302);
   });
 
+  it('should redirect to the authorize url for any route if attemptSilentLogin', async () => {
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        authRequired: false,
+        attemptSilentLogin: true,
+      })
+    );
+    const res = await request.get('/session', {
+      baseUrl,
+      followRedirect: false,
+    });
+    assert.equal(res.statusCode, 302);
+  });
+
   it('should redirect to the authorize url for /login in code flow', async () => {
     server = await createServer(
       auth({

--- a/test/requiresAuth.tests.js
+++ b/test/requiresAuth.tests.js
@@ -77,6 +77,18 @@ describe('requiresAuth', () => {
     assert.equal(parsed.returnTo, '/protected');
   });
 
+  it("should 401 for anonymous users who don't accept html", async () => {
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        authRequired: false,
+      }),
+      requiresAuth()
+    );
+    const response = await request({ baseUrl, url: '/protected', json: true });
+    assert.equal(response.statusCode, 401);
+  });
+
   it('should return 401 when anonymous user visits a protected route', async () => {
     server = await createServer(
       auth({
@@ -327,7 +339,7 @@ describe('requiresAuth', () => {
     assert.equal(response.statusCode, 200);
   });
 
-  it('should not allow anonymouse users to check custom claims', async () => {
+  it('should not allow anonymous users to check custom claims', async () => {
     const checkSpy = sinon.spy();
     server = await createServer(
       auth({


### PR DESCRIPTION
### Description

Add `attemptSilentLogin` MW and `attemptSilentLogin` config option to attempt login with `prompt=none` the first time a user visits a route.

### References

https://auth0.com/docs/api-auth/tutorials/silent-authentication

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
