### PR TITLE
missing base64url dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@hapi/joi": "^17.1.1",
+    "base64url": "^3.0.1",
     "cb": "^0.1.0",
     "clone": "^2.1.2",
     "cookie": "^0.4.1",


### PR DESCRIPTION
> base64url is indirectly referenced through openid-client but you require it directly in your own code.

fixes #179 