### PR TITLE
[SDK-1877] Add refresh method to access token

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,10 @@
 // Type definitions for express-openid-connect
 
-import { AuthorizationParameters, IdTokenClaims } from 'openid-client';
+import {
+  AuthorizationParameters,
+  IdTokenClaims,
+  RefreshExtras,
+} from 'openid-client';
 import { Request, Response, RequestHandler } from 'express';
 
 /**
@@ -71,27 +75,7 @@ interface RequestContext {
    *
    * See: https://auth0.com/docs/protocols/oidc#access-tokens
    */
-  accessToken?: {
-    /**
-     * The access token itself, can be an opaque string, JWT, or non-JWT token.
-     */
-    access_token: string;
-
-    /**
-     * The type of access token, Usually "Bearer".
-     */
-    token_type: string;
-
-    /**
-     * Number of seconds until the access token expires.
-     */
-    expires_in: number;
-
-    /**
-     * Returns `true` if the access_token has expired.
-     */
-    isExpired: () => boolean;
-  };
+  accessToken?: AccessToken;
 
   /**
    * Credentials that can be used to refresh an access token.
@@ -452,6 +436,34 @@ interface SessionConfigParams {
    * Defaults to "Lax" but will be adjusted based on {@link AuthorizationParameters.response_type}.
    */
   sameSite?: string;
+}
+
+interface AccessToken {
+  /**
+   * The access token itself, can be an opaque string, JWT, or non-JWT token.
+   */
+  access_token: string;
+
+  /**
+   * The type of access token, Usually "Bearer".
+   */
+  token_type: string;
+
+  /**
+   * Number of seconds until the access token expires.
+   */
+  expires_in: number;
+
+  /**
+   * Returns `true` if the access_token has expired.
+   */
+  isExpired: () => boolean;
+
+  /**
+   * Performs refresh_token grant type exchange and updates the session's access token.
+   * @param opts Add extra parameters to the Token Endpoint Request and/or Client Authentication JWT Assertion
+   */
+  refresh(opts?: RefreshExtras): Promise<AccessToken>;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -483,6 +483,14 @@ interface AccessToken {
 
   /**
    * Performs refresh_token grant type exchange and updates the session's access token.
+   *
+   * ```js
+   * let accessToken = req.oidc.accessToken;
+   * if (accessToken.isExpired()) {
+   *   accessToken = await accessToken.refresh();
+   * }
+   * ```
+   *
    * @param opts Add extra parameters to the Token Endpoint Request and/or Client Authentication JWT Assertion
    */
   refresh(opts?: RefreshExtras): Promise<AccessToken>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,6 @@
 import {
   AuthorizationParameters,
   IdTokenClaims,
-  RefreshExtras,
   UserinfoResponse,
 } from 'openid-client';
 import { Request, Response, RequestHandler } from 'express';
@@ -108,14 +107,8 @@ interface RequestContext {
    * })
    * ```
    *
-   * @param options Options for the UserInfo request.
    */
-  fetchUserInfo(options?: {
-    verb?: 'GET' | 'POST';
-    via?: 'header' | 'body' | 'query';
-    tokenType?: string;
-    params?: object;
-  }): Promise<UserinfoResponse>;
+  fetchUserInfo(): Promise<UserinfoResponse>;
 }
 
 /**
@@ -490,10 +483,8 @@ interface AccessToken {
    *   accessToken = await accessToken.refresh();
    * }
    * ```
-   *
-   * @param opts Add extra parameters to the Token Endpoint Request and/or Client Authentication JWT Assertion
    */
-  refresh(opts?: RefreshExtras): Promise<AccessToken>;
+  refresh(): Promise<AccessToken>;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import {
   AuthorizationParameters,
   IdTokenClaims,
   RefreshExtras,
+  UserinfoResponse,
 } from 'openid-client';
 import { Request, Response, RequestHandler } from 'express';
 
@@ -94,6 +95,27 @@ interface RequestContext {
    * specified in {@link ConfigParams.identityClaimFilter identityClaimFilter} removed.
    */
   user?: object;
+
+  /**
+   * Fetches the OIDC userinfo response.
+   *
+   * ```js
+   * app.use(auth());
+   *
+   * app.get('/user-info', async (req, res) => {
+   *   const userInfo = await req.oidc.fetchUserInfo();
+   *   res.json(userInfo);
+   * })
+   * ```
+   *
+   * @param options Options for the UserInfo request.
+   */
+  fetchUserInfo(options?: {
+    verb?: 'GET' | 'POST';
+    via?: 'header' | 'body' | 'query';
+    tokenType?: string;
+    params?: object;
+  }): Promise<UserinfoResponse>;
 }
 
 /**

--- a/lib/context.js
+++ b/lib/context.js
@@ -127,6 +127,13 @@ class RequestContext {
       return undefined;
     }
   }
+
+  async fetchUserInfo(opts) {
+    const { config } = weakRef(this);
+
+    const client = await getClient(config);
+    return client.userinfo(tokenSet.call(this), opts);
+  }
 }
 
 class ResponseContext {

--- a/lib/context.js
+++ b/lib/context.js
@@ -15,11 +15,15 @@ function isExpired() {
   return tokenSet.call(this).expired();
 }
 
-async function refresh(opts) {
+async function refresh() {
   let { config, req } = weakRef(this);
   const client = await getClient(config);
   const oldTokenSet = tokenSet.call(this);
-  const newTokenSet = await client.refresh(oldTokenSet, opts);
+  const newTokenSet = await client.refresh(oldTokenSet);
+  // If no new refresh token assume the current refresh token is valid.
+  if (!newTokenSet.refresh_token) {
+    newTokenSet.refresh_token = oldTokenSet.refresh_token;
+  }
 
   // Update the session's tokenSet
   const session = req[config.session.name];
@@ -128,11 +132,11 @@ class RequestContext {
     }
   }
 
-  async fetchUserInfo(opts) {
+  async fetchUserInfo() {
     const { config } = weakRef(this);
 
     const client = await getClient(config);
-    return client.userinfo(tokenSet.call(this), opts);
+    return client.userinfo(tokenSet.call(this));
   }
 }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -15,6 +15,20 @@ function isExpired() {
   return tokenSet.call(this).expired();
 }
 
+async function refresh(opts) {
+  let { config, req } = weakRef(this);
+  const client = await getClient(config);
+  const oldTokenSet = tokenSet.call(this);
+  const newTokenSet = await client.refresh(oldTokenSet, opts);
+
+  // Update the session's tokenSet
+  const session = req[config.session.name];
+  const cachedTokenSet = weakRef(session);
+  cachedTokenSet.value = newTokenSet;
+
+  return this.accessToken;
+}
+
 function tokenSet() {
   const contextCache = weakRef(this);
   const session = contextCache.req[contextCache.config.session.name];
@@ -83,6 +97,7 @@ class RequestContext {
         token_type,
         expires_in,
         isExpired: isExpired.bind(this),
+        refresh: refresh.bind(this),
       };
     } catch (err) {
       return undefined;


### PR DESCRIPTION
### Description

You should be able to use the `openid-client` to refresh an access token.

```js
let accessToken = req.oidc.accessToken;
if (accessToken.isExpired()) {
  accessToken = await accessToken.refresh();
}
```

Also, add `fetchUserInfo` for completeness

```js
const userInfo = await req.oidc.fetchUserInfo();
```

### References

https://github.com/panva/node-openid-client/blob/master/docs/README.md#clientrefreshrefreshtoken-extras
https://github.com/panva/node-openid-client/blob/master/docs/README.md#clientuserinfoaccesstoken-options

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
