### PR TITLE
Prompt should be passed as an auth param

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -160,10 +160,10 @@ class ResponseContext {
     return urlJoin(config.baseURL, config.routes.callback);
   }
 
-  silentLogin(options) {
+  silentLogin(options = {}) {
     return this.login({
       ...options,
-      prompt: 'none',
+      authorizationParams: { ...options.authorizationParams, prompt: 'none' },
     });
   }
 

--- a/test/attemptSilentLogin.tests.js
+++ b/test/attemptSilentLogin.tests.js
@@ -1,3 +1,4 @@
+const { URL } = require('url');
 const { assert } = require('chai');
 const { create: createServer } = require('./fixture/server');
 const { makeIdToken } = require('./fixture/cert');
@@ -50,6 +51,8 @@ describe('attemptSilentLogin', () => {
     const response = await request({ baseUrl, jar, url: '/protected' });
 
     assert.equal(response.statusCode, 302);
+    const uri = new URL(response.headers.location);
+    assert.equal(uri.searchParams.get('prompt'), 'none');
     assert.include(jar.getCookies(baseUrl)[0], {
       key: 'skipSilentLogin',
       value: 'true',


### PR DESCRIPTION
### Description

`silentLogin` was not "silent", because `prompt=none` was not being passed correctly to `login`

### References

fixes #212 

### Testing

Have added a regression test to assert that `prompt=none` is passed to the `/authorize` endpoint.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
