### PR TITLE
Move transient cookies into one cookie [SDK-1908]

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -195,13 +195,6 @@ class ResponseContext {
       ...options.authorizationParams,
     };
 
-    const transientOpts = {
-      sameSite:
-        options.authorizationParams.response_mode === 'form_post'
-          ? 'None'
-          : 'Lax',
-    };
-
     const stateValue = await config.getLoginState(req, options);
     if (typeof stateValue !== 'object') {
       next(new Error('Custom state value must be an object.'));
@@ -217,41 +210,40 @@ class ResponseContext {
     }
 
     try {
-      const authParams = {
-        ...options.authorizationParams,
-        nonce: transient.store('nonce', req, res, transientOpts),
-        state: transient.store('state', req, res, {
-          ...transientOpts,
-          value: encodeState(stateValue),
-        }),
-        ...(usePKCE
-          ? {
-              code_challenge: transient.calculateCodeChallenge(
-                transient.store('code_verifier', req, res, transientOpts)
-              ),
-              code_challenge_method: 'S256',
-            }
-          : undefined),
-      };
-
       const validResponseTypes = ['id_token', 'code id_token', 'code'];
       assert(
-        validResponseTypes.includes(authParams.response_type),
+        validResponseTypes.includes(options.authorizationParams.response_type),
         `response_type should be one of ${validResponseTypes.join(', ')}`
       );
       assert(
-        /\bopenid\b/.test(authParams.scope),
+        /\bopenid\b/.test(options.authorizationParams.scope),
         'scope should contain "openid"'
       );
 
-      // TODO: hook here
-
-      if (authParams.max_age) {
-        transient.store('max_age', req, res, {
-          ...transientOpts,
-          value: authParams.max_age,
-        });
+      const authVerification = {
+        nonce: transient.generateNonce(),
+        state: encodeState(stateValue),
+        ...(options.authorizationParams.max_age ? {
+          "max_age": options.authorizationParams.max_age
+        } : undefined)
       }
+      const authParams = { ...options.authorizationParams, ...authVerification };
+
+      if (usePKCE) {
+        authVerification.code_verifier = transient.generateNonce();
+
+        authParams.code_challenge_method= 'S256';
+        authParams.code_challenge = transient.calculateCodeChallenge(
+          authVerification.code_verifier
+        );
+      }
+
+      transient.store('auth_verification', req, res, {
+        sameSite: options.authorizationParams.response_mode === 'form_post'
+          ? 'None'
+          : 'Lax',
+        value: JSON.stringify(authVerification)
+      });
 
       const authorizationUrl = client.authorizationUrl(authParams);
       debug('redirecting to %s', authorizationUrl);

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -25,6 +25,10 @@ const defaultConfig = {
 };
 let server;
 
+const generateCookies = (values) => ({
+  auth_verification: JSON.stringify(values),
+});
+
 const setup = async (params) => {
   const authOpts = Object.assign({}, defaultConfig, params.authOpts || {});
   const router = params.router || auth(authOpts);
@@ -37,6 +41,7 @@ const setup = async (params) => {
 
   Object.keys(params.cookies).forEach(function (cookieName) {
     let value;
+
     transient.store(
       cookieName,
       {},
@@ -115,10 +120,10 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: {
+      cookies: generateCookies({
         nonce: '__test_nonce__',
         state: '__test_state__',
-      },
+      }),
       body: true,
     });
     assert.equal(statusCode, 400);
@@ -149,10 +154,10 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: {
+      cookies: generateCookies({
         nonce: '__test_nonce__',
         state: '__valid_state__',
-      },
+      }),
       body: {
         state: '__invalid_state__',
       },
@@ -168,10 +173,10 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: {
+      cookies: generateCookies({
         nonce: '__test_nonce__',
         state: '__test_state__',
-      },
+      }),
       body: {
         state: '__test_state__',
         id_token: '__invalid_token__',
@@ -191,10 +196,10 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: {
+      cookies: generateCookies({
         nonce: '__test_nonce__',
         state: '__test_state__',
-      },
+      }),
       body: {
         state: '__test_state__',
         id_token: jose.JWT.sign({ sub: '__test_sub__' }, 'secret', {
@@ -213,10 +218,10 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: {
+      cookies: generateCookies({
         nonce: '__test_nonce__',
         state: '__test_state__',
-      },
+      }),
       body: {
         state: '__test_state__',
         id_token: makeIdToken({ iss: undefined }),
@@ -233,9 +238,9 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: {
+      cookies: generateCookies({
         state: '__test_state__',
-      },
+      }),
       body: {
         state: '__test_state__',
         id_token: makeIdToken(),
@@ -257,8 +262,7 @@ describe('callback response_mode: form_post', () => {
         legacySameSiteCookie: false,
       },
       cookies: {
-        // Only set the fallback cookie value.
-        _state: '__test_state__',
+        _auth_verification: JSON.stringify({ state: '__test_state__', }),
       },
       body: {
         state: '__test_state__',
@@ -274,10 +278,10 @@ describe('callback response_mode: form_post', () => {
       authOpts: {
         identityClaimFilter: [],
       },
-      cookies: {
-        _state: expectedDefaultState,
-        _nonce: '__test_nonce__',
-      },
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
+      }),
       body: {
         state: expectedDefaultState,
         id_token: makeIdToken(),
@@ -297,10 +301,10 @@ describe('callback response_mode: form_post', () => {
       currentUser,
       tokens,
     } = await setup({
-      cookies: {
-        _state: expectedDefaultState,
-        _nonce: '__test_nonce__',
-      },
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
+      }),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -339,10 +343,10 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: {
-        _state: expectedDefaultState,
-        _nonce: '__test_nonce__',
-      },
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
+      }),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -377,10 +381,10 @@ describe('callback response_mode: form_post', () => {
           response_type: 'code',
         },
       },
-      cookies: {
-        _state: expectedDefaultState,
-        _nonce: '__test_nonce__',
-      },
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
+      }),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -435,10 +439,10 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: {
-        _state: expectedDefaultState,
-        _nonce: '__test_nonce__',
-      },
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
+      }),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -519,10 +523,10 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: {
-        _state: expectedDefaultState,
-        _nonce: '__test_nonce__',
-      },
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
+      }),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -588,10 +592,10 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: {
-        _state: expectedDefaultState,
-        _nonce: '__test_nonce__',
-      },
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
+      }),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -631,10 +635,10 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: {
-        _state: expectedDefaultState,
-        _nonce: '__test_nonce__',
-      },
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
+      }),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -658,11 +662,11 @@ describe('callback response_mode: form_post', () => {
     const jar = request.jar();
     jar.setCookie('skipSilentLogin=true', baseUrl);
     await setup({
-      cookies: {
-        _state: expectedDefaultState,
-        _nonce: '__test_nonce__',
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
         skipSilentLogin: '1',
-      },
+      }),
       body: {
         state: expectedDefaultState,
         id_token: idToken,

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -273,6 +273,26 @@ describe('callback response_mode: form_post', () => {
     assert.equal(err.message, 'checks.state argument is missing');
   });
 
+  it('should use legacy samesite fallback', async () => {
+    const { currentUser } = await setup({
+      authOpts: {
+        identityClaimFilter: [],
+      },
+      cookies: {
+        _auth_verification: JSON.stringify({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+      },
+      body: {
+        state: expectedDefaultState,
+        id_token: makeIdToken(),
+      },
+    });
+
+    assert.exists(currentUser);
+  });
+
   it('should not strip claims when using custom claim filtering', async () => {
     const { currentUser } = await setup({
       authOpts: {

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -741,10 +741,10 @@ describe('callback response_mode: form_post', () => {
             scope: 'openid profile email',
           },
         },
-        cookies: {
-          _state: expectedDefaultState,
-          _nonce: '__test_nonce__',
-        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
         body: {
           state: expectedDefaultState,
           id_token: idToken,
@@ -781,10 +781,10 @@ describe('callback response_mode: form_post', () => {
       const { response: { statusCode } } = await setup({
         router: auth(authOpts),
         authOpts, 
-        cookies: {
-          _state: expectedDefaultState,
-          _nonce: '__test_nonce__',
-        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
         body: {
           state: expectedDefaultState,
           id_token: idToken,


### PR DESCRIPTION
Currently all transient cookies (state, nonce, max_age and code_verifier) are stored individually.  This refactors these values to be stored in a single cookie. 