### PR TITLE
Make the test clearer that discovery alg is ignored

### DIFF
--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -90,7 +90,7 @@ describe('client initialization', function () {
         .reply(
           200,
           Object.assign({}, wellKnown, {
-            id_token_signing_alg_values_supported: ['none', 'RS256'],
+            id_token_signing_alg_values_supported: ['none'],
           })
         );
 

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -370,6 +370,18 @@ describe('get config', () => {
     );
   });
 
+  it('should not allow "none" for idTokenSigningAlg', () => {
+    const config = {
+      ...defaultConfig,
+      idTokenSigningAlg: 'none',
+    };
+    assert.throws(
+      () => getConfig(config),
+      TypeError,
+      '"idTokenSigningAlg" contains an invalid value'
+    );
+  });
+
   it('should require clientSecret for ID tokens with HMAC based algorithms', () => {
     const config = {
       ...defaultConfig,


### PR DESCRIPTION
### Description

Update test to make it clearer that if the discovery doc is compromised the `idTokenSigningAlg` can not be overridden from the client configuration options.

And add a test to show "none" is not allowed for `idTokenSigningAlg` config