### PR TITLE
Add documentation for baseURL Paths

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -318,6 +318,16 @@ interface ConfigParams {
   /**
    * REQUIRED. The root URL for the application router, eg https://localhost
    * Can use env key BASE_URL instead.
+   *
+   * Note: In the event that the URL has a path
+   * at the end the `auth` middleware will need to be bound relative to that path. I.e
+   *
+   * ```js
+   * app.use('/some/path', auth({
+   *  baseURL: "https://example.com/some/path"
+   *  [...]
+   * })
+   * ```
    */
   baseURL?: string;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -319,7 +319,7 @@ interface ConfigParams {
    * REQUIRED. The root URL for the application router, eg https://localhost
    * Can use env key BASE_URL instead.
    *
-   * Note: In the event that the URL has a path at the end the `auth` middleware
+   * Note: In the event that the URL has a path at the end, the `auth` middleware
    * will need to be bound relative to that path. I.e
    *
    * ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -319,8 +319,8 @@ interface ConfigParams {
    * REQUIRED. The root URL for the application router, eg https://localhost
    * Can use env key BASE_URL instead.
    *
-   * Note: In the event that the URL has a path
-   * at the end the `auth` middleware will need to be bound relative to that path. I.e
+   * Note: In the event that the URL has a path at the end the `auth` middleware
+   * will need to be bound relative to that path. I.e
    *
    * ```js
    * app.use('/some/path', auth({


### PR DESCRIPTION
### Description

This PR follows from #390 and adds some extra documentation to make the usage of BaseURL slightly more clearer.


### References
- #390 

### Testing
The change should only be documentation (No active code changes)

# Further Notes
I could not run `typedoc` without it picking up things from it being my fork / using the incorrect commit hash. I can commit the changed `.html` files if that would be preferable? 

Thanks for looking at this!

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
