### PR TITLE
[SDK-2614] Fix flakey logout test

### DIFF
--- a/test/logout.tests.js
+++ b/test/logout.tests.js
@@ -16,12 +16,12 @@ const defaultConfig = {
   authRequired: false,
 };
 
-const login = async (baseUrl = 'http://localhost:3000') => {
+const login = async (baseUrl = 'http://localhost:3000', idToken) => {
   const jar = request.jar();
   await request.post({
     uri: '/session',
     json: {
-      id_token: makeIdToken(),
+      id_token: idToken || makeIdToken(),
     },
     baseUrl,
     jar,
@@ -85,14 +85,15 @@ describe('logout route', async () => {
       })
     );
 
-    const { jar } = await login();
+    const idToken = makeIdToken();
+    const { jar } = await login('http://localhost:3000', idToken);
     const { response, session: loggedOutSession } = await logout(jar);
     assert.notOk(loggedOutSession.id_token);
     assert.equal(response.statusCode, 302);
     assert.include(
       response.headers,
       {
-        location: `https://op.example.com/session/end?post_logout_redirect_uri=http%3A%2F%2Fexample.org&id_token_hint=${makeIdToken()}`,
+        location: `https://op.example.com/session/end?post_logout_redirect_uri=http%3A%2F%2Fexample.org&id_token_hint=${idToken}`,
       },
       'should redirect to the identity provider'
     );


### PR DESCRIPTION
### Description

The logout test fails occaisonally because the time we create the ID token at login, doesn't always match the time we create an ID token to assert the logout url (can be off my 1ms)

### References

![image](https://user-images.githubusercontent.com/1299658/122781346-9e2c3200-d2a7-11eb-9d9d-f68f2afc46e1.png)

https://app.circleci.com/pipelines/github/auth0/express-openid-connect/517/workflows/5e545785-6011-4de8-87e1-55c27d1a0cf2/jobs/527

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
