### PR TITLE
Set cookie headers on header write (before res.end)

### DIFF
--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -8,6 +8,7 @@ const {
 const crypto = require('crypto');
 const { promisify } = require('util');
 const cookie = require('cookie');
+const onHeaders = require('on-headers');
 const COOKIES = require('./cookies');
 const { encryption: deriveKey } = require('./hkdf');
 const debug = require('./debug')('appSession');
@@ -146,7 +147,11 @@ module.exports = (config) => {
       };
     }
 
-    async set(id, req, res, iat) {
+    async set() {
+      // noop
+    }
+
+    setCookie(id, req, res, iat) {
       setCookie(req, res, iat);
     }
   }
@@ -169,19 +174,31 @@ module.exports = (config) => {
       { uat = epoch(), iat = uat, exp = calculateExp(iat, uat) }
     ) {
       if (!req[sessionName] || !Object.keys(req[sessionName]).length) {
-        if (id) {
-          res.clearCookie(sessionName, {
-            domain: cookieConfig.domain,
-            path: cookieConfig.path,
-          });
+        if (req[COOKIES][sessionName]) {
           await this._destroy(id);
         }
       } else {
-        id = id || crypto.randomBytes(16).toString('hex');
         await this._set(id, {
           header: { iat, uat, exp },
           data: req[sessionName],
         });
+      }
+    }
+
+    setCookie(
+      id,
+      req,
+      res,
+      { uat = epoch(), iat = uat, exp = calculateExp(iat, uat) }
+    ) {
+      if (!req[sessionName] || !Object.keys(req[sessionName]).length) {
+        if (req[COOKIES][sessionName]) {
+          res.clearCookie(sessionName, {
+            domain: cookieConfig.domain,
+            path: cookieConfig.path,
+          });
+        }
+      } else {
         const cookieOptions = {
           ...cookieConfig,
           expires: cookieConfig.transient ? 0 : new Date(exp * 1000),
@@ -289,10 +306,18 @@ module.exports = (config) => {
       attachSessionObject(req, sessionName, {});
     }
 
+    const id = existingSessionValue || crypto.randomBytes(16).toString('hex');
+
+    onHeaders(res, () =>
+      store.setCookie(id, req, res, {
+        iat,
+      })
+    );
+
     const { end: origEnd } = res;
     res.end = async function resEnd(...args) {
       try {
-        await store.set(existingSessionValue, req, res, {
+        await store.set(id, req, res, {
           iat,
         });
         origEnd.call(res, ...args);

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -147,10 +147,6 @@ module.exports = (config) => {
       };
     }
 
-    async set() {
-      // noop
-    }
-
     setCookie(id, req, res, iat) {
       setCookie(req, res, iat);
     }
@@ -308,26 +304,24 @@ module.exports = (config) => {
 
     const id = existingSessionValue || crypto.randomBytes(16).toString('hex');
 
-    onHeaders(res, () =>
-      store.setCookie(id, req, res, {
-        iat,
-      })
-    );
+    onHeaders(res, () => store.setCookie(id, req, res, { iat }));
 
-    const { end: origEnd } = res;
-    res.end = async function resEnd(...args) {
-      try {
-        await store.set(id, req, res, {
-          iat,
-        });
-        origEnd.call(res, ...args);
-      } catch (e) {
-        // need to restore the original `end` so that it gets
-        // called after `next(e)` calls the express error handling mw
-        res.end = origEnd;
-        process.nextTick(() => next(e));
-      }
-    };
+    if (store.set) {
+      const { end: origEnd } = res;
+      res.end = async function resEnd(...args) {
+        try {
+          await store.set(id, req, res, {
+            iat,
+          });
+          origEnd.call(res, ...args);
+        } catch (e) {
+          // need to restore the original `end` so that it gets
+          // called after `next(e)` calls the express error handling mw
+          res.end = origEnd;
+          process.nextTick(() => next(e));
+        }
+      };
+    }
 
     return next();
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4134,6 +4134,11 @@
         "ee-first": "1.1.1"
       }
     },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "futoin-hkdf": "^1.3.2",
     "http-errors": "^1.7.3",
     "jose": "^2.0.0",
+    "on-headers": "^1.0.2",
     "openid-client": "^4.0.0",
     "p-memoize": "^4.0.0",
     "url-join": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-openid-connect",
-  "version": "2.3.0-tmp.0",
+  "version": "2.3.0",
   "description": "Express middleware to protect web applications using OpenID Connect.",
   "homepage": "https://github.com/auth0/express-openid-connect",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-openid-connect",
-  "version": "2.3.0",
+  "version": "2.3.0-tmp.0",
   "description": "Express middleware to protect web applications using OpenID Connect.",
   "homepage": "https://github.com/auth0/express-openid-connect",
   "license": "MIT",


### PR DESCRIPTION
### Description

When we added custom stores we handled async saves by monkey-patching `res.end` eg

```js
const origEnd = res.end;
res.end = async (...args) => {
  await asyncSave();
  origEnd.call(res, ...args);
}
```

This is fine, except we also wrote to the `set-cookie` header in `asyncSave`. The problem is that we shouldn't assume the header hasn't been written already written at this point. Some MWs, like `http-proxy-middleware` will `writeHead` if `!res.headersSent` (eg https://github.com/chimurai/http-proxy-middleware/blob/master/src/handlers.ts#L65-L80) which means that when we write to the head in `res.end`, we'll get `ERR_HTTP_HEADERS_SENT`.

To avoid this, we should do what express-session does, and split setting the cookie out of `asyncSave`, write the cookie to the header in `onHeaders` (eg https://github.com/expressjs/session/blob/a8641429502fcc076c4b2dcbd6b2320891c1650c/index.js#L219) and do the custom store saving in the monkey-patched `res.end` (eg https://github.com/expressjs/session/blob/a8641429502fcc076c4b2dcbd6b2320891c1650c/index.js#L246) eg.

```js
// write the cookie
onHeaders(res, () => setCookie());

// async save the session 
const origEnd = res.end;
res.end = async (...args) => {
  await asyncSave(); // no set-cookie
  origEnd.call(res, ...args);
}
```
### References

fixes #204 

### Testing

```js
const proxy = require('http-proxy-middleware');

app.use(auth());

app.get(
  '*',
  proxy.createProxyMiddleware({
    target: 'http://localhost:3001',
    changeOrigin: true,
  })
);

app.listen(3000, () => console.log('Visit http://localhost:3000'));
```

- visit `/login`
- see `ERR_HTTP_HEADERS_SENT` in logs after callback.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
