### PR TITLE
Looser cookie name validation

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -39,7 +39,10 @@ const paramsSchema = Joi.object({
     })
       .optional()
       .default(7 * 24 * 60 * 60), // 7 days,
-    name: Joi.string().token().optional().default('appSession'),
+    name: Joi.string()
+      .pattern(/^[0-9a-zA-Z_-]+$/, { name: 'cookie name' })
+      .optional()
+      .default('appSession'),
     store: Joi.object().optional(),
     genid: Joi.function()
       .maxArity(1)

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -205,6 +205,37 @@ describe('get config', () => {
     });
   });
 
+  it('should validate session name', () => {
+    const validNames = [
+      'mySession',
+      'my-session',
+      'my_session',
+      '__Host-mysession',
+      'mySession123',
+    ];
+    const invalidNames = [
+      'my session',
+      'my;session',
+      'mysession?',
+      'my{session}',
+      '<my_session>',
+      'my@session',
+      'mySession:123',
+      'my=session',
+    ];
+
+    for (const name of validNames) {
+      assert.doesNotThrow(() => {
+        getConfig({ ...defaultConfig, session: { name } });
+      });
+    }
+    for (const name of invalidNames) {
+      assert.throws(() => {
+        getConfig({ ...defaultConfig, session: { name } });
+      });
+    }
+  });
+
   it('should set default transaction cookie sameSite configuration', () => {
     const config = getConfig({
       ...defaultConfig,


### PR DESCRIPTION
### Description

The Joi [token](https://joi.dev/api/?v=17.6.0#stringtoken) token validation is too strict for a cookie name, since these can contain dashes.

### References

fixes #322 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes
https://joi.dev/api/?v=17.6.0#stringtoken

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
