### PR TITLE
allow configuration of same site attribute on auth_verification cookie

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -571,6 +571,11 @@ interface SessionConfigParams {
   absoluteDuration?: boolean | number;
 
   /**
+   * Configuration parameters used for the verification cookie.
+   */
+  verificationCookie: Pick<CookieConfigParams, 'sameSite'>;
+
+  /**
    * Configuration parameters used for the session cookie and transient cookies.
    */
   cookie?: CookieConfigParams;

--- a/lib/config.js
+++ b/lib/config.js
@@ -45,6 +45,14 @@ const paramsSchema = Joi.object({
       .maxArity(1)
       .optional()
       .default(() => defaultSessionIdGenerator),
+    verificationCookie: Joi.object({
+      sameSite: Joi.string()
+        .valid('Lax', 'Strict', 'None')
+        .optional()
+        .default('Lax'),
+    })
+      .default()
+      .unknown(false),
     cookie: Joi.object({
       domain: Joi.string().optional(),
       transient: Joi.boolean().optional().default(false),

--- a/lib/context.js
+++ b/lib/context.js
@@ -259,7 +259,7 @@ class ResponseContext {
         sameSite:
           options.authorizationParams.response_mode === 'form_post'
             ? 'None'
-            : config.session.cookie.sameSite,
+            : config.session.verificationCookie.sameSite,
         value: JSON.stringify(authVerification),
       });
 

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -136,6 +136,9 @@ describe('get config', () => {
       baseURL: 'http://example.com',
     });
     assert.deepInclude(config.session, {
+      verificationCookie: {
+        sameSite: 'Lax',
+      },
       rollingDuration: 86400,
       name: 'appSession',
       cookie: {
@@ -153,6 +156,9 @@ describe('get config', () => {
       baseURL: 'https://example.com',
     });
     assert.deepInclude(config.session, {
+      verificationCookie: {
+        sameSite: 'Lax',
+      },
       rollingDuration: 86400,
       name: 'appSession',
       cookie: {
@@ -170,6 +176,9 @@ describe('get config', () => {
       ...defaultConfig,
       secret: ['__test_session_secret_1__', '__test_session_secret_2__'],
       session: {
+        verificationCookie: {
+          sameSite: 'Strict',
+        },
         name: '__test_custom_session_name__',
         rollingDuration: 1234567890,
         genid: sessionIdGenerator,
@@ -186,6 +195,9 @@ describe('get config', () => {
     assert.deepInclude(config, {
       secret: ['__test_session_secret_1__', '__test_session_secret_2__'],
       session: {
+        verificationCookie: {
+          sameSite: 'Strict',
+        },
         name: '__test_custom_session_name__',
         rollingDuration: 1234567890,
         absoluteDuration: 604800,

--- a/test/login.tests.js
+++ b/test/login.tests.js
@@ -363,13 +363,13 @@ describe('auth', () => {
     assert.isDefined(fetchFromAuthCookie(res, 'code_verifier'));
   });
 
-  it('should respect sameSite when response_mode is not form_post', async () => {
+  it('should respect verificationCookie.sameSite when response_mode is not form_post', async () => {
     server = await createServer(
       auth({
         ...defaultConfig,
         clientSecret: '__test_client_secret__',
         session: {
-          cookie: {
+          verificationCookie: {
             sameSite: 'Strict',
           },
         },


### PR DESCRIPTION
### Description

This is a breaking change. Allows to use a custom same site configuration for the `auth_verification` cookie. I only included the override of the samesite but it could be extended later on.

### References

#322 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
