### PR TITLE
[SDK-3110] Allow customising the UA header in client reqs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -475,7 +475,7 @@ interface ConfigParams {
   /**
    * Optional User-Agent header value for oidc client requests.  Default is `express-openid-connect/{version}`.
    */
-  httpUserAgent?: number;
+  httpUserAgent?: string;
 }
 
 interface SessionStorePayload {

--- a/index.d.ts
+++ b/index.d.ts
@@ -471,6 +471,11 @@ interface ConfigParams {
    * Http timeout for oidc client requests in milliseconds.  Default is 5000.   Minimum is 500.
    */
   httpTimeout?: number;
+
+  /**
+   * Optional User-Agent header value for oidc client requests.  Default is `express-openid-connect/{version}`.
+   */
+  httpUserAgent?: number;
 }
 
 interface SessionStorePayload {

--- a/lib/client.js
+++ b/lib/client.js
@@ -23,7 +23,7 @@ async function get(config) {
   const defaultHttpOptions = (options) => {
     options.headers = {
       ...options.headers,
-      'User-Agent': `${pkg.name}/${pkg.version}`,
+      'User-Agent': config.httpUserAgent || `${pkg.name}/${pkg.version}`,
       ...(config.enableTelemetry
         ? {
             'Auth0-Client': Buffer.from(

--- a/lib/config.js
+++ b/lib/config.js
@@ -200,6 +200,7 @@ const paramsSchema = Joi.object({
         : 'client_secret_basic';
     }),
   httpTimeout: Joi.number().optional().min(500).default(5000),
+  httpUserAgent: Joi.string().optional(),
 });
 
 module.exports.get = function (config = {}) {


### PR DESCRIPTION
### Description

Add the option to override the default `User-Agent` header in requests sent to the Authorization server.

### References

fixes #295

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
