### PR TITLE
[SDK-3109] Add ability to pass custom logout params

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,7 @@
   "extends": "eslint:recommended",
   "rules": {
     "no-useless-escape": 1,
+    "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "ignoreRestSiblings": true }],
     "no-console": 0,
     "linebreak-style": ["error", "unix"]
   },

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -6,9 +6,6 @@ const app = express();
 app.use(
   auth({
     idpLogout: true,
-    logoutParams: {
-      federated: '',
-    },
   })
 );
 

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -6,6 +6,9 @@ const app = express();
 app.use(
   auth({
     idpLogout: true,
+    logoutParams: {
+      federated: '',
+    },
   })
 );
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -218,6 +218,11 @@ interface LogoutOptions {
    *  URL to returnTo after logout, overrides the Default in {@link ConfigParams.routes.postLogoutRedirect routes.postLogoutRedirect}
    */
   returnTo?: string;
+
+  /**
+   * Additional custom parameters to pass to the logout endpoint.
+   */
+  logoutParams?: { [key: string]: any };
 }
 
 /**
@@ -302,6 +307,11 @@ interface ConfigParams {
    * ```
    */
   authorizationParams?: AuthorizationParameters;
+
+  /**
+   * Additional custom parameters to pass to the logout endpoint.
+   */
+  logoutParams?: { [key: string]: any };
 
   /**
    * REQUIRED. The root URL for the application router, eg https://localhost

--- a/lib/client.js
+++ b/lib/client.js
@@ -101,11 +101,24 @@ async function get(config) {
     ) {
       Object.defineProperty(client, 'endSessionUrl', {
         value(params) {
+          const {
+            id_token_hint,
+            post_logout_redirect_uri,
+            ...extraParams
+          } = params;
           const parsedUrl = url.parse(urlJoin(issuer.issuer, '/v2/logout'));
           parsedUrl.query = {
-            returnTo: params.post_logout_redirect_uri,
+            ...extraParams,
+            returnTo: post_logout_redirect_uri,
             client_id: client.client_id,
           };
+
+          Object.entries(parsedUrl.query).forEach(([key, value]) => {
+            if (value === null || value === undefined) {
+              delete parsedUrl.query[key];
+            }
+          });
+
           return url.format(parsedUrl);
         },
       });

--- a/lib/config.js
+++ b/lib/config.js
@@ -107,6 +107,7 @@ const paramsSchema = Joi.object({
     .optional()
     .unknown(true)
     .default(),
+  logoutParams: Joi.object().optional(),
   baseURL: Joi.string()
     .uri()
     .required()

--- a/lib/context.js
+++ b/lib/context.js
@@ -300,6 +300,8 @@ class ResponseContext {
 
     try {
       returnURL = client.endSessionUrl({
+        ...config.logoutParams,
+        ...params.logoutParams,
         post_logout_redirect_uri: returnURL,
         id_token_hint,
       });


### PR DESCRIPTION
### Description

Add the ability to pass custom `logoutParams` to the `end_session_endpoint` on logout.

These will also be passed to the proprietary Auth0 logout endpoint, to do a [federated logout from auth0 ](https://auth0.com/docs/authenticate/login/logout/log-users-out-of-idps)you can pass the federated param, eg

`{ logoutParams: { federated: '' } }`

### References

Fixes #292 
https://openid.net/specs/openid-connect-rpinitiated-1_0-01.html#RPLogout
https://auth0.com/docs/authenticate/login/logout/log-users-out-of-idps

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
