### PR TITLE
Jwt client authn

### DIFF
--- a/end-to-end/fixture/oidc-provider.js
+++ b/end-to-end/fixture/oidc-provider.js
@@ -17,6 +17,7 @@ const config = {
   clients: [
     client,
     Object.assign({}, client, {
+      client_secret: undefined,
       client_id: 'jwtca-client',
       token_endpoint_auth_method: 'private_key_jwt',
       jwks: {

--- a/examples/jwt-client-authn.js
+++ b/examples/jwt-client-authn.js
@@ -13,9 +13,12 @@ app.use(
       response_type: 'code',
     },
     clientAuthMethod: 'private_key_jwt',
-    clientAssertionSigningKey: fs.readFileSync(
+    clientAssertionConfig: {
+      signingKey: fs.readFileSync(
       path.join(__dirname, 'private-key.pem')
     ),
+      signingAlg: 'RS256'
+    }
   })
 );
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ import {
   UserinfoResponse,
 } from 'openid-client';
 import { Request, Response, RequestHandler } from 'express';
+import { KeyInput } from 'jose';
 
 /**
  * Session object
@@ -458,6 +459,24 @@ interface ConfigParams {
   clientAuthMethod?: string;
 
   /**
+   * Private key and signing algorithm for use with 'private_key_jwt' clients
+   *
+   * ```js
+   * app.use(auth({
+   *   ...
+   *   clientAuthMethod: 'private_key_jwt',
+   *   clientAssertionConfig: {
+   *    signingKey: fs.readFileSync(
+   *      path.join(__dirname, 'private-key.pem')
+   *    ),
+   *    signingAlg: 'RS384'
+   *  }
+   * }))
+   * ```
+   */
+  clientAssertionConfig?: ClientAssertionConfig;
+
+  /**
    * Additional request body properties to be sent to the `token_endpoint` during authorization code exchange or token refresh.
    */
   tokenEndpointParams?: TokenParameters;
@@ -466,6 +485,22 @@ interface ConfigParams {
    * Http timeout for oidc client requests in milliseconds.  Default is 5000.   Minimum is 500.
    */
   httpTimeout?: number;
+}
+
+interface ClientAssertionConfig {
+  signingKey: KeyInput | object;
+  signingAlg:
+    | 'RS256'
+    | 'RS384'
+    | 'RS512'
+    | 'PS256'
+    | 'PS384'
+    | 'PS512'
+    | 'ES256'
+    | 'ES256K'
+    | 'ES384'
+    | 'ES512'
+    | 'EdDSA';
 }
 
 interface SessionStorePayload {

--- a/index.d.ts
+++ b/index.d.ts
@@ -451,6 +451,11 @@ interface ConfigParams {
      * Relative path to the application callback to process the response from the authorization server.
      */
     callback?: string;
+
+    /**
+     * Relative path to the application's JSON Web Key Set URL (JWKS URL).
+     */
+    jwksUrl?: string;
   };
 
   /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -86,6 +86,38 @@ async function get(config) {
     );
   }
 
+  const configTokenAuthMethod = config.clientAuthMethod;
+  const issuerTokenAuthMethods = Array.isArray(
+    issuer.token_endpoint_auth_methods_supported
+  )
+    ? issuer.token_endpoint_auth_methods_supported
+    : [];
+  if (!issuerTokenAuthMethods.includes(configTokenAuthMethod)) {
+    debug(
+      'Client authn method %o is not supported by the issuer. ' +
+        'Supported authn methods are %o.',
+      configTokenAuthMethod,
+      issuerTokenAuthMethods
+    );
+  }
+
+  if (config.clientAuthMethod == 'private_key_jwt') {
+    const configTokenAuthAlg = config.clientAssertionConfig.signingKey;
+    const issuerTokenAuthAlgs = Array.isArray(
+      issuer.token_endpoint_auth_signing_alg_values_supported
+    )
+      ? issuer.token_endpoint_auth_signing_alg_values_supported
+      : [];
+    if (!issuerTokenAuthAlgs.includes(configTokenAuthAlg)) {
+      debug(
+        'Client authn signing alg %o is not supported by the issuer. ' +
+          'Supported authn algs are %o.',
+        configTokenAuthAlg,
+        issuerTokenAuthAlgs
+      );
+    }
+  }
+
   const jwks =
     config.clientAuthMethod == 'private_key_jwt'
       ? {
@@ -111,7 +143,6 @@ async function get(config) {
   const client = new issuer.Client(
     {
       client_id: config.clientID,
-      client_secret: config.clientSecret,
       id_token_signed_response_alg: config.idTokenSigningAlg,
       token_endpoint_auth_method: config.clientAuthMethod,
       ...getClientAuthMetdata(config),

--- a/lib/client.js
+++ b/lib/client.js
@@ -122,7 +122,10 @@ async function get(config) {
     config.clientAuthMethod == 'private_key_jwt'
       ? {
           keys: [
-            JWK.asKey(config.clientAssertionConfig.signingKey).toJWK(true),
+            JWK.asKey(config.clientAssertionConfig.signingKey, {
+              alg: config.clientAssertionConfig.signingAlg,
+              use: 'sig',
+            }).toJWK(true),
           ],
         }
       : { keys: [] };

--- a/lib/client.js
+++ b/lib/client.js
@@ -86,10 +86,27 @@ async function get(config) {
     );
   }
 
-  let jwks;
-  if (config.clientAssertionSigningKey) {
-    const jwk = JWK.asKey(config.clientAssertionSigningKey).toJWK(true);
-    jwks = { keys: [jwk] };
+  const jwks =
+    config.clientAuthMethod == 'private_key_jwt'
+      ? {
+          keys: [
+            JWK.asKey(config.clientAssertionConfig.signingKey).toJWK(true),
+          ],
+        }
+      : { keys: [] };
+  function getClientAuthMetdata(config) {
+    switch (config.clientAuthMethod) {
+      case 'none':
+        return {};
+      case 'private_key_jwt':
+        return {
+          token_endpoint_auth_signing_alg:
+            config.clientAssertionConfig.signingAlg,
+        };
+      case 'client_secret_basic':
+      case 'client_secret_post':
+        return { client_secret: config.clientSecret };
+    }
   }
   const client = new issuer.Client(
     {
@@ -97,6 +114,7 @@ async function get(config) {
       client_secret: config.clientSecret,
       id_token_signed_response_alg: config.idTokenSigningAlg,
       token_endpoint_auth_method: config.clientAuthMethod,
+      ...getClientAuthMetdata(config),
     },
     jwks
   );

--- a/lib/config.js
+++ b/lib/config.js
@@ -195,8 +195,35 @@ const paramsSchema = Joi.object({
       return parent.authorizationParams.response_type === 'id_token'
         ? 'none'
         : 'client_secret_basic';
+  clientAssertionConfig: Joi.object({
+    signingKey: Joi.any().required(), // <Object> | <string> | <Buffer> | <KeyObject>
+    signingAlg: Joi.string()
+      .valid(
+      'RS256',
+      'RS384',
+      'RS512',
+      'PS256',
+      'PS384',
+      'PS512',
+      'ES256',
+      'ES256K',
+      'ES384',
+      'ES512',
+      'EdDSA'
+      )
+      .required(),
+  }).when(
+      Joi.ref('clientAuthMethod', {
+        adjust: (value) => value && value == 'private_key_jwt',
+      }),
+      {
+        is: true,
+        then: Joi.required().messages({
+          'any.required':
+            '"clientAssertionConfig" is required for a "clientAuthMethod" of includes "private_key_jwt"',
     }),
-  clientAssertionSigningKey: Joi.any(), // <Object> | <string> | <Buffer> | <KeyObject>
+    }
+  ),
   httpTimeout: Joi.number().optional().min(500).default(5000),
 });
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -180,6 +180,10 @@ const paramsSchema = Joi.object({
     ]).default('/logout'),
     callback: Joi.string().uri({ relativeOnly: true }).default('/callback'),
     postLogoutRedirect: Joi.string().uri({ allowRelative: true }).default(''),
+    jwksUrl: Joi.alternatives([
+      Joi.string().uri({ relativeOnly: true }),
+      Joi.boolean().valid(false),
+    ]).default('/jwks.json'),
   })
     .default()
     .unknown(false),

--- a/lib/config.js
+++ b/lib/config.js
@@ -112,14 +112,14 @@ const paramsSchema = Joi.object({
   clientID: Joi.string().required(),
   clientSecret: Joi.string()
     .when(
-      Joi.ref('authorizationParams.response_type', {
-        adjust: (value) => value && value.includes('code'),
+      Joi.ref('clientAuthMethod', {
+        adjust: (value) => value && value.includes('client_secret'),
       }),
       {
         is: true,
         then: Joi.string().required().messages({
           'any.required':
-            '"clientSecret" is required for a response_type that includes code',
+            '"clientSecret" is required for a "clientAuthMethod" that includes client_secret',
         }),
       }
     )
@@ -195,33 +195,46 @@ const paramsSchema = Joi.object({
       return parent.authorizationParams.response_type === 'id_token'
         ? 'none'
         : 'client_secret_basic';
+    })
+    .when(
+      Joi.ref('authorizationParams.response_type', {
+        adjust: (value) => value && value.includes('code'),
+      }),
+      {
+        is: true,
+        then: Joi.string().invalid('none').messages({
+          'any.only':
+            '"clientAuthMethod" cannot be "none" when "response_type" includes "code"',
+        }),
+      }
+    ),
   clientAssertionConfig: Joi.object({
     signingKey: Joi.any().required(), // <Object> | <string> | <Buffer> | <KeyObject>
     signingAlg: Joi.string()
       .valid(
-      'RS256',
-      'RS384',
-      'RS512',
-      'PS256',
-      'PS384',
-      'PS512',
-      'ES256',
-      'ES256K',
-      'ES384',
-      'ES512',
-      'EdDSA'
+        'RS256',
+        'RS384',
+        'RS512',
+        'PS256',
+        'PS384',
+        'PS512',
+        'ES256',
+        'ES256K',
+        'ES384',
+        'ES512',
+        'EdDSA'
       )
       .required(),
   }).when(
-      Joi.ref('clientAuthMethod', {
-        adjust: (value) => value && value == 'private_key_jwt',
-      }),
-      {
-        is: true,
-        then: Joi.required().messages({
-          'any.required':
-            '"clientAssertionConfig" is required for a "clientAuthMethod" of includes "private_key_jwt"',
+    Joi.ref('clientAuthMethod', {
+      adjust: (value) => value && value == 'private_key_jwt',
     }),
+    {
+      is: true,
+      then: Joi.required().messages({
+        'any.required':
+          '"clientAssertionConfig" is required for a "clientAuthMethod" of includes "private_key_jwt"',
+      }),
     }
   ),
   httpTimeout: Joi.number().optional().min(500).default(5000),

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cb = require('cb');
 const createError = require('http-errors');
+const { JWK } = require('jose');
 
 const debug = require('../lib/debug')('auth');
 const { get: getConfig } = require('../lib/config');
@@ -56,6 +57,23 @@ const auth = function (params) {
     router.get(path, (req, res) => res.oidc.logout());
   } else {
     debug('logout handling route not applied');
+  }
+
+  // jwks url route, configured with routes.jwksUrl
+  if (config.routes.jwksUrl && config.clientAuthMethod == 'private_key_jwt') {
+    const path = enforceLeadingSlash(config.routes.jwksUrl);
+    debug('adding GET %s route', path);
+    const jwks = {
+      keys: [
+        JWK.asKey(config.clientAssertionConfig.signingKey, {
+          alg: config.clientAssertionConfig.signingAlg,
+          use: 'sig',
+        }).toJWK(false),
+      ],
+    };
+    router.get(path, (req, res) => res.json(jwks));
+  } else {
+    debug('json web key set distribution route not applied');
   }
 
   // Callback route, configured with routes.callback.

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -424,32 +424,71 @@ describe('get config', () => {
     );
   });
 
-  it("shouldn't allow code flow without clientSecret", () => {
-    const config = {
-      ...defaultConfig,
-      authorizationParams: {
-        response_type: 'code',
-      },
-    };
-    assert.throws(
-      () => getConfig(config),
-      TypeError,
-      '"clientSecret" is required for a response_type that includes code'
-    );
+  context(
+    'when clientAuthMethod is "client_secret_basic" (by default)',
+    async () => {
+      it("shouldn't allow code flow without client authn", () => {
+        const config = {
+          ...defaultConfig,
+          authorizationParams: {
+            response_type: 'code',
+          },
+        };
+        assert.throws(
+          () => getConfig(config),
+          TypeError,
+          '"clientSecret" is required for a "clientAuthMethod" that includes client_secret'
+        );
+      });
+
+      it("shouldn't allow hybrid flow without client authn", () => {
+        const config = {
+          ...defaultConfig,
+          authorizationParams: {
+            response_type: 'code id_token',
+          },
+        };
+        assert.throws(
+          () => getConfig(config),
+          TypeError,
+          '"clientSecret" is required for a "clientAuthMethod" that includes client_secret'
+        );
+      });
+    }
+  );
+
+  context('when clientAuthMethod is "none"', async () => {
+    it("shouldn't allow code flow without client authn", () => {
+      const config = {
+        ...defaultConfig,
+        authorizationParams: {
+          response_type: 'code',
+        },
+        clientAuthMethod: 'none',
+      };
+      assert.throws(
+        () => getConfig(config),
+        TypeError,
+        '"clientAuthMethod" cannot be "none" when "response_type" includes "code"'
+      );
+    });
   });
 
-  it("shouldn't allow hybrid flow without clientSecret", () => {
-    const config = {
-      ...defaultConfig,
-      authorizationParams: {
-        response_type: 'code id_token',
-      },
-    };
-    assert.throws(
-      () => getConfig(config),
-      TypeError,
-      '"clientSecret" is required for a response_type that includes code'
-    );
+  context('when clientAuthMethod is "private_key_jwt"', async () => {
+    it('should require "clientAssertionConfig"', () => {
+      const config = {
+        ...defaultConfig,
+        authorizationParams: {
+          response_type: 'code',
+        },
+        clientAuthMethod: 'private_key_jwt',
+      };
+      assert.throws(
+        () => getConfig(config),
+        TypeError,
+        '"clientAssertionConfig" is required for a "clientAuthMethod" of includes "private_key_jwt"'
+      );
+    });
   });
 
   it('should not allow "none" for idTokenSigningAlg', () => {


### PR DESCRIPTION
### Description
This PR adds JWT based client authentication to the library (building on Adam's initial implementation). All signing algorithms supported by [jose@2.0.5](https://github.com/panva/jose/tree/v2.x#detailed-support-matrix) will be supported here (though upgrading jose versions is an option). This PR also adds a configurable JWKS endpoint, so that the public keys associated with the client can be distributed.

### References
Following up on my [issue](https://github.com/auth0/express-openid-connect/issues/162) for this enhancement.
GitHub [Project](https://github.com/madaster97/express-openid-connect/projects/1) where I documented the additions

### Testing
There's an example JWT client that @adamjmcgrath already added. I've been using that to test, but I've been having issues getting it to work against the fixture provider. I think the `run_example.js` script is accidentally setting up a client_secret client instead of a jwt one. I've been testing against an example Openid Provider that supports private_key_jwt clients and it's worked so far.
- [x] This change adds test coverage for new/changed/fixed functionality

#### TBD on testing
- [] Adding testing for the JWKS endpoint

### Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
