### PR TITLE
d.ts: fix routes.logout

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -368,7 +368,7 @@ interface ConfigParams {
     /**
      * Relative path to application logout.
      */
-    logoutPath?: string | false;
+    logout?: string | false;
 
     /**
      * Either a relative path to the application or a valid URI to an external domain.


### PR DESCRIPTION
The new config name is `logout` not `logoutPath`