### PR TITLE
refactor: use native node hkdf when available

### DIFF
--- a/lib/hkdf.js
+++ b/lib/hkdf.js
@@ -1,9 +1,9 @@
-const hkdf = require('futoin-hkdf');
+const crypto = require('crypto');
 
 const BYTE_LENGTH = 32;
 const ENCRYPTION_INFO = 'JWE CEK';
 const SIGNING_INFO = 'JWS Cookie Signing';
-const options = { hash: 'SHA-256' };
+const DIGEST = 'sha256';
 
 /**
  *
@@ -13,7 +13,33 @@ const options = { hash: 'SHA-256' };
  * @see https://tools.ietf.org/html/rfc5869
  *
  */
-module.exports.encryption = (secret) =>
-  hkdf(secret, BYTE_LENGTH, { info: ENCRYPTION_INFO, ...options });
-module.exports.signing = (secret) =>
-  hkdf(secret, BYTE_LENGTH, { info: SIGNING_INFO, ...options });
+
+if (crypto.hkdfSync) {
+  // added in v15.0.0
+  module.exports.encryption = (secret) =>
+    Buffer.from(
+      crypto.hkdfSync(
+        DIGEST,
+        secret,
+        Buffer.alloc(0),
+        ENCRYPTION_INFO,
+        BYTE_LENGTH
+      )
+    );
+  module.exports.signing = (secret) =>
+    Buffer.from(
+      crypto.hkdfSync(
+        DIGEST,
+        secret,
+        Buffer.alloc(0),
+        SIGNING_INFO,
+        BYTE_LENGTH
+      )
+    );
+} else {
+  const hkdf = require('futoin-hkdf');
+  module.exports.encryption = (secret) =>
+    hkdf(secret, BYTE_LENGTH, { info: ENCRYPTION_INFO, hash: DIGEST });
+  module.exports.signing = (secret) =>
+    hkdf(secret, BYTE_LENGTH, { info: SIGNING_INFO, hash: DIGEST });
+}


### PR DESCRIPTION
This makes use of the builtin crypto module [`hkdf`](https://nodejs.org/api/crypto.html#crypto_crypto_hkdfsync_digest_key_salt_info_keylen) sync version instead of the `futoin-hkdf` userland module when it is available.