### PR TITLE
feat(patch): Added httpTimeout Option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -463,7 +463,7 @@ interface ConfigParams {
   tokenEndpointParams?: TokenParameters;
 
   /**
-   * Default http timeout for oidc client requests in milliseconds.  Default is `5000`.
+   * Http timeout for oidc client requests in milliseconds.  Default is 5000.
    */
   httpTimeout?: number;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -463,7 +463,7 @@ interface ConfigParams {
   tokenEndpointParams?: TokenParameters;
 
   /**
-   * Http timeout for oidc client requests in milliseconds.  Default is 5000.
+   * Http timeout for oidc client requests in milliseconds.  Default is 5000.   Minimum is 500.
    */
   httpTimeout?: number;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -461,6 +461,11 @@ interface ConfigParams {
    * Additional request body properties to be sent to the `token_endpoint` during authorization code exchange or token refresh.
    */
   tokenEndpointParams?: TokenParameters;
+
+  /**
+   * Default http timeout for oidc client requests in milliseconds.  Default is `5000`.
+   */
+  httpTimeout?: number;
 }
 
 interface SessionStorePayload {

--- a/lib/client.js
+++ b/lib/client.js
@@ -32,9 +32,10 @@ async function get(config) {
           }
         : undefined),
     };
-    options.timeout = 5000;
+    options.timeout = config.httpTimeout;
     return options;
   };
+
   const applyHttpOptionsCustom = (entity) =>
     (entity[custom.http_options] = defaultHttpOptions);
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -184,6 +184,7 @@ const paramsSchema = Joi.object({
         ? 'none'
         : 'client_secret_basic';
     }),
+  httpTimeout: Joi.number().optional().min(500).default(5000),
 });
 
 module.exports.get = function (config = {}) {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -75,12 +75,6 @@ describe('client initialization', function () {
   });
 
   describe('idTokenSigningAlg configuration is not overridden by discovery server', function () {
-    nock('https://op.example.com', { allowUnmocked: true })
-      .persist()
-      .get('/.well-known/openid-configuration')
-      .delayBody(2000) // 2 second delay
-      .reply(200, { ...wellKnown });
-
     const config = getConfig({
       secret: '__test_session_secret__',
       clientID: '__test_client_id__',

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -1,4 +1,4 @@
-const { assert } = require('chai').use(require('chai-as-promised'));
+const { assert, expect } = require('chai').use(require('chai-as-promised'));
 const { get: getConfig } = require('../lib/config');
 const { get: getClient } = require('../lib/client');
 const wellKnown = require('./fixture/well-known.json');
@@ -75,6 +75,12 @@ describe('client initialization', function () {
   });
 
   describe('idTokenSigningAlg configuration is not overridden by discovery server', function () {
+    nock('https://op.example.com', { allowUnmocked: true })
+      .persist()
+      .get('/.well-known/openid-configuration')
+      .delayBody(2000) // 2 second delay
+      .reply(200, { ...wellKnown });
+
     const config = getConfig({
       secret: '__test_session_secret__',
       clientID: '__test_client_id__',
@@ -96,6 +102,55 @@ describe('client initialization', function () {
 
       const client = await getClient(config);
       assert.equal(client.id_token_signed_response_alg, 'RS256');
+    });
+  });
+
+  describe('client respects httpTimeout configuration', function () {
+    const config = getConfig({
+      secret: '__test_session_secret__',
+      clientID: '__test_client_id__',
+      clientSecret: '__test_client_secret__',
+      issuerBaseURL: 'https://op.example.com',
+      baseURL: 'https://example.org',
+    });
+
+    function mockRequest(delay = 0) {
+      nock('https://op.example.com').post('/slow').delay(delay).reply(200);
+    }
+
+    async function invokeRequest(client) {
+      return await client.requestResource(
+        'https://op.example.com/slow',
+        'token',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer foo',
+          },
+        }
+      );
+    }
+
+    it('should not timeout for default', async function () {
+      mockRequest(0);
+      const client = await getClient({ ...config });
+      const response = await invokeRequest(client);
+      assert.equal(response.statusCode, 200);
+    });
+
+    it('should not timeout for delay < httpTimeout', async function () {
+      mockRequest(1000);
+      const client = await getClient({ ...config, httpTimeout: 1500 });
+      const response = await invokeRequest(client);
+      assert.equal(response.statusCode, 200);
+    });
+
+    it('should timeout for delay > httpTimeout', async function () {
+      mockRequest(1500);
+      const client = await getClient({ ...config, httpTimeout: 500 });
+      await expect(invokeRequest(client)).to.be.rejectedWith(
+        `Timeout awaiting 'request' for 500ms`
+      );
     });
   });
 });

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -180,6 +180,7 @@ describe('get config', () => {
         },
       },
     });
+
     assert.deepInclude(config, {
       secret: ['__test_session_secret_1__', '__test_session_secret_2__'],
       session: {
@@ -377,6 +378,29 @@ describe('get config', () => {
         },
       });
     }, '"session.cookie.domain" must be a string');
+  });
+
+  it('should fail when http timeout is invalid', function () {
+    assert.throws(() => {
+      getConfig({
+        ...defaultConfig,
+        httpTimeout: 'abcd',
+      });
+    }, '"httpTimeout" must be a number');
+
+    assert.throws(() => {
+      getConfig({
+        ...defaultConfig,
+        httpTimeout: '-100',
+      });
+    }, '"httpTimeout" must be greater than or equal to 500');
+
+    assert.throws(() => {
+      getConfig({
+        ...defaultConfig,
+        httpTimeout: '499',
+      });
+    }, '"httpTimeout" must be greater than or equal to 500');
   });
 
   it("shouldn't allow a secret of less than 8 chars", () => {
@@ -630,6 +654,18 @@ describe('get config', () => {
     );
   });
 
+  it('should allow valid httpTimeout configuration', () => {
+    const config = (httpTimeout) => ({
+      ...defaultConfig,
+      httpTimeout,
+    });
+
+    assert.doesNotThrow(() => config(5000));
+    assert.doesNotThrow(() => config(10000));
+    assert.doesNotThrow(() => config('5000'));
+    assert.doesNotThrow(() => config('10000'));
+  });
+
   it('should default clientAuthMethod to none for id_token response type', () => {
     {
       const config = getConfig(defaultConfig);
@@ -644,6 +680,15 @@ describe('get config', () => {
       });
       assert.deepInclude(config, {
         clientAuthMethod: 'none',
+      });
+    }
+  });
+
+  it('should default httpTimeout to 5000', () => {
+    {
+      const config = getConfig(defaultConfig);
+      assert.deepInclude(config, {
+        httpTimeout: 5000,
       });
     }
   });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Facilitates `httpTimeout` configuration option (in milliseconds) on `ConfigParams` interface.  This allows package consumers to configure the http timeout for requests against less-than-performant issuers.

### References

Closes #249.

### Testing

**Language:** Javascript
**Node Versions Tested:** 12.19.0 

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
