### PR TITLE
Change res.openid to res.oidc

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -119,7 +119,7 @@ interface RequestContext {
  * app.use(auth());
  *
  * app.get('/admin-login', (req, res) => {
- *   res.openid.login({ returnTo: '/admin' })
+ *   res.oidc.login({ returnTo: '/admin' })
  * })
  * ```
  */


### PR DESCRIPTION
New docs still had v1 API reference

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Just a minor typo fix in the API documentation

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
