### PR TITLE
afterCallback Hook [SDK-1728]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -324,6 +324,25 @@ interface ConfigParams {
   getLoginState?: (req: OpenidRequest, options: LoginOptions) => object;
 
   /**
+   * Function for custom callback handling after receiving tokens and before redirecting
+   * This can be used for handling token storage, making userinfo calls, claim validation, etc.
+   *
+   * ```js
+   * app.use(auth({
+   *   ...
+   *   afterCallback(req, res, session, decodedState) {
+   *     ...
+   *     return {
+   *       ...session,
+   *       ...additionalUserClaims
+   *     };
+   *   }
+   * }))
+   * ``
+   */
+  afterCallback?: (req: OpenidRequest, res: OpenidResponse, session: object, decodedState: object) => object;
+
+  /**
    * Array value of claims to remove from the ID token before storing the cookie session.
    * Default is `['aud', 'iss', 'iat', 'exp', 'nbf', 'nonce', 'azp', 'auth_time', 's_hash', 'at_hash', 'c_hash' ]`
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,21 @@ import {
 import { Request, Response, RequestHandler } from 'express';
 
 /**
+ * Session object
+ */
+interface Session {
+  /**
+   * Values stored in an authentication session
+   */
+  id_token: string;
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  expires_at: string;
+  [key: string]: any;
+}
+
+/**
  * The Express.js Request with `oidc` context added by the `auth` middleware.
  *
  * ```js
@@ -330,8 +345,8 @@ interface ConfigParams {
    * ```js
    * app.use(auth({
    *   ...
-   *   afterCallback(req, res, session, decodedState) {
-   *     ...
+   *   afterCallback: async (req, res, session, decodedState) => {
+   *     const additionalUserClaims = await req.oidc.fetchUserInfo();
    *     return {
    *       ...session,
    *       ...additionalUserClaims
@@ -340,7 +355,7 @@ interface ConfigParams {
    * }))
    * ``
    */
-  afterCallback?: (req: OpenidRequest, res: OpenidResponse, session: object, decodedState: object) => object;
+  afterCallback?: (req: OpenidRequest, res: OpenidResponse, session: Session, decodedState: {[key: string]: any}) => Promise<Session> | Session;
 
   /**
    * Array value of claims to remove from the ID token before storing the cookie session.

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,6 @@
 const Joi = require('@hapi/joi');
 const clone = require('clone');
 const { defaultState: getLoginState } = require('./hooks/getLoginState');
-
 const isHttps = /^https:/i;
 
 const paramsSchema = Joi.object({
@@ -135,6 +134,8 @@ const paramsSchema = Joi.object({
   getLoginState: Joi.function()
     .optional()
     .default(() => getLoginState),
+  afterCallback: Joi.function()
+  .optional(),
   identityClaimFilter: Joi.array()
     .optional()
     .default([

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -110,7 +110,7 @@ module.exports = function (params) {
           req.openidState = decodeState(expectedState);
 
           if (config.afterCallback) {
-            session = await config.afterCallback(req, res, session); 
+            session = await config.afterCallback(req, res, session, req.openidState); 
           }
 
           Object.assign(req[config.session.name], session);

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -84,7 +84,8 @@ module.exports = function (params) {
           const redirectUri = res.oidc.getRedirectUri();
 
           let expectedState;
-          let tokenSet;
+          let session;
+
           try {
             const callbackParams = client.callbackParams(req);
             expectedState = transient.getOnce('state', req, res);
@@ -95,7 +96,7 @@ module.exports = function (params) {
             const code_verifier = transient.getOnce('code_verifier', req, res);
             const nonce = transient.getOnce('nonce', req, res);
 
-            tokenSet = await client.callback(redirectUri, callbackParams, {
+            session = await client.callback(redirectUri, callbackParams, {
               max_age,
               code_verifier,
               nonce,
@@ -108,15 +109,11 @@ module.exports = function (params) {
           // TODO:?
           req.openidState = decodeState(expectedState);
 
-          // intentional clone of the properties on tokenSet
-          Object.assign(req[config.session.name], {
-            id_token: tokenSet.id_token,
-            access_token: tokenSet.access_token,
-            refresh_token: tokenSet.refresh_token,
-            token_type: tokenSet.token_type,
-            expires_at: tokenSet.expires_at,
-          });
+          if (config.afterCallback) {
+            session = await config.afterCallback(req, res, session); 
+          }
 
+          Object.assign(req[config.session.name], session);
           attemptSilentLogin.resumeSilentLogin(req, res);
 
           next();


### PR DESCRIPTION
This PR introduces an afterCallback to allow the user to cover the following usecases:

1. Validating additional Claims in the ID token
> Given I configure an organisation in Auth0 org_abc123, when I login with the SDK, then I can verify the org_id claim that it equals org_abs123, and if it is successful I can finish the login, and if it fails I can fail the login with a 401

2. Adding additional profile information from /userinfo
> Given my id_token does not contain all my profile claims, when I login, then I can fetch extra claims from /userinfo, and I can add them to the session