### PR TITLE
Allow periods in cookie name

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -40,7 +40,7 @@ const paramsSchema = Joi.object({
       .optional()
       .default(7 * 24 * 60 * 60), // 7 days,
     name: Joi.string()
-      .pattern(/^[0-9a-zA-Z_-]+$/, { name: 'cookie name' })
+      .pattern(/^[0-9a-zA-Z_.-]+$/, { name: 'cookie name' })
       .optional()
       .default('appSession'),
     store: Joi.object().optional(),

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -212,6 +212,7 @@ describe('get config', () => {
       'my_session',
       '__Host-mysession',
       'mySession123',
+      'my.session',
     ];
     const invalidNames = [
       'my session',


### PR DESCRIPTION
### Description
Similar to https://github.com/auth0/express-openid-connect/pull/330, this PR relaxes the validation on the cookie name by allowing `.`s. As per https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes, this should be allowed.

I stumbled into this issue migrating over from `express-session`, which uses [`connect.sid` as the default cookie name](https://github.com/expressjs/session/blob/5df613c481bc7c5979aeaeac691b64ef0a5c4948/README.md#name). I saw that https://github.com/auth0/express-openid-connect/pull/330 relaxed this to allow for `-`, so figured I'd do the same for `.`.

### References
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#attributes

### Testing
Added a new `my.session` value to test against in the test setup provided by https://github.com/auth0/express-openid-connect/pull/330.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
