### PR TITLE
Tokenendpoint Parameters [SDK-1730]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -453,7 +453,7 @@ interface ConfigParams {
   clientAuthMethod?: string;
 
   /**
-   * Additional request body properties to be sent to the `oauth/token` endpoint during code exchange or token refresh.
+   * Additional request body properties to be sent to the `token_endpoint` during authorization code exchange or token refresh.
    */
   tokenParameters?: {
     [key: string]: unknown;

--- a/index.d.ts
+++ b/index.d.ts
@@ -451,6 +451,13 @@ interface ConfigParams {
    * String value for the client's authentication method. Default is `none` when using response_type='id_token', otherwise `client_secret_basic`.
    */
   clientAuthMethod?: string;
+
+  /**
+   * Additional extra request body properties to be sent to the AS during code or refresh token exchange
+   */
+  tokenParameters?: {
+    [key: string]: unknown;
+  }
 }
 
 interface SessionStorePayload {

--- a/index.d.ts
+++ b/index.d.ts
@@ -453,7 +453,7 @@ interface ConfigParams {
   clientAuthMethod?: string;
 
   /**
-   * Additional extra request body properties to be sent to the AS during code or refresh token exchange
+   * Additional request body properties to be sent to the `oauth/token` endpoint during code exchange or token refresh.
    */
   tokenParameters?: {
     [key: string]: unknown;

--- a/index.d.ts
+++ b/index.d.ts
@@ -455,7 +455,7 @@ interface ConfigParams {
   /**
    * Additional request body properties to be sent to the `token_endpoint` during authorization code exchange or token refresh.
    */
-  tokenParameters?: TokenParameters
+  tokenEndpointParams?: TokenParameters
 }
 
 interface SessionStorePayload {

--- a/index.d.ts
+++ b/index.d.ts
@@ -455,9 +455,7 @@ interface ConfigParams {
   /**
    * Additional request body properties to be sent to the `token_endpoint` during authorization code exchange or token refresh.
    */
-  tokenParameters?: {
-    [key: string]: unknown;
-  }
+  tokenParameters?: TokenParameters
 }
 
 interface SessionStorePayload {
@@ -630,7 +628,11 @@ interface AccessToken {
    * }
    * ```
    */
-  refresh(): Promise<AccessToken>;
+  refresh(params?: TokenParameters): Promise<AccessToken>;
+}
+
+interface TokenParameters {
+  [key: string]: unknown;
 }
 
 /**

--- a/lib/config.js
+++ b/lib/config.js
@@ -71,6 +71,7 @@ const paramsSchema = Joi.object({
     .default()
     .unknown(false),
   auth0Logout: Joi.boolean().optional().default(false),
+  tokenEndpointParams: Joi.object().optional(),
   authorizationParams: Joi.object({
     response_type: Joi.string()
       .optional()

--- a/lib/context.js
+++ b/lib/context.js
@@ -15,11 +15,17 @@ function isExpired() {
   return tokenSet.call(this).expired();
 }
 
-async function refresh() {
+async function refresh(params) {
   let { config, req } = weakRef(this);
   const client = await getClient(config);
   const oldTokenSet = tokenSet.call(this);
-  const newTokenSet = await client.refresh(oldTokenSet);
+
+  let extras;
+  if (config.tokenEndpointParams || params) {
+    extras = { exchangeBody: { ...config.tokenEndpointParams, ...params } };
+  }
+
+  const newTokenSet = await client.refresh(oldTokenSet, extras);
 
   // Update the session
   const session = req[config.session.name];

--- a/lib/context.js
+++ b/lib/context.js
@@ -15,14 +15,14 @@ function isExpired() {
   return tokenSet.call(this).expired();
 }
 
-async function refresh(params) {
+async function refresh({ tokenEndpointParams } = {}) {
   let { config, req } = weakRef(this);
   const client = await getClient(config);
   const oldTokenSet = tokenSet.call(this);
 
   let extras;
-  if (config.tokenEndpointParams || params) {
-    extras = { exchangeBody: { ...config.tokenEndpointParams, ...params } };
+  if (config.tokenEndpointParams || tokenEndpointParams) {
+    extras = { exchangeBody: { ...config.tokenEndpointParams, ...tokenEndpointParams } };
   }
 
   const newTokenSet = await client.refresh(oldTokenSet, extras);

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -96,13 +96,20 @@ const auth = function (params) {
             const { max_age, code_verifier, nonce, state } = authVerification
               ? JSON.parse(authVerification)
               : {};
-
-            session = await client.callback(redirectUri, callbackParams, {
+            
+            const checks = {
               max_age,
               code_verifier,
               nonce,
               state,
-            });
+            };
+            
+            let extras;
+            if (config.tokenEndpointParams) {
+              extras = { exchangeBody: config.tokenEndpointParams }
+            }
+
+            session = await client.callback(redirectUri, callbackParams, checks, extras);
 
             req.openidState = decodeState(state);
           } catch (err) {


### PR DESCRIPTION
## Description
Given I configure the SDK
When I add custom parameters to the tokenEndpointParams argument
Then those additional parameters are reflected in the oauth/token request for the code exchange

Given I configure the SDK
When I add custom parameters to the tokenEndpointParams argument
Then those additional parameters are reflected in the oauth/token request for the refresh grant

Given I configure the SDK
When I add custom parameters to the tokenEndpointParams argument
And I call req.oidc.accessToken.refresh({ tokenEndpointParams }) method with extra params
Then both the config and refresh argument params are passed to the token endpoint with the params argument taking precedence