### PR TITLE
Release v2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v2.7.2](https://github.com/auth0/express-openid-connect/tree/v2.7.2) (2022-03-29)
+[Full Changelog](https://github.com/auth0/express-openid-connect/compare/v2.7.1...v2.7.2)
+
+**Security**
+- URL Redirection to Untrusted Site ('Open Redirect') in express-openid-connect [GHSA-7p99-3798-f85c](https://github.com/auth0/express-openid-connect/security/advisories/GHSA-7p99-3798-f85c)
+
 ## [v2.7.1](https://github.com/auth0/express-openid-connect/tree/v2.7.1) (2022-02-24)
 [Full Changelog](https://github.com/auth0/express-openid-connect/compare/v2.7.0...v2.7.1)
 

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -2953,7 +2953,7 @@ npm <span class="hljs-built_in">test</span></code></pre>
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L811">index.d.ts:811</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L811">index.d.ts:811</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2984,7 +2984,7 @@ app.get(<span class="hljs-string">&#x27;/&#x27;</span>, attemptSilentLogin(), <s
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L711">index.d.ts:711</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L711">index.d.ts:711</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3034,7 +3034,7 @@ app.get(<span class="hljs-string">&#x27;/&#x27;</span>, <span class="hljs-functi
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L791">index.d.ts:791</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L791">index.d.ts:791</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3091,7 +3091,7 @@ app.get(<span class="hljs-string">&#x27;/admin/community&#x27;</span>, claimChec
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L752">index.d.ts:752</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L752">index.d.ts:752</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3134,7 +3134,7 @@ app.get(<span class="hljs-string">&#x27;/admin&#x27;</span>, claimEquals(<span c
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L772">index.d.ts:772</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L772">index.d.ts:772</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3177,7 +3177,7 @@ app.get(<span class="hljs-string">&#x27;/admin/delete&#x27;</span>, claimInclude
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L733">index.d.ts:733</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L733">index.d.ts:733</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2954,7 +2954,7 @@ npm <span class="hljs-built_in">test</span></code></pre>
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L811">index.d.ts:811</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L811">index.d.ts:811</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2985,7 +2985,7 @@ app.get(<span class="hljs-string">&#x27;/&#x27;</span>, attemptSilentLogin(), <s
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L711">index.d.ts:711</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L711">index.d.ts:711</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3035,7 +3035,7 @@ app.get(<span class="hljs-string">&#x27;/&#x27;</span>, <span class="hljs-functi
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L791">index.d.ts:791</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L791">index.d.ts:791</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3092,7 +3092,7 @@ app.get(<span class="hljs-string">&#x27;/admin/community&#x27;</span>, claimChec
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L752">index.d.ts:752</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L752">index.d.ts:752</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3135,7 +3135,7 @@ app.get(<span class="hljs-string">&#x27;/admin&#x27;</span>, claimEquals(<span c
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L772">index.d.ts:772</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L772">index.d.ts:772</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -3178,7 +3178,7 @@ app.get(<span class="hljs-string">&#x27;/admin/delete&#x27;</span>, claimInclude
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L733">index.d.ts:733</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L733">index.d.ts:733</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/__global.express.request.html
+++ b/docs/interfaces/__global.express.request.html
@@ -2764,7 +2764,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">oidc<span class="tsd-signature-symbol">:</span> <a href="requestcontext.html" class="tsd-signature-type">RequestContext</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L184">index.d.ts:184</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L184">index.d.ts:184</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/interfaces/__global.express.response.html
+++ b/docs/interfaces/__global.express.response.html
@@ -2764,7 +2764,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">oidc<span class="tsd-signature-symbol">:</span> <a href="responsecontext.html" class="tsd-signature-type">ResponseContext</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L188">index.d.ts:188</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L188">index.d.ts:188</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/interfaces/accesstoken.html
+++ b/docs/interfaces/accesstoken.html
@@ -2842,7 +2842,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">access_<wbr>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L644">index.d.ts:644</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L644">index.d.ts:644</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2857,7 +2857,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">expires_<wbr>in<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L654">index.d.ts:654</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L654">index.d.ts:654</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2872,7 +2872,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">is<wbr>Expired<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L659">index.d.ts:659</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L659">index.d.ts:659</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2902,7 +2902,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">token_<wbr>type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L649">index.d.ts:649</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L649">index.d.ts:649</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2924,7 +2924,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L671">index.d.ts:671</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L671">index.d.ts:671</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/configparams.html
+++ b/docs/interfaces/configparams.html
@@ -2938,7 +2938,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">after<wbr>Callback<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><a href="openidrequest.html" class="tsd-signature-type">OpenidRequest</a>, res<span class="tsd-signature-symbol">: </span><a href="openidresponse.html" class="tsd-signature-type">OpenidResponse</a>, session<span class="tsd-signature-symbol">: </span><a href="session.html" class="tsd-signature-type">Session</a>, decodedState<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{}</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="session.html" class="tsd-signature-type">Session</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> | </span><a href="session.html" class="tsd-signature-type">Session</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L398">index.d.ts:398</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L398">index.d.ts:398</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3000,7 +3000,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">attempt<wbr>Silent<wbr>Login<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L361">index.d.ts:361</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L361">index.d.ts:361</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3020,7 +3020,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">auth0<wbr>Logout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L262">index.d.ts:262</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L262">index.d.ts:262</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3035,7 +3035,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">auth<wbr>Required<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L436">index.d.ts:436</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L436">index.d.ts:436</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3050,7 +3050,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">authorization<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AuthorizationParameters</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L309">index.d.ts:309</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L309">index.d.ts:309</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3094,7 +3094,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">baseURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L320">index.d.ts:320</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L320">index.d.ts:320</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3110,7 +3110,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">client<wbr>Auth<wbr>Method<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L473">index.d.ts:473</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L473">index.d.ts:473</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3125,7 +3125,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">clientID<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L326">index.d.ts:326</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L326">index.d.ts:326</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3141,7 +3141,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">client<wbr>Secret<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L333">index.d.ts:333</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L333">index.d.ts:333</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3158,7 +3158,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">clock<wbr>Tolerance<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L339">index.d.ts:339</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L339">index.d.ts:339</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3174,7 +3174,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">enable<wbr>Telemetry<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L345">index.d.ts:345</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L345">index.d.ts:345</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3190,7 +3190,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">error<wbr>OnRequired<wbr>Auth<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L351">index.d.ts:351</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L351">index.d.ts:351</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3206,7 +3206,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">get<wbr>Login<wbr>State<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><a href="openidrequest.html" class="tsd-signature-type">OpenidRequest</a>, options<span class="tsd-signature-symbol">: </span><a href="loginoptions.html" class="tsd-signature-type">LoginOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">object</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L379">index.d.ts:379</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L379">index.d.ts:379</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3256,7 +3256,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">http<wbr>Timeout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L483">index.d.ts:483</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L483">index.d.ts:483</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3271,7 +3271,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">http<wbr>User<wbr>Agent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L488">index.d.ts:488</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L488">index.d.ts:488</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3286,7 +3286,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">id<wbr>Token<wbr>Signing<wbr>Alg<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L419">index.d.ts:419</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L419">index.d.ts:419</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3301,7 +3301,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">identity<wbr>Claim<wbr>Filter<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L409">index.d.ts:409</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L409">index.d.ts:409</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3317,7 +3317,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">idp<wbr>Logout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L414">index.d.ts:414</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L414">index.d.ts:414</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3332,7 +3332,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">issuer<wbr>BaseURL<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L425">index.d.ts:425</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L425">index.d.ts:425</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3348,7 +3348,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">legacy<wbr>Same<wbr>Site<wbr>Cookie<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L431">index.d.ts:431</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L431">index.d.ts:431</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3364,7 +3364,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">logout<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L314">index.d.ts:314</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L314">index.d.ts:314</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3387,7 +3387,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">routes<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>callback<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span>login<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol">; </span>logout<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol">; </span>postLogoutRedirect<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L441">index.d.ts:441</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L441">index.d.ts:441</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3441,7 +3441,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">secret<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Array</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L252">index.d.ts:252</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L252">index.d.ts:252</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3459,7 +3459,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">session<span class="tsd-signature-symbol">:</span> <a href="sessionconfigparams.html" class="tsd-signature-type">SessionConfigParams</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L257">index.d.ts:257</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L257">index.d.ts:257</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3474,7 +3474,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">token<wbr>Endpoint<wbr>Params<span class="tsd-signature-symbol">:</span> <a href="tokenparameters.html" class="tsd-signature-type">TokenParameters</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L478">index.d.ts:478</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L478">index.d.ts:478</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -3489,7 +3489,7 @@ CLIENT_SECRET=YOUR_CLIENT_SECRET</code></pre>
 				<div class="tsd-signature tsd-kind-icon">transaction<wbr>Cookie<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><a href="cookieconfigparams.html" class="tsd-signature-type">CookieConfigParams</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">"sameSite"</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L468">index.d.ts:468</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L468">index.d.ts:468</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/cookieconfigparams.html
+++ b/docs/interfaces/cookieconfigparams.html
@@ -2841,7 +2841,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">domain<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L604">index.d.ts:604</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L604">index.d.ts:604</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2857,7 +2857,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">http<wbr>Only<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L623">index.d.ts:623</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L623">index.d.ts:623</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2874,7 +2874,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">path<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L610">index.d.ts:610</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L610">index.d.ts:610</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2890,7 +2890,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">same<wbr>Site<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L637">index.d.ts:637</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L637">index.d.ts:637</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2907,7 +2907,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">secure<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L630">index.d.ts:630</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L630">index.d.ts:630</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2924,7 +2924,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">transient<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L616">index.d.ts:616</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L616">index.d.ts:616</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/loginoptions.html
+++ b/docs/interfaces/loginoptions.html
@@ -2836,7 +2836,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">authorization<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">AuthorizationParameters</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L200">index.d.ts:200</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L200">index.d.ts:200</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2851,7 +2851,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L205">index.d.ts:205</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L205">index.d.ts:205</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2866,7 +2866,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">silent<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L210">index.d.ts:210</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L210">index.d.ts:210</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/logoutoptions.html
+++ b/docs/interfaces/logoutoptions.html
@@ -2832,7 +2832,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">logout<wbr>Params<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L225">index.d.ts:225</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L225">index.d.ts:225</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2855,7 +2855,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">return<wbr>To<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L220">index.d.ts:220</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L220">index.d.ts:220</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/openidrequest.html
+++ b/docs/interfaces/openidrequest.html
@@ -3504,7 +3504,7 @@ app.get(<span class="hljs-string">&#x27;/profile&#x27;</span>, <span class="hljs
 				<div class="tsd-signature tsd-kind-icon">oidc<span class="tsd-signature-symbol">:</span> <a href="requestcontext.html" class="tsd-signature-type">RequestContext</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L44">index.d.ts:44</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L44">index.d.ts:44</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/openidresponse.html
+++ b/docs/interfaces/openidresponse.html
@@ -3346,10 +3346,10 @@ app.get(<span class="hljs-string">&#x27;/login&#x27;</span>, <span class="hljs-f
 						<p>Send JSON response.</p>
 					</div>
 					<p>Examples:</p>
-					<pre><code><span class="hljs-selector-tag">res</span><span class="hljs-selector-class">.json</span>(null);
-<span class="hljs-selector-tag">res</span><span class="hljs-selector-class">.json</span>({ <span class="hljs-attribute">user</span>: <span class="hljs-string">&#x27;tj&#x27;</span> });
-<span class="hljs-selector-tag">res</span><span class="hljs-selector-class">.status</span>(<span class="hljs-number">500</span>)<span class="hljs-selector-class">.json</span>(<span class="hljs-string">&#x27;oh noes!&#x27;</span>);
-<span class="hljs-selector-tag">res</span><span class="hljs-selector-class">.status</span>(<span class="hljs-number">404</span>)<span class="hljs-selector-class">.json</span>(<span class="hljs-string">&#x27;I dont have that&#x27;</span>);</code></pre>
+					<pre><code>res.json(<span class="hljs-keyword">null</span>);
+res.json({ <span class="hljs-keyword">user</span>: <span class="hljs-string">&#x27;tj&#x27;</span> });
+res.status(<span class="hljs-number">500</span>).json(<span class="hljs-string">&#x27;oh noes!&#x27;</span>);
+res.status(<span class="hljs-number">404</span>).json(<span class="hljs-string">&#x27;I dont have that&#x27;</span>);</code></pre>
 				</div>
 			</section>
 			<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface tsd-is-inherited">
@@ -3390,7 +3390,7 @@ app.get(<span class="hljs-string">&#x27;/login&#x27;</span>, <span class="hljs-f
 				<div class="tsd-signature tsd-kind-icon">oidc<span class="tsd-signature-symbol">:</span> <a href="responsecontext.html" class="tsd-signature-type">ResponseContext</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L65">index.d.ts:65</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L65">index.d.ts:65</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/refreshparams.html
+++ b/docs/interfaces/refreshparams.html
@@ -2821,7 +2821,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">token<wbr>Endpoint<wbr>Params<span class="tsd-signature-symbol">:</span> <a href="tokenparameters.html" class="tsd-signature-type">TokenParameters</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L675">index.d.ts:675</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L675">index.d.ts:675</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/interfaces/requestcontext.html
+++ b/docs/interfaces/requestcontext.html
@@ -2864,7 +2864,7 @@ app.get(<span class="hljs-string">&#x27;/profile&#x27;</span>, <span class="hljs
 				<div class="tsd-signature tsd-kind-icon">access<wbr>Token<span class="tsd-signature-symbol">:</span> <a href="accesstoken.html" class="tsd-signature-type">AccessToken</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L99">index.d.ts:99</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L99">index.d.ts:99</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2880,7 +2880,7 @@ app.get(<span class="hljs-string">&#x27;/profile&#x27;</span>, <span class="hljs
 				<div class="tsd-signature tsd-kind-icon">id<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L92">index.d.ts:92</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L92">index.d.ts:92</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2896,7 +2896,7 @@ app.get(<span class="hljs-string">&#x27;/profile&#x27;</span>, <span class="hljs
 				<div class="tsd-signature tsd-kind-icon">id<wbr>Token<wbr>Claims<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">IdTokenClaims</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L111">index.d.ts:111</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L111">index.d.ts:111</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2911,7 +2911,7 @@ app.get(<span class="hljs-string">&#x27;/profile&#x27;</span>, <span class="hljs
 				<div class="tsd-signature tsd-kind-icon">is<wbr>Authenticated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L85">index.d.ts:85</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L85">index.d.ts:85</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2941,7 +2941,7 @@ app.get(<span class="hljs-string">&#x27;/profile&#x27;</span>, <span class="hljs
 				<div class="tsd-signature tsd-kind-icon">refresh<wbr>Token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L106">index.d.ts:106</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L106">index.d.ts:106</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2957,7 +2957,7 @@ app.get(<span class="hljs-string">&#x27;/profile&#x27;</span>, <span class="hljs
 				<div class="tsd-signature tsd-kind-icon">user<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L117">index.d.ts:117</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L117">index.d.ts:117</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2980,7 +2980,7 @@ app.get(<span class="hljs-string">&#x27;/profile&#x27;</span>, <span class="hljs
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L132">index.d.ts:132</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L132">index.d.ts:132</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/responsecontext.html
+++ b/docs/interfaces/responsecontext.html
@@ -2838,7 +2838,7 @@ app.get(<span class="hljs-string">&#x27;/admin-login&#x27;</span>, <span class="
 				<div class="tsd-signature tsd-kind-icon">login<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>opts<span class="tsd-signature-symbol">?: </span><a href="loginoptions.html" class="tsd-signature-type">LoginOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L163">index.d.ts:163</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L163">index.d.ts:163</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2883,7 +2883,7 @@ app.get(<span class="hljs-string">&#x27;/admin-login&#x27;</span>, <span class="
 				<div class="tsd-signature tsd-kind-icon">logout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>opts<span class="tsd-signature-symbol">?: </span><a href="logoutoptions.html" class="tsd-signature-type">LogoutOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L175">index.d.ts:175</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L175">index.d.ts:175</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/session.html
+++ b/docs/interfaces/session.html
@@ -2853,7 +2853,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">access_<wbr>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L18">index.d.ts:18</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L18">index.d.ts:18</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2863,7 +2863,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">expires_<wbr>at<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L21">index.d.ts:21</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L21">index.d.ts:21</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2873,7 +2873,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">id_<wbr>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L17">index.d.ts:17</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L17">index.d.ts:17</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2888,7 +2888,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">refresh_<wbr>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L19">index.d.ts:19</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L19">index.d.ts:19</a></li>
 					</ul>
 				</aside>
 			</section>
@@ -2898,7 +2898,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">token_<wbr>type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L20">index.d.ts:20</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L20">index.d.ts:20</a></li>
 					</ul>
 				</aside>
 			</section>

--- a/docs/interfaces/sessionconfigparams.html
+++ b/docs/interfaces/sessionconfigparams.html
@@ -2852,7 +2852,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">absolute<wbr>Duration<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L591">index.d.ts:591</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L591">index.d.ts:591</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2870,7 +2870,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">cookie<span class="tsd-signature-symbol">:</span> <a href="cookieconfigparams.html" class="tsd-signature-type">CookieConfigParams</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L596">index.d.ts:596</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L596">index.d.ts:596</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2885,7 +2885,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">genid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><a href="openidrequest.html" class="tsd-signature-type">OpenidRequest</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L567">index.d.ts:567</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L567">index.d.ts:567</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2926,7 +2926,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">name<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L548">index.d.ts:548</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L548">index.d.ts:548</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2943,7 +2943,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">rolling<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L576">index.d.ts:576</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L576">index.d.ts:576</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2962,7 +2962,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">rolling<wbr>Duration<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L583">index.d.ts:583</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L583">index.d.ts:583</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2979,7 +2979,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">store<span class="tsd-signature-symbol">:</span> <a href="sessionstore.html" class="tsd-signature-type">SessionStore</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L557">index.d.ts:557</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L557">index.d.ts:557</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sessionstore.html
+++ b/docs/interfaces/sessionstore.html
@@ -2837,7 +2837,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L534">index.d.ts:534</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L534">index.d.ts:534</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2886,7 +2886,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L517">index.d.ts:517</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L517">index.d.ts:517</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">
@@ -2938,7 +2938,7 @@ img {
 					<li class="tsd-description">
 						<aside class="tsd-sources">
 							<ul>
-								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L525">index.d.ts:525</a></li>
+								<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L525">index.d.ts:525</a></li>
 							</ul>
 						</aside>
 						<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sessionstorepayload.html
+++ b/docs/interfaces/sessionstorepayload.html
@@ -2825,7 +2825,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <a href="session.html" class="tsd-signature-type">Session</a></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L510">index.d.ts:510</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L510">index.d.ts:510</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-comment tsd-typography">
@@ -2840,7 +2840,7 @@ img {
 				<div class="tsd-signature tsd-kind-icon">header<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span>exp<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>iat<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span>uat<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> }</span></div>
 				<aside class="tsd-sources">
 					<ul>
-						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/bdf968f/index.d.ts#L492">index.d.ts:492</a></li>
+						<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/0947b92/index.d.ts#L492">index.d.ts:492</a></li>
 					</ul>
 				</aside>
 				<div class="tsd-type-declaration">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-openid-connect",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-openid-connect",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Express middleware to protect web applications using OpenID Connect.",
   "homepage": "https://github.com/auth0/express-openid-connect",
   "license": "MIT",


### PR DESCRIPTION
**Security**
- URL Redirection to Untrusted Site ('Open Redirect') in express-openid-connect [GHSA-7p99-3798-f85c](https://github.com/auth0/express-openid-connect/security/advisories/GHSA-7p99-3798-f85c)
