### PR TITLE
Update index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -343,7 +343,7 @@ interface ConfigParams {
   getLoginState?: (req: OpenidRequest, options: LoginOptions) => object;
 
   /**
-   * Function for custom callback handling after receiving tokens and before redirecting
+   * Function for custom callback handling after receiving and validating the ID Token and before redirecting.
    * This can be used for handling token storage, making userinfo calls, claim validation, etc.
    *
    * ```js


### PR DESCRIPTION
Make it clear in the documentation that the ID Token is validated before the `afterCallback` hook is called

fixes #206