### PR TITLE
discovery errors should be handled in express middleware

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -179,50 +179,52 @@ class ResponseContext {
   async login(options = {}) {
     let { config, req, res, next, transient } = weakRef(this);
     next = cb(next).once();
-    const client = await getClient(config);
-
-    // Set default returnTo value, allow passed-in options to override or use originalUrl on GET
-    let returnTo = config.baseURL;
-    if (options.returnTo) {
-      returnTo = options.returnTo;
-      debug('req.oidc.login() called with returnTo: %s', returnTo);
-    } else if (req.method === 'GET' && req.originalUrl) {
-      // Collapse any leading slashes to a single slash to prevent Open Redirects
-      returnTo = req.originalUrl.replace(/^\/+/, '/');
-      debug('req.oidc.login() without returnTo, using: %s', returnTo);
-    }
-
-    options = {
-      authorizationParams: {},
-      returnTo,
-      ...options,
-    };
-
-    // Ensure a redirect_uri, merge in configuration options, then passed-in options.
-    options.authorizationParams = {
-      redirect_uri: this.getRedirectUri(),
-      ...config.authorizationParams,
-      ...options.authorizationParams,
-    };
-
-    const stateValue = await config.getLoginState(req, options);
-    if (typeof stateValue !== 'object') {
-      next(new Error('Custom state value must be an object.'));
-    }
-    stateValue.nonce = transient.generateNonce();
-    if (options.silent) {
-      stateValue.attemptingSilentLogin = true;
-    }
-
-    const usePKCE = options.authorizationParams.response_type.includes('code');
-    if (usePKCE) {
-      debug(
-        'response_type includes code, the authorization request will use PKCE'
-      );
-      stateValue.code_verifier = transient.generateCodeVerifier();
-    }
-
     try {
+      const client = await getClient(config);
+
+      // Set default returnTo value, allow passed-in options to override or use originalUrl on GET
+      let returnTo = config.baseURL;
+      if (options.returnTo) {
+        returnTo = options.returnTo;
+        debug('req.oidc.login() called with returnTo: %s', returnTo);
+      } else if (req.method === 'GET' && req.originalUrl) {
+        // Collapse any leading slashes to a single slash to prevent Open Redirects
+        returnTo = req.originalUrl.replace(/^\/+/, '/');
+        debug('req.oidc.login() without returnTo, using: %s', returnTo);
+      }
+
+      options = {
+        authorizationParams: {},
+        returnTo,
+        ...options,
+      };
+
+      // Ensure a redirect_uri, merge in configuration options, then passed-in options.
+      options.authorizationParams = {
+        redirect_uri: this.getRedirectUri(),
+        ...config.authorizationParams,
+        ...options.authorizationParams,
+      };
+
+      const stateValue = await config.getLoginState(req, options);
+      if (typeof stateValue !== 'object') {
+        next(new Error('Custom state value must be an object.'));
+      }
+      stateValue.nonce = transient.generateNonce();
+      if (options.silent) {
+        stateValue.attemptingSilentLogin = true;
+      }
+
+      const usePKCE = options.authorizationParams.response_type.includes(
+        'code'
+      );
+      if (usePKCE) {
+        debug(
+          'response_type includes code, the authorization request will use PKCE'
+        );
+        stateValue.code_verifier = transient.generateCodeVerifier();
+      }
+
       const validResponseTypes = ['id_token', 'code id_token', 'code'];
       assert(
         validResponseTypes.includes(options.authorizationParams.response_type),
@@ -275,31 +277,31 @@ class ResponseContext {
   async logout(params = {}) {
     let { config, req, res, next } = weakRef(this);
     next = cb(next).once();
-    const client = await getClient(config);
-
     let returnURL = params.returnTo || config.routes.postLogoutRedirect;
     debug('req.oidc.logout() with return url: %s', returnURL);
 
-    if (url.parse(returnURL).host === null) {
-      returnURL = urlJoin(config.baseURL, returnURL);
-    }
-
-    cancelSilentLogin(req, res);
-
-    if (!req.oidc.isAuthenticated()) {
-      debug('end-user already logged out, redirecting to %s', returnURL);
-      return res.redirect(returnURL);
-    }
-
-    const { idToken: id_token_hint } = req.oidc;
-    req[config.session.name] = undefined;
-
-    if (!config.idpLogout) {
-      debug('performing a local only logout, redirecting to %s', returnURL);
-      return res.redirect(returnURL);
-    }
-
     try {
+      const client = await getClient(config);
+
+      if (url.parse(returnURL).host === null) {
+        returnURL = urlJoin(config.baseURL, returnURL);
+      }
+
+      cancelSilentLogin(req, res);
+
+      if (!req.oidc.isAuthenticated()) {
+        debug('end-user already logged out, redirecting to %s', returnURL);
+        return res.redirect(returnURL);
+      }
+
+      const { idToken: id_token_hint } = req.oidc;
+      req[config.session.name] = undefined;
+
+      if (!config.idpLogout) {
+        debug('performing a local only logout, redirecting to %s', returnURL);
+        return res.redirect(returnURL);
+      }
+
       returnURL = client.endSessionUrl({
         ...config.logoutParams,
         ...params.logoutParams,

--- a/test/setup.js
+++ b/test/setup.js
@@ -7,22 +7,22 @@ let warn;
 
 beforeEach(function () {
   warn = sinon.stub(global.console, 'warn');
-  nock('https://op.example.com', { allowUnmocked: true })
+  nock('https://op.example.com')
     .persist()
     .get('/.well-known/openid-configuration')
     .reply(200, wellKnown);
 
-  nock('https://op.example.com', { allowUnmocked: true })
+  nock('https://op.example.com')
     .persist()
     .get('/.well-known/jwks.json')
     .reply(200, certs.jwks);
 
-  nock('https://test.eu.auth0.com', { allowUnmocked: true })
+  nock('https://test.eu.auth0.com')
     .persist()
     .get('/.well-known/openid-configuration')
     .reply(200, { ...wellKnown, end_session_endpoint: undefined });
 
-  nock('https://test.eu.auth0.com', { allowUnmocked: true })
+  nock('https://test.eu.auth0.com')
     .persist()
     .get('/.well-known/jwks.json')
     .reply(200, certs.jwks);


### PR DESCRIPTION
### Description

`getClient` starts the issuer discovery which can fail due to network conditions.

Move `getClient` into the `try ... catch` block so any discovery errors it throws can be caught and handled in Express mw

(Best to look at this PR with "ignore whitespace")

### References

fixes #370 
https://expressjs.com/en/guide/error-handling.html#catching-errors

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`
