### PR TITLE
Update the custom session store example for redis 4

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -256,10 +256,15 @@ By default the session is stored in an encrypted cookie. But when the session ge
 
 ```js
 const { auth } = require('express-openid-connect');
-const redis = require('redis');
+const { createClient } = require('redis');
 const RedisStore = require('connect-redis')(auth);
 
-const redisClient = redis.createClient();
+// redis@v4
+let redisClient = createClient({ legacyMode: true });
+redisClient.connect().catch(console.error);
+
+// redis@v3
+let redisClient = createClient();
 
 app.use(
   auth({


### PR DESCRIPTION
Updating the `redis` store example to include instructions for `redis@4` (to match https://www.npmjs.com/package/connect-redis#user-content-api)