### PR TITLE
feat(types): extend express request/response interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,9 @@ interface Session {
  *   ...
  * })
  * ```
+ *
+ * @deprecated use the native the `Request` interface of `express` instead; it has
+ * been extended and now includes a built in `oidc` param.
  */
 interface OpenidRequest extends Request {
   /**
@@ -51,6 +54,9 @@ interface OpenidRequest extends Request {
  *   res.oidc.login();
  * })
  * ```
+ *
+ * @deprecated use the native the `Response` interface of `express` instead; it has
+ * been extended and now includes a built in `oidc` param.
  */
 interface OpenidResponse extends Response {
   /**
@@ -167,6 +173,21 @@ interface ResponseContext {
    * ```
    */
   logout: (opts?: LogoutOptions) => Promise<void>;
+}
+
+/**
+ * Extend express interfaces (Response/Request) to support oidc param
+ */
+declare global {
+  namespace Express {
+    interface Request {
+      oidc: RequestContext;
+    }
+
+    interface Response {
+      oidc: ResponseContext;
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
**Extend express interfaces (Response/Request) to support oidc param**

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
I'm submitting this pull request since the `index.d.ts` file (for the type definitions) does not include extensions for the `Request` and `Response` native `express` interfaces. 

In this PR I have simply created an extension for the above interfaces and marked the two other ones as deprecated because they should not be used in their original form anymore.


### References
GitHub Issue/PR number addressed or fixed: https://github.com/auth0/express-openid-connect/issues/222

### Testing
Can not be tested since it is only a type definitions file

### Checklist
- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
