### PR TITLE
WIP: Add initial implementation of websocket authentication

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ import {
   UserinfoResponse,
 } from 'openid-client';
 import { Request, Response, RequestHandler } from 'express';
+import { IncomingMessage } from 'http';
 
 /**
  * The Express.js Request with `oidc` context added by the `auth` middleware.
@@ -522,7 +523,30 @@ interface AccessToken {
  *  app.listen(3000, () => console.log('listening at http://localhost:3000'))
  * ```
  */
-export function auth(params?: ConfigParams): RequestHandler;
+export function auth(params?: ConfigParamsWithoutWebSocket): RequestHandler;
+export function auth(params: ConfigParamWithWebSocket): Authenticators;
+
+interface ConfigParamsWithoutWebSocket extends ConfigParams {
+  webSocket?: false;
+}
+
+interface ConfigParamWithWebSocket extends ConfigParams {
+  webSocket: true;
+}
+
+type WebSocketAuthenticatorCallback = (
+  err: unknown,
+  oidc: RequestContext
+) => void;
+type WebSocketAuthenticator = (
+  req: IncomingMessage,
+  next: WebSocketAuthenticatorCallback
+) => void;
+
+interface Authenticators {
+  expressAuthRouter: RequestHandler;
+  webSocketAuthenticate: WebsocketAuthenticator;
+}
 
 /**
  * Set {@link ConfigParams.authRequired authRequired} to `false` then require authentication

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -140,7 +140,93 @@ module.exports = (config) => {
     }
   }
 
-  return (req, res, next) => {
+  function readExistingSessionCiphertext(cookies) {
+    if (cookies.hasOwnProperty(sessionName)) {
+      // get JWE from unchunked session cookie
+      debug('reading session from %s cookie', sessionName);
+      return cookies[sessionName];
+    } else if (cookies.hasOwnProperty(`${sessionName}.0`)) {
+      // get JWE from chunked session cookie
+      // iterate all cookie names
+      // match and filter for the ones that match sessionName.<number>
+      // sort by chunk index
+      // concat
+      return Object.entries(cookies)
+        .map(([cookie, value]) => {
+          const match = cookie.match(`^${sessionName}\\.(\\d+)$`);
+          if (match) {
+            return [match[1], value];
+          }
+        })
+        .filter(Boolean)
+        .sort(([a], [b]) => {
+          return parseInt(a, 10) - parseInt(b, 10);
+        })
+        .map(([i, chunk]) => {
+          debug('reading session chunk from %s.%d cookie', sessionName, i);
+          return chunk;
+        })
+        .join('');
+    }
+  }
+
+  function assertHeaderNotExpired(iat, uat, exp) {
+    // check that the existing session isn't expired based on options when it was established
+    assert(
+      exp > epoch(),
+      'it is expired based on options when it was established'
+    );
+
+    // check that the existing session isn't expired based on current rollingDuration rules
+    if (rollingDuration) {
+      assert(
+        uat + rollingDuration > epoch(),
+        'it is expired based on current rollingDuration rules'
+      );
+    }
+
+    // check that the existing session isn't expired based on current absoluteDuration rules
+    if (absoluteDuration) {
+      assert(
+        iat + absoluteDuration > epoch(),
+        'it is expired based on current absoluteDuration rules'
+      );
+    }
+  }
+
+  function tryReadingExistingSession(cookies) {
+    const existingSessionValue = readExistingSessionCiphertext(cookies);
+    let iat;
+    let uat;
+    let exp;
+
+    try {
+      if (existingSessionValue) {
+        const { protected: header, cleartext } = decrypt(existingSessionValue);
+        ({ iat, uat, exp } = header);
+        assertHeaderNotExpired(iat, uat, exp);
+        return { iat, existingSession: JSON.parse(cleartext) };
+      } else {
+        return { iat };
+      }
+    } catch (err) {
+      if (err instanceof AssertionError) {
+        debug('existing session was rejected because', err.message);
+        return { iat, err };
+      } else if (err instanceof JOSEError) {
+        debug(
+          'existing session was rejected because it could not be decrypted',
+          err
+        );
+        return { iat, err };
+      } else {
+        debug('unexpected error handling session', err);
+        return { iat, err };
+      }
+    }
+  }
+
+  function expectNoSessionYet(req, next) {
     if (req.hasOwnProperty(sessionName)) {
       debug(
         'request object (req) already has %o property, this is indicative of a middleware setup problem',
@@ -152,89 +238,29 @@ module.exports = (config) => {
         )
       );
     }
+  }
+
+  function appSessionMiddleware(req, res, next) {
+    expectNoSessionYet(req, next);
 
     req[COOKIES] = cookie.parse(req.get('cookie') || '');
 
-    let iat;
-    let uat;
-    let exp;
-    let existingSessionValue;
-
-    try {
-      if (req[COOKIES].hasOwnProperty(sessionName)) {
-        // get JWE from unchunked session cookie
-        debug('reading session from %s cookie', sessionName);
-        existingSessionValue = req[COOKIES][sessionName];
-      } else if (req[COOKIES].hasOwnProperty(`${sessionName}.0`)) {
-        // get JWE from chunked session cookie
-        // iterate all cookie names
-        // match and filter for the ones that match sessionName.<number>
-        // sort by chunk index
-        // concat
-        existingSessionValue = Object.entries(req[COOKIES])
-          .map(([cookie, value]) => {
-            const match = cookie.match(`^${sessionName}\\.(\\d+)$`);
-            if (match) {
-              return [match[1], value];
-            }
-          })
-          .filter(Boolean)
-          .sort(([a], [b]) => {
-            return parseInt(a, 10) - parseInt(b, 10);
-          })
-          .map(([i, chunk]) => {
-            debug('reading session chunk from %s.%d cookie', sessionName, i);
-            return chunk;
-          })
-          .join('');
-      }
-      if (existingSessionValue) {
-        const { protected: header, cleartext } = decrypt(existingSessionValue);
-        ({ iat, uat, exp } = header);
-
-        // check that the existing session isn't expired based on options when it was established
-        assert(
-          exp > epoch(),
-          'it is expired based on options when it was established'
-        );
-
-        // check that the existing session isn't expired based on current rollingDuration rules
-        if (rollingDuration) {
-          assert(
-            uat + rollingDuration > epoch(),
-            'it is expired based on current rollingDuration rules'
-          );
-        }
-
-        // check that the existing session isn't expired based on current absoluteDuration rules
-        if (absoluteDuration) {
-          assert(
-            iat + absoluteDuration > epoch(),
-            'it is expired based on current absoluteDuration rules'
-          );
-        }
-
-        attachSessionObject(req, sessionName, JSON.parse(cleartext));
-      }
-    } catch (err) {
-      if (err instanceof AssertionError) {
-        debug('existing session was rejected because', err.message);
-      } else if (err instanceof JOSEError) {
-        debug(
-          'existing session was rejected because it could not be decrypted',
-          err
-        );
-      } else {
-        debug('unexpected error handling session', err);
-      }
-    }
-
-    if (!req.hasOwnProperty(sessionName) || !req[sessionName]) {
-      attachSessionObject(req, sessionName, {});
-    }
-
+    const { iat, existingSession } = tryReadingExistingSession(req[COOKIES]);
+    attachSessionObject(req, sessionName, existingSession || {});
     onHeaders(res, setCookie.bind(undefined, req, res, { iat }));
 
     return next();
-  };
+  }
+
+  function attachSessionToHttpRequestIfExists(req, errorCallback) {
+    expectNoSessionYet(req, errorCallback);
+    const cookies = cookie.parse(req.headers['cookie'] || '');
+    const { existingSession } = tryReadingExistingSession(cookies);
+    if (existingSession) {
+      attachSessionObject(req, sessionName, existingSession);
+      return existingSession;
+    }
+  }
+
+  return { appSessionMiddleware, attachSessionToHttpRequestIfExists };
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -148,6 +148,7 @@ const paramsSchema = Joi.object({
   })
     .default()
     .unknown(false),
+  webSocket: Joi.boolean().optional().default(false),
 });
 
 module.exports.get = function (params) {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,9 @@
     "request-promise-native": "^1.0.8",
     "sinon": "^7.5.0",
     "typedoc": "^0.17.8",
-    "typescript": "^3.9.6"
+    "typescript": "^3.9.6",
+    "websocket-as-promised": "^1.1.0",
+    "ws": "^7.3.1"
   },
   "peerDependencies": {
     "express": ">= 4.17.0"

--- a/test/appSession.tests.js
+++ b/test/appSession.tests.js
@@ -6,11 +6,13 @@ const request = require('request-promise-native').defaults({
 });
 const sinon = require('sinon');
 
-const appSession = require('../lib/appSession');
+const appSessionOriginal = require('../lib/appSession');
 const { encrypted } = require('./fixture/sessionEncryption');
 const { makeIdToken } = require('./fixture/cert');
 const { get: getConfig } = require('../lib/config');
 const { create: createServer } = require('./fixture/server');
+
+const appSession = (config) => appSessionOriginal(config).appSessionMiddleware;
 
 const defaultConfig = {
   clientID: '__test_client_id__',

--- a/test/websockets.tests.js
+++ b/test/websockets.tests.js
@@ -1,0 +1,160 @@
+const { assert } = require('chai');
+const sinon = require('sinon');
+const { create: createServer } = require('./fixture/server');
+const { makeIdToken } = require('./fixture/cert');
+const WebSocket = require('ws');
+const WebSocketAsPromised = require('websocket-as-promised');
+const { auth, requiresAuth } = require('..');
+const request = require('request-promise-native').defaults({
+  simple: false,
+  resolveWithFullResponse: true,
+  followRedirect: false,
+});
+
+const baseUrl = 'http://localhost:3000';
+const wsUrl = 'ws://localhost:3000';
+const HR_MS = 60 * 60 * 1000;
+
+const defaultConfig = {
+  secret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  baseURL: 'https://example.org',
+  issuerBaseURL: 'https://op.example.com',
+};
+
+const createWebSocketClient = (options) =>
+  new WebSocketAsPromised(wsUrl, {
+    createWebSocket: (url) => new WebSocket(url, options),
+    packMessage: (msg) => JSON.stringify(msg),
+    unpackMessage: (msg) => JSON.parse(msg),
+    attachRequestId: (data, id) => ({ id, data }),
+    extractRequestId: (data) => data && data.id,
+    extractMessageData: (data) => data,
+  });
+
+const createWebSocketClientWithJar = (jar) =>
+  createWebSocketClient({ headers: { Cookie: jar.getCookieString(baseUrl) } });
+
+const createWebSocketServer = (server, webSocketAuthenticate) => {
+  const wss = new WebSocket.Server({ noServer: true });
+  server.on('upgrade', (req, socket, head) => {
+    webSocketAuthenticate(req, (err, oidc) => {
+      if (err || !oidc) {
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+        socket.destroy();
+      } else {
+        wss.handleUpgrade(req, socket, head, (ws) => {
+          wss.emit('connection', ws, request, oidc);
+        });
+      }
+    });
+  });
+
+  wss.on('connection', (ws, req, oidc) => {
+    ws.on('message', async (msg) => {
+      const { id, data } = JSON.parse(msg);
+      if (data == 'profile') {
+        const reply = JSON.stringify({ id, data: oidc.user });
+        ws.send(reply);
+      }
+    });
+  });
+  return wss;
+};
+
+const login = async (claims) => {
+  const jar = request.jar();
+  await request.post('/session', {
+    baseUrl,
+    jar,
+    json: {
+      id_token: makeIdToken(claims),
+    },
+  });
+  return jar;
+};
+
+describe('webSocketAuthenticate', () => {
+  let server;
+  let wss;
+  let ws;
+
+  afterEach(async () => {
+    if (server) {
+      server.close();
+    }
+    if (wss) {
+      wss.close();
+    }
+    if (ws) {
+      ws.close();
+    }
+  });
+
+  it('should allow logged in users to connect', async () => {
+    const { expressAuthRouter, webSocketAuthenticate } = auth({
+      ...defaultConfig,
+      authRequired: false,
+      webSocket: true,
+    });
+    server = await createServer(expressAuthRouter, requiresAuth());
+    wss = createWebSocketServer(server, webSocketAuthenticate);
+
+    const jar = await login();
+    ws = createWebSocketClientWithJar(jar);
+
+    await assert.isFulfilled(ws.open());
+  });
+
+  it('should allow authenticated users to retrieve their profile', async () => {
+    const { expressAuthRouter, webSocketAuthenticate } = auth({
+      ...defaultConfig,
+      authRequired: false,
+      webSocket: true,
+    });
+    server = await createServer(expressAuthRouter, requiresAuth());
+    wss = createWebSocketServer(server, webSocketAuthenticate);
+
+    const jar = await login();
+    ws = createWebSocketClientWithJar(jar);
+
+    await ws.open();
+    const { data: user } = await ws.sendRequest('profile');
+    assert.equal(user.nickname, '__test_nickname__');
+  });
+
+  it('should block unauthenticated users', async () => {
+    const { expressAuthRouter, webSocketAuthenticate } = auth({
+      ...defaultConfig,
+      authRequired: false,
+      webSocket: true,
+    });
+    server = await createServer(expressAuthRouter, requiresAuth());
+    wss = createWebSocketServer(server, webSocketAuthenticate);
+    ws = createWebSocketClient();
+
+    await assert.isRejected(ws.open());
+  });
+
+  it('should block new connections from users with an expired cookie', async () => {
+    const clock = sinon.useFakeTimers({ toFake: ['Date'] });
+    const { expressAuthRouter, webSocketAuthenticate } = auth({
+      ...defaultConfig,
+      authRequired: false,
+      webSocket: true,
+    });
+    server = await createServer(expressAuthRouter, requiresAuth());
+    wss = createWebSocketServer(server, webSocketAuthenticate);
+
+    const jar = await login();
+
+    clock.tick(23 * HR_MS);
+    ws = createWebSocketClientWithJar(jar);
+    await assert.isFulfilled(ws.open());
+    await ws.close();
+    clock.tick(25 * HR_MS);
+    ws = createWebSocketClientWithJar(jar);
+    await assert.isRejected(ws.open());
+    clock.restore();
+  });
+});


### PR DESCRIPTION
***This pull request is a work in progress and is not ready to merge quite yet***

### Description
Adds the ability to authenticate WebSocket upgrade requests using a pre-existing session cookie as requested in #151.

Can be enabled by setting the new `webSocket` config option to true. This calls an overload of `auth` which returns both the express `Router` as well as a function with type `(req: http.IncomingMessage,  next: (err: unknown, oidc: RequestContext) => void;` which can be used as in [this](https://github.com/websockets/ws#client-authentication) code sample to authenticate web socket connections when the HTTP upgrade request is recieved.

### References
Issue #151 
https://github.com/websockets/ws#client-authentication

### Testing
> **TODO**
> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

> Also include details of the environment this PR was developed in (language/platform/browser version).
- This PR was developed and tested on Fedora 32 Linux using yarn 1.22.10 with Node v12.18.3 with Firefox 80.1.

- [x] This change adds test coverage for new/changed/fixed functionality - *minimal at present*

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
