### PR TITLE
Fix refresh signature in ts defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -648,7 +648,11 @@ interface AccessToken {
    * }
    * ```
    */
-  refresh(params?: TokenParameters): Promise<AccessToken>;
+  refresh(params?: RefreshParams): Promise<AccessToken>;
+}
+
+interface RefreshParams {
+  tokenEndpointParams?: TokenParameters;
 }
 
 interface TokenParameters {


### PR DESCRIPTION
### Description

The signature for `AccessToken#refresh` was missing `tokenEndpointParams` property

### References

fixes #293 
