### PR TITLE
Fix cookie chunking

### DIFF
--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -51,6 +51,7 @@ module.exports = (config) => {
 
   const { transient: emptyTransient, ...emptyCookieOptions } = cookieConfig;
   emptyCookieOptions.expires = emptyTransient ? 0 : new Date();
+  emptyCookieOptions.path = emptyCookieOptions.path || '/';
 
   const emptyCookie = cookie.serialize(
     `${sessionName}.0`,

--- a/test/appSession.tests.js
+++ b/test/appSession.tests.js
@@ -123,6 +123,33 @@ describe('appSession', () => {
   });
 
   it('should limit total cookie size to 4096 Bytes', async () => {
+    server = await createServer(appSession(getConfig(defaultConfig)));
+    const jar = request.jar();
+
+    await request.post('session', {
+      baseUrl,
+      jar,
+      json: {
+        sub: '__test_sub__',
+        random: crypto.randomBytes(8000).toString('base64'),
+      },
+    });
+
+    const cookies = jar
+      .getCookies(baseUrl)
+      .reduce(
+        (obj, value) => Object.assign(obj, { [value.key]: value + '' }),
+        {}
+      );
+
+    assert.exists(cookies);
+    assert.equal(cookies['appSession.0'].length, 4096);
+    assert.equal(cookies['appSession.1'].length, 4096);
+    assert.equal(cookies['appSession.2'].length, 4096);
+    assert.isTrue(cookies['appSession.3'].length <= 4096);
+  });
+
+  it('should limit total cookie size to 4096 Bytes with custom path', async () => {
     const path =
       '/some-really-really-really-really-really-really-really-really-really-really-really-really-really-long-path';
     server = await createServer(


### PR DESCRIPTION
### Description

`res.cookie` [adds a default path](https://github.com/expressjs/express/blob/master/lib/response.js#L853-L855) to cookies so we should add a default one when measuring the default cookie string length.

### References

fixes #269 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
