### PR TITLE
Respect SameSite in Auth Cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@
 [Full Changelog](https://github.com/auth0/express-openid-connect/compare/v2.1.0...v2.2.0)
 
 **Added**
-- afterCallback Hook [#168](https://github.com/auth0/express-openid-connect/pull/168) ([davidpatrick](https://github.com/davidpatrick))
+- afterCallback Hook [#171](https://github.com/auth0/express-openid-connect/pull/171) ([davidpatrick](https://github.com/davidpatrick))
 
 **Changed**
-- Move transient cookies into single cookie [#171](https://github.com/auth0/express-openid-connect/pull/171) ([davidpatrick](https://github.com/davidpatrick))
+- Move transient cookies into single cookie [#168](https://github.com/auth0/express-openid-connect/pull/168) ([davidpatrick](https://github.com/davidpatrick))
 - Use native node hkdf when available (Node >=15) [#177](https://github.com/auth0/express-openid-connect/pull/177) ([panva](https://github.com/panva))
 
 ## [2.1.0](https://github.com/auth0/express-openid-connect/tree/v2.1.0) (2020-12-15)

--- a/lib/context.js
+++ b/lib/context.js
@@ -223,26 +223,32 @@ class ResponseContext {
       const authVerification = {
         nonce: transient.generateNonce(),
         state: encodeState(stateValue),
-        ...(options.authorizationParams.max_age ? {
-          "max_age": options.authorizationParams.max_age
-        } : undefined)
-      }
-      const authParams = { ...options.authorizationParams, ...authVerification };
+        ...(options.authorizationParams.max_age
+          ? {
+              max_age: options.authorizationParams.max_age,
+            }
+          : undefined),
+      };
+      const authParams = {
+        ...options.authorizationParams,
+        ...authVerification,
+      };
 
       if (usePKCE) {
         authVerification.code_verifier = transient.generateNonce();
 
-        authParams.code_challenge_method= 'S256';
+        authParams.code_challenge_method = 'S256';
         authParams.code_challenge = transient.calculateCodeChallenge(
           authVerification.code_verifier
         );
       }
 
       transient.store('auth_verification', req, res, {
-        sameSite: options.authorizationParams.response_mode === 'form_post'
-          ? 'None'
-          : 'Lax',
-        value: JSON.stringify(authVerification)
+        sameSite:
+          options.authorizationParams.response_mode === 'form_post'
+            ? 'None'
+            : config.session.cookie.sameSite,
+        value: JSON.stringify(authVerification),
       });
 
       const authorizationUrl = client.authorizationUrl(authParams);


### PR DESCRIPTION
### Description
This PR addresses issue #187 by dynamically using the `config.session.cookie.sameSite` cookie attribute on the `auth_verification` cookie ONLY when the response mode is not `form_post`.

Prior to this, any response mode other than form_post would set the auth_verification cookie (which contains state, nonce and PKCE values) with the `None` SameSite attribute, and would otherwise default to `Lax`. 

The main use case is for non- `form_post` response type flows, where the RP would like the auth cookie to have a `SameSite` value of `None` or `Strict`, rather than the forced default of `Lax`.

#### Docs on the Setting
The language (see [docs](https://auth0.github.io/express-openid-connect/interfaces/cookieconfigparams.html#samesite)) around the `SameSite` field states:
> Defaults to "Lax" but will be adjusted based on {@link AuthorizationParameters.response_type}.

It seems the docs above **actually meant to mention `response_mode`**, if that's the case, we should address that here as well.

From that language, I belive the intended behavior was that:
1. The `appSession` cookie will always use the configured sameSite value
2. The `auth_verification` cookie will:
   - use `SameSite=None` for `form_post` response types, ignoring config
   - Otherwise respect the configured sameSite attribute

#### Potential Security Concern
Up to this point, devs may be relying on the default of `Lax` for response modes other than `form_post`. **TBD**: What are the security considerations for changing that default behavior, given that:
1. The default for `config.session.cookie.sameSite` is also `Lax`
2. We would only ever use another SameSite value if it was intentionally set in the config, and already be in use for the `appSession` cookie.

### References
- Fixes Issue #187
- [Lib Docs](https://auth0.github.io/express-openid-connect/interfaces/cookieconfigparams.html#samesite) on SameSite Cookie
- [MDN Article](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) on SameSite Cookies Attribute 

### Testing
I added tests to cover what I believe is the expected behavior (see above).
- [X] This change adds test coverage in the `login.tests.js` file (see last two tests)
- - [X] Test that `form_post` response modes ignore config and use `None`
- - [X] Test that other response modes respect configured SameSite attribute

### Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
   - **???**: See above for potential doc change. I'd like someone to review the [SameSite config docs](https://auth0.github.io/express-openid-connect/interfaces/cookieconfigparams.html#samesite) to make sure I'm interpreting it correctly (`response_type` is mentioned, but should it be `response_mode`?).
- [ ] All active GitHub checks for tests, formatting, and security are passing
   - **???**:  All tests are passing and linting looks good, but what about security testing?
- [X] The correct base branch is being used, if not `master`