### PR TITLE
[SDK-1879] postLogoutRedirect and response_type check

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -175,7 +175,7 @@ interface LoginOptions {
  */
 interface LogoutOptions {
   /**
-   *  URL to returnTo after logout, overrides the Default in {@link ConfigParams.routes.postLogoutRedirectUri routes.postLogoutRedirectUri}
+   *  URL to returnTo after logout, overrides the Default in {@link ConfigParams.routes.postLogoutRedirect routes.postLogoutRedirect}
    */
   returnTo?: string;
 }
@@ -376,7 +376,7 @@ interface ConfigParams {
      * This value must be registered on the authorization server.
      * The user will be redirected to this after a logout has been performed.
      */
-    postLogoutRedirectUri?: string;
+    postLogoutRedirect?: string;
 
     /**
      * Relative path to the application callback to process the response from the authorization server.
@@ -452,8 +452,6 @@ interface SessionConfigParams {
    * Defaults to "Lax" but will be adjusted based on {@link AuthorizationParameters.response_type}.
    */
   sameSite?: string;
-
-  // TODO do we need a path option?
 }
 
 /**

--- a/lib/config.js
+++ b/lib/config.js
@@ -139,9 +139,7 @@ const paramsSchema = Joi.object({
       Joi.boolean().valid(false),
     ]).default('/logout'),
     callback: Joi.string().uri({ relativeOnly: true }).default('/callback'),
-    postLogoutRedirectUri: Joi.string()
-      .uri({ allowRelative: true })
-      .default(''), //_ TODO: find a better name
+    postLogoutRedirect: Joi.string().uri({ allowRelative: true }).default(''),
   })
     .default()
     .unknown(false),

--- a/lib/context.js
+++ b/lib/context.js
@@ -202,7 +202,11 @@ class ResponseContext {
           : undefined),
       };
 
-      // TODO: validate response_type / response_mode?
+      const validResponseTypes = ['id_token', 'code id_token', 'code'];
+      assert(
+        validResponseTypes.includes(authParams.response_type),
+        `response_type should be one of ${validResponseTypes.join(', ')}`
+      );
       assert(
         /\bopenid\b/.test(authParams.scope),
         'scope should contain "openid"'
@@ -230,7 +234,7 @@ class ResponseContext {
     next = cb(next).once();
     const client = await getClient(config);
 
-    let returnURL = params.returnTo || config.routes.postLogoutRedirectUri;
+    let returnURL = params.returnTo || config.routes.postLogoutRedirect;
     debug('req.oidc.logout() with return url: %s', returnURL);
 
     if (url.parse(returnURL).host === null) {

--- a/test/login.tests.js
+++ b/test/login.tests.js
@@ -289,6 +289,31 @@ describe('auth', () => {
     assert.equal(res.body.err.message, 'scope should contain "openid"');
   });
 
+  it('should not allow an invalid response_type', async function () {
+    const router = auth({ ...defaultConfig, routes: { login: false } });
+    router.get('/login', (req, res) => {
+      res.oidc.login({
+        authorizationParams: {
+          response_type: 'invalid',
+        },
+      });
+    });
+    server = await createServer(router);
+
+    const cookieJar = request.jar();
+    const res = await request.get('/login', {
+      cookieJar,
+      baseUrl,
+      json: true,
+      followRedirect: false,
+    });
+    assert.equal(res.statusCode, 500);
+    assert.equal(
+      res.body.err.message,
+      'response_type should be one of id_token, code id_token, code'
+    );
+  });
+
   it('should use a custom state builder', async () => {
     server = await createServer(
       auth({

--- a/test/logout.tests.js
+++ b/test/logout.tests.js
@@ -124,12 +124,12 @@ describe('logout route', async () => {
     );
   });
 
-  it('should redirect to postLogoutRedirectUri', async () => {
+  it('should redirect to postLogoutRedirect', async () => {
     server = await createServer(
       auth({
         ...defaultConfig,
         routes: {
-          postLogoutRedirectUri: '/after-logout-in-auth-config',
+          postLogoutRedirect: '/after-logout-in-auth-config',
         },
       })
     );
@@ -143,7 +143,7 @@ describe('logout route', async () => {
       {
         location: 'https://example.org/after-logout-in-auth-config',
       },
-      'should redirect to postLogoutRedirectUri'
+      'should redirect to postLogoutRedirect'
     );
   });
 
@@ -152,7 +152,7 @@ describe('logout route', async () => {
       ...defaultConfig,
       routes: {
         logout: false,
-        postLogoutRedirectUri: '/after-logout-in-auth-config',
+        postLogoutRedirect: '/after-logout-in-auth-config',
       },
     });
     server = await createServer(router);


### PR DESCRIPTION
### Description

- rename `postLogoutRedirectUri` - can be a path, so shouldn't have `Uri`
- assert that response_type is one of `['id_token', 'code id_token', 'code']` incase it's changed in a custom `login`

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
