### PR TITLE
[SDK-3111] Add Oauth error props to http error when available

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ See the [API documentation](https://auth0.github.io/express-openid-connect) for 
 
 ## A note on error handling
 
-Errors raised by this library are handled by the [default Express error handler](https://expressjs.com/en/guide/error-handling.html#the-default-error-handler) which, in the interests of security, does not include the stack trace or error message in the production environment. If you write your own error handler, you should not render the error message without using a templating engine that will properly escape it first.
+Errors raised by this library are handled by the [default Express error handler](https://expressjs.com/en/guide/error-handling.html#the-default-error-handler) which, in the interests of security, does not include the stack trace or error message in the production environment. If you write your own error handler, you should not render the error message or the OAuth `error`/`error_description` properties without using a templating engine that will properly escape them first.
 
 To write your own error handler, see the Express documentation on writing [Custom error handlers](https://expressjs.com/en/guide/error-handling.html#writing-error-handlers). 
 

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -118,7 +118,10 @@ const auth = function (params) {
               extras
             );
           } catch (err) {
-            throw createError.BadRequest(err.message);
+            throw createError(400, err.message, {
+              error: err.error,
+              error_description: err.error_description,
+            });
           }
 
           let session = Object.assign({}, tokenSet); // Remove non-enumerable methods from the TokenSet

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -290,6 +290,26 @@ describe('callback response_mode: form_post', () => {
     assert.equal(err.message, 'checks.state argument is missing');
   });
 
+  it('should include oauth error properties in error', async () => {
+    const {
+      response: {
+        statusCode,
+        body: {
+          err: { error, error_description },
+        },
+      },
+    } = await setup({
+      cookies: {},
+      body: {
+        error: 'foo',
+        error_description: 'bar',
+      },
+    });
+    assert.equal(statusCode, 400);
+    assert.equal(error, 'foo');
+    assert.equal(error_description, 'bar');
+  });
+
   it('should use legacy samesite fallback', async () => {
     const { currentUser } = await setup({
       authOpts: {
@@ -948,7 +968,12 @@ describe('callback response_mode: form_post', () => {
     const store = new MemoryStore({
       checkPeriod: 24 * 60 * 1000,
     });
-    const { currentSession, currentUser, existingSessionCookie, jar } = await setup({
+    const {
+      currentSession,
+      currentUser,
+      existingSessionCookie,
+      jar,
+    } = await setup({
       cookies: generateCookies({
         state: expectedDefaultState,
         nonce: '__test_nonce__',
@@ -969,7 +994,7 @@ describe('callback response_mode: form_post', () => {
 
     const cookies = jar.getCookies(baseUrl);
     const newSessionCookie = cookies.find(({ key }) => key === 'appSession');
-    
+
     assert.equal(currentUser.sub, 'foo');
     assert.equal(currentSession.shoppingCartId, 'bar');
     assert.equal(
@@ -984,7 +1009,12 @@ describe('callback response_mode: form_post', () => {
     const store = new MemoryStore({
       checkPeriod: 24 * 60 * 1000,
     });
-    const { currentSession, currentUser, existingSessionCookie, jar } = await setup({
+    const {
+      currentSession,
+      currentUser,
+      existingSessionCookie,
+      jar,
+    } = await setup({
       cookies: generateCookies({
         state: expectedDefaultState,
         nonce: '__test_nonce__',
@@ -1006,7 +1036,7 @@ describe('callback response_mode: form_post', () => {
 
     const cookies = jar.getCookies(baseUrl);
     const newSessionCookie = cookies.find(({ key }) => key === 'appSession');
-    
+
     assert.equal(currentUser.sub, 'foo');
     assert.equal(currentSession.shoppingCartId, 'bar');
     assert.equal(
@@ -1021,7 +1051,12 @@ describe('callback response_mode: form_post', () => {
     const store = new MemoryStore({
       checkPeriod: 24 * 60 * 1000,
     });
-    const { currentSession, currentUser, existingSessionCookie, jar } = await setup({
+    const {
+      currentSession,
+      currentUser,
+      existingSessionCookie,
+      jar,
+    } = await setup({
       cookies: generateCookies({
         state: expectedDefaultState,
         nonce: '__test_nonce__',
@@ -1043,7 +1078,7 @@ describe('callback response_mode: form_post', () => {
 
     const cookies = jar.getCookies(baseUrl);
     const newSessionCookie = cookies.find(({ key }) => key === 'appSession');
-    
+
     assert.equal(currentUser.sub, 'bar');
     assert.isUndefined(currentSession.shoppingCartId);
     assert.equal(

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -48,7 +48,15 @@ module.exports.create = function (router, protect, path) {
 
   // eslint-disable-next-line no-unused-vars
   app.use((err, req, res, next) => {
-    res.status(err.status || 500).json({ err: { message: err.message } });
+    res
+      .status(err.status || 500)
+      .json({
+        err: {
+          message: err.message,
+          error: err.error,
+          error_description: err.error_description,
+        },
+      });
   });
 
   let mainApp;


### PR DESCRIPTION
### Description

Add the OAuth `error` and `error_description` properties to the `BadRequest` error (via [custom properties](https://github.com/jshttp/http-errors#createerrorstatus-message-properties)) when they're available

### References

fixes #301 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
