### PR TITLE
transactionCookie configuration should be optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -465,7 +465,7 @@ interface ConfigParams {
   /**
    * Configuration parameters used for the transaction cookie.
    */
-  transactionCookie: Pick<CookieConfigParams, 'sameSite'>;
+  transactionCookie?: Pick<CookieConfigParams, 'sameSite'>;
 
   /**
    * String value for the client's authentication method. Default is `none` when using response_type='id_token', otherwise `client_secret_basic`.


### PR DESCRIPTION
### Description

Should have been optional from the start since it defaults to `session.cookie.sameSite` (or its default), see https://github.com/auth0/express-openid-connect/commit/2f427f4ab4a3929436d2a16045add5f14a4a5aa5#diff-59cc4a3af1181865c858de26aa6d223f2c332351d061d6e6025d24fcd190bfb5R208

### References

#323 
#334 
#335 

### Testing

Covered in #323 

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
