### PR TITLE
[SDK-1878] Express SDK beta should login/logout scoped to a subpath

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -426,6 +426,12 @@ interface SessionConfigParams {
   domain?: string;
 
   /**
+   * Path for the cookie.
+   * Passed to the [Response cookie](https://expressjs.com/en/api.html#res.cookie) as `path`
+   */
+  path?: string;
+
+  /**
    * Set to true to use a transient cookie (cookie without an explicit expiration).
    * Default is `false`
    */

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -102,7 +102,10 @@ module.exports = (config) => {
       );
       for (const cookieName of Object.keys(req[COOKIES])) {
         if (cookieName.match(`^${sessionName}(?:\\.\\d)?$`)) {
-          res.clearCookie(cookieName, { domain: cookieOptions.domain });
+          res.clearCookie(cookieName, {
+            domain: cookieOptions.domain,
+            path: cookieOptions.path,
+          });
         }
       }
     } else {

--- a/lib/config.js
+++ b/lib/config.js
@@ -46,6 +46,7 @@ const paramsSchema = Joi.object({
         .optional()
         .default('Lax'),
       secure: Joi.boolean().optional(),
+      path: Joi.string().uri({ relativeOnly: true }).optional(),
     })
       .default()
       .unknown(false),

--- a/lib/transientHandler.js
+++ b/lib/transientHandler.js
@@ -67,8 +67,7 @@ class TransientCookieHandler {
     }
     this.currentKey = current;
     this.keyStore = keystore;
-    this.secureCookieConfig =
-      session && session.cookie && session.cookie.secure;
+    this.sessionCookieConfig = (session && session.cookie) || {};
     this.legacySameSiteCookie = legacySameSiteCookie;
   }
 
@@ -92,12 +91,12 @@ class TransientCookieHandler {
     { sameSite = 'None', value = this.generateNonce() } = {}
   ) {
     const isSameSiteNone = sameSite === 'None';
+    const { domain, path, secure } = this.sessionCookieConfig;
     const basicAttr = {
       httpOnly: true,
-      secure:
-        typeof this.secureCookieConfig === 'boolean'
-          ? this.secureCookieConfig
-          : req.secure,
+      secure: typeof secure === 'boolean' ? secure : req.secure,
+      domain,
+      path,
     };
 
     {
@@ -191,7 +190,11 @@ class TransientCookieHandler {
    * @param {Object} res Express Response object
    */
   deleteCookie(name, res) {
-    res.clearCookie(name);
+    const { domain, path } = this.sessionCookieConfig;
+    res.clearCookie(name, {
+      domain,
+      path,
+    });
   }
 }
 

--- a/middleware/attemptSilentLogin.js
+++ b/middleware/attemptSilentLogin.js
@@ -7,30 +7,31 @@ const COOKIE_NAME = 'skipSilentLogin';
 const cancelSilentLogin = (req, res) => {
   const {
     config: {
-      session: { cookie: cookieConfig },
+      session: {
+        cookie: { secure, domain, path },
+      },
     },
   } = weakRef(req.oidc);
   res.cookie(COOKIE_NAME, true, {
     httpOnly: true,
-    secure:
-      typeof cookieConfig.secure === 'boolean'
-        ? cookieConfig.secure
-        : req.secure,
+    secure: typeof secure === 'boolean' ? secure : req.secure,
+    domain,
+    path,
   });
 };
 
 const resumeSilentLogin = (req, res) => {
   const {
     config: {
-      session: { cookie: cookieConfig },
+      session: {
+        cookie: { domain, path },
+      },
     },
   } = weakRef(req.oidc);
   res.clearCookie(COOKIE_NAME, {
     httpOnly: true,
-    secure:
-      typeof cookieConfig.secure === 'boolean'
-        ? cookieConfig.secure
-        : req.secure,
+    domain,
+    path,
   });
 };
 


### PR DESCRIPTION
### Description

Scope all cookies (skipSilentLogin, transient and appSession) to the app session cookie path and domain config (if specified)

Doing the transient cookies was probably overkill, but it should prevent concurrency issues if a user were to login to 2 sites under different paths on the same domain at the same time 🤷 

### Testing

Tested using:

```js
const express = require('express');
const { auth } = require('./');
const app = express();
app.use(
  '/foo',
  auth({
    attemptSilentLogin: true,
    baseURL: 'http://localhost:3000/foo',
    session: {
      cookie: {
        path: '/foo',
      },
    },
  })
);
app.get('/foo', (req, res) => {
  res.send(`hi ${req.oidc.user.name}`);
});
app.listen(3000, () => {});
```

- [x] Added test coverage for app session cookie - existing coverage handles the default (no path/domain case)

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
