### PR TITLE
[SDK-3717] Add cookie prop to support more express-session stores

### DIFF
--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -223,6 +223,10 @@ module.exports = (config) => {
         await this._set(req[REGENERATED_SESSION_ID] || id, {
           header: { iat, uat, exp },
           data: req[sessionName],
+          cookie: {
+            expires: exp * 1000,
+            maxAge: exp * 1000 - Date.now(),
+          },
         });
       }
     }


### PR DESCRIPTION
### Description

Add `cookie.expires` and `cookie.maxAge` to the stored session store session to support express-session stores that rely on this prop. (eg `redis-connect`)

### References

fixes #345 

### Testing

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
