### PR TITLE
fix(types): change user type to be record instead of object

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -114,7 +114,7 @@ interface RequestContext {
    * An object containing all the claims of the ID Token with the claims
    * specified in {@link ConfigParams.identityClaimFilter identityClaimFilter} removed.
    */
-  user?: object;
+  user?: Record<string, any>;
 
   /**
    * Fetches the OIDC userinfo response.


### PR DESCRIPTION
Change the user property inside the RequestContext interface to be of type Record<string, any> instead of an object.
Giving a temporary solution to #207 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
