### PR TITLE
 Issue 227 - allow custom session id generation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -532,6 +532,16 @@ interface SessionConfigParams {
   store?: SessionStore;
 
   /**
+   * A Function for generating a session id when using a custom session store.
+   * For full details see the documentation for express-session
+   * at [genid](https://github.com/expressjs/session/blob/master/README.md#genid).
+   * If encrypted cookie storage is used or no value is provided, a default implementation is used.
+   * Be aware the default implmentation is  slightly different in this library as compared to the
+   * default session id generation used express-session.
+   */
+  genid?: (req: OpenidRequest) => string;
+
+  /**
    * If you want your session duration to be rolling, eg reset everytime the
    * user is active on your site, set this to a `true`. If you want the session
    * duration to be absolute, where the user is logged out a fixed time after login,

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -5,7 +5,6 @@ const {
   JWE,
   errors: { JOSEError },
 } = require('jose');
-const crypto = require('crypto');
 const { promisify } = require('util');
 const cookie = require('cookie');
 const onHeaders = require('on-headers');
@@ -44,15 +43,20 @@ module.exports = (config) => {
   const sessionName = config.session.name;
   const cookieConfig = config.session.cookie;
   const {
+    genid: generateId,
     absoluteDuration,
     rolling: rollingEnabled,
     rollingDuration,
   } = config.session;
 
-  const { transient: emptyTransient , ...emptyCookieOptions } = cookieConfig;
+  const { transient: emptyTransient, ...emptyCookieOptions } = cookieConfig;
   emptyCookieOptions.expires = emptyTransient ? 0 : new Date();
 
-  const emptyCookie = cookie.serialize(`${sessionName}.0`, '', emptyCookieOptions);
+  const emptyCookie = cookie.serialize(
+    `${sessionName}.0`,
+    '',
+    emptyCookieOptions
+  );
   const cookieChunkSize = MAX_COOKIE_SIZE - emptyCookie.length;
 
   let keystore = new JWKS.KeyStore();
@@ -97,7 +101,7 @@ module.exports = (config) => {
     { uat = epoch(), iat = uat, exp = calculateExp(iat, uat) }
   ) {
     const cookies = req[COOKIES];
-    const { transient: cookieTransient , ...cookieOptions } = cookieConfig;
+    const { transient: cookieTransient, ...cookieOptions } = cookieConfig;
     cookieOptions.expires = cookieTransient ? 0 : new Date(exp * 1000);
 
     // session was deleted or is empty, this matches all session cookies (chunked or unchunked)
@@ -143,7 +147,7 @@ module.exports = (config) => {
           debug('replacing non chunked cookie with chunked cookies');
           res.clearCookie(sessionName, {
             domain: cookieConfig.domain,
-            path: cookieConfig.path
+            path: cookieConfig.path,
           });
         }
       } else {
@@ -153,7 +157,7 @@ module.exports = (config) => {
           if (cookieName.match(`^${sessionName}\\.\\d$`)) {
             res.clearCookie(cookieName, {
               domain: cookieConfig.domain,
-              path: cookieConfig.path
+              path: cookieConfig.path,
             });
           }
         }
@@ -325,7 +329,7 @@ module.exports = (config) => {
       attachSessionObject(req, sessionName, {});
     }
 
-    const id = existingSessionValue || crypto.randomBytes(16).toString('hex');
+    const id = existingSessionValue || generateId(req);
 
     onHeaders(res, () => store.setCookie(id, req, res, { iat }));
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,9 @@
 const Joi = require('joi');
+const crypto = require('crypto');
 const { defaultState: getLoginState } = require('./hooks/getLoginState');
 const isHttps = /^https:/i;
+
+const defaultSessionIdGenerator = () => crypto.randomBytes(16).toString('hex');
 
 const paramsSchema = Joi.object({
   secret: Joi.alternatives([
@@ -38,6 +41,10 @@ const paramsSchema = Joi.object({
       .default(7 * 24 * 60 * 60), // 7 days,
     name: Joi.string().token().optional().default('appSession'),
     store: Joi.object().optional(),
+    genid: Joi.function()
+      .maxArity(1)
+      .optional()
+      .default(() => defaultSessionIdGenerator),
     cookie: Joi.object({
       domain: Joi.string().optional(),
       transient: Joi.boolean().optional().default(false),

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -165,12 +165,14 @@ describe('get config', () => {
   });
 
   it('should set custom cookie configuration', () => {
+    const sessionIdGenerator = () => '1235';
     const config = getConfig({
       ...defaultConfig,
       secret: ['__test_session_secret_1__', '__test_session_secret_2__'],
       session: {
         name: '__test_custom_session_name__',
         rollingDuration: 1234567890,
+        genid: sessionIdGenerator,
         cookie: {
           domain: '__test_custom_domain__',
           transient: true,
@@ -187,6 +189,7 @@ describe('get config', () => {
         rollingDuration: 1234567890,
         absoluteDuration: 604800,
         rolling: true,
+        genid: sessionIdGenerator,
         cookie: {
           domain: '__test_custom_domain__',
           transient: true,


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
This commit address [issue
227](https://github.com/auth0/express-openid-connect/issues/227) allowing an implementation of genid to be used when a custom session store is used.  This is fully compatible with the existing implementation and aligns with how expression-session allows for overriding the way session ids are generated. Note because of how session ids are generated in this library, it is not possible to simply fall into the custom store's genid function.

In implementing these changes, the following was done:
- Moved the default session id generation into config to make it clear what said default is
- Added a new parameter genid compatible with how it works for express-session
- Updated the appsession code to take advantage of the provided value and fallback to the default.
- Added unit tests validating the genid parameter being used when specified and not having any effect on the encrypted cookie
- Reordered the spread operators in the appsession custom store tests so that overrides are respected.  This changed no other existing tests.
- Updated documentation with the additional, optional parameter along with links to the compatible usage in express-session.

### References
See discussion in this issue https://github.com/auth0/express-openid-connect/issues/227
Also https://github.com/expressjs/session#genid

### Testing
Tested with node 14
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
