### PR TITLE
[SDK-2533] Swallow error on silent auth

### DIFF
--- a/end-to-end/attempt-silent-login.test.js
+++ b/end-to-end/attempt-silent-login.test.js
@@ -1,0 +1,78 @@
+const { assert } = require('chai');
+const puppeteer = require('puppeteer');
+const provider = require('./fixture/oidc-provider');
+const {
+  baseUrl,
+  start,
+  login,
+  runExample,
+  stubEnv,
+  goto,
+} = require('./fixture/helpers');
+
+describe('attempt silent login', async () => {
+  let authServer;
+  let appServer;
+
+  beforeEach(async () => {
+    stubEnv();
+    authServer = await start(provider, 3001);
+    appServer = await runExample('attempt-silent-login');
+  });
+
+  afterEach(async () => {
+    authServer.close();
+    appServer.close();
+  });
+
+  it('should attempt silent login and swallow failures', async () => {
+    const browser = await puppeteer.launch({
+      args: ['no-sandbox', 'disable-setuid-sandbox'],
+    });
+    const page = await browser.newPage();
+    await goto(baseUrl, page);
+    await page.waitForNavigation();
+    assert.equal(page.url(), `${baseUrl}/`);
+    const cookies = await page.cookies('http://localhost:3000');
+    assert.ok(
+      cookies.find(
+        ({ name, value }) => name === 'skipSilentLogin' && value === 'true'
+      )
+    );
+    assert.isNotOk(cookies.find(({ name }) => name === 'appSession'));
+  });
+
+  it('should login silently if there is an active session on the IDP', async () => {
+    const browser = await puppeteer.launch({
+      args: ['no-sandbox', 'disable-setuid-sandbox'],
+    });
+    const page = await browser.newPage();
+    await goto(`${baseUrl}/login`, page);
+    assert.match(
+      page.url(),
+      /http:\/\/localhost:3001\/interaction/,
+      'User should have been redirected to the auth server to login'
+    );
+    await login('username', 'password', page);
+    assert.equal(
+      page.url(),
+      `${baseUrl}/`,
+      'User is returned to the original page'
+    );
+    const loggedInCookies = await page.cookies(baseUrl);
+    assert.ok(loggedInCookies.find(({ name }) => name === 'appSession'));
+
+    await page.deleteCookie(
+      { name: 'appSession' },
+      { name: 'skipSilentLogin' }
+    );
+    const loggedOutCookies = await page.cookies(baseUrl);
+    assert.isNotOk(loggedOutCookies.find(({ name }) => name === 'appSession'));
+
+    await goto(baseUrl, page);
+    await page.waitForNavigation();
+    assert.equal(page.url(), `${baseUrl}/`);
+    const cookies = await page.cookies('http://localhost:3000');
+    assert.ok(cookies.find(({ name }) => name === 'appSession'));
+  });
+});

--- a/examples/attempt-silent-login.js
+++ b/examples/attempt-silent-login.js
@@ -1,0 +1,21 @@
+const express = require('express');
+const { auth } = require('../');
+
+const app = express();
+
+app.use(
+  auth({
+    attemptSilentLogin: true,
+    authRequired: false,
+  })
+);
+
+app.get('/', (req, res) => {
+  if (req.oidc.isAuthenticated()) {
+    res.send(`hello ${req.oidc.user.sub}`);
+  } else {
+    res.send('<a href="/login">login</a>');
+  }
+});
+
+module.exports = app;

--- a/index.d.ts
+++ b/index.d.ts
@@ -203,6 +203,11 @@ interface LoginOptions {
    *  URL to return to after login, overrides the Default is {@link Request.originalUrl}
    */
   returnTo?: string;
+
+  /**
+   *  Used by {@link ConfigParams.attemptSilentLogin} to swallow callback errors on silent login.
+   */
+  silent?: boolean;
 }
 
 /**

--- a/lib/context.js
+++ b/lib/context.js
@@ -163,6 +163,7 @@ class ResponseContext {
   silentLogin(options = {}) {
     return this.login({
       ...options,
+      silent: true,
       authorizationParams: { ...options.authorizationParams, prompt: 'none' },
     });
   }
@@ -200,6 +201,9 @@ class ResponseContext {
       next(new Error('Custom state value must be an object.'));
     }
     stateValue.nonce = transient.generateNonce();
+    if (options.silent) {
+      stateValue.attemptingSilentLogin = true;
+    }
 
     const usePKCE = options.authorizationParams.response_type.includes('code');
     if (usePKCE) {

--- a/lib/hooks/getLoginState.js
+++ b/lib/hooks/getLoginState.js
@@ -39,7 +39,11 @@ function encodeState(stateObject = {}) {
  * @return {object}
  */
 function decodeState(stateValue) {
-  return JSON.parse(base64url.decode(stateValue));
+  try {
+    return JSON.parse(base64url.decode(stateValue));
+  } catch (e) {
+    return false;
+  }
 }
 
 module.exports.defaultState = defaultState;


### PR DESCRIPTION
### Description

When the application attempts silent auth, callback errors should be swallowed.

### References

fixes #219 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
