### PR TITLE
Adding client id to _auth_verification cookie key to support multiple…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -477,7 +477,7 @@ interface ConfigParams {
   /**
    * Configuration parameters used for the transaction cookie.
    */
-  transactionCookie?: Pick<CookieConfigParams, 'sameSite'>;
+  transactionCookie?: Pick<CookieConfigParams, 'sameSite'> & { name?: string };
 
   /**
    * String value for the client's authentication method. Default is `none` when using response_type='id_token', `private_key_jwt` when using a `clientAssertionSigningKey`, otherwise `client_secret_basic`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -85,6 +85,7 @@ const paramsSchema = Joi.object({
       .valid('Lax', 'Strict', 'None')
       .optional()
       .default(Joi.ref('...session.cookie.sameSite')),
+    name: Joi.string().optional().default('auth_verification'),
   })
     .default()
     .unknown(false),

--- a/lib/context.js
+++ b/lib/context.js
@@ -252,7 +252,7 @@ class ResponseContext {
         );
       }
 
-      transient.store('auth_verification.' + config.clientID, req, res, {
+      transient.store(config.transactionCookie.name, req, res, {
         sameSite:
           options.authorizationParams.response_mode === 'form_post'
             ? 'None'

--- a/lib/context.js
+++ b/lib/context.js
@@ -58,13 +58,8 @@ function tokenSet() {
   const cachedTokenSet = weakRef(session);
 
   if (!('value' in cachedTokenSet)) {
-    const {
-      id_token,
-      access_token,
-      refresh_token,
-      token_type,
-      expires_at,
-    } = session;
+    const { id_token, access_token, refresh_token, token_type, expires_at } =
+      session;
     cachedTokenSet.value = new TokenSet({
       id_token,
       access_token,
@@ -215,9 +210,8 @@ class ResponseContext {
         stateValue.attemptingSilentLogin = true;
       }
 
-      const usePKCE = options.authorizationParams.response_type.includes(
-        'code'
-      );
+      const usePKCE =
+        options.authorizationParams.response_type.includes('code');
       if (usePKCE) {
         debug(
           'response_type includes code, the authorization request will use PKCE'
@@ -258,7 +252,7 @@ class ResponseContext {
         );
       }
 
-      transient.store('auth_verification', req, res, {
+      transient.store('auth_verification.' + config.clientID, req, res, {
         sameSite:
           options.authorizationParams.response_mode === 'form_post'
             ? 'None'

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -89,7 +89,7 @@ const auth = function (params) {
           try {
             const callbackParams = client.callbackParams(req);
             const authVerification = transient.getOnce(
-              'auth_verification.' + config.clientID,
+              config.transactionCookie.name,
               req,
               res
             );

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -89,7 +89,7 @@ const auth = function (params) {
           try {
             const callbackParams = client.callbackParams(req);
             const authVerification = transient.getOnce(
-              'auth_verification',
+              'auth_verification.' + config.clientID,
               req,
               res
             );

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -287,7 +287,7 @@ describe('callback response_mode: form_post', () => {
         legacySameSiteCookie: false,
       },
       cookies: {
-        ['_auth_verification.' + clientID]: JSON.stringify({
+        ['_auth_verification.']: JSON.stringify({
           state: '__test_state__',
         }),
       },

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -30,8 +30,8 @@ const defaultConfig = {
 };
 let server;
 
-const generateCookies = (values) => ({
-  auth_verification: JSON.stringify(values),
+const generateCookies = (values, clientID) => ({
+  ['auth_verification.' + clientID]: JSON.stringify(values),
 });
 
 const setup = async (params) => {
@@ -145,10 +145,13 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: generateCookies({
-        nonce: '__test_nonce__',
-        state: '__test_state__',
-      }),
+      cookies: generateCookies(
+        {
+          nonce: '__test_nonce__',
+          state: '__test_state__',
+        },
+        clientID
+      ),
       body: true,
     });
     assert.equal(statusCode, 400);
@@ -179,10 +182,13 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: generateCookies({
-        nonce: '__test_nonce__',
-        state: '__valid_state__',
-      }),
+      cookies: generateCookies(
+        {
+          nonce: '__test_nonce__',
+          state: '__valid_state__',
+        },
+        clientID
+      ),
       body: {
         state: '__invalid_state__',
       },
@@ -198,10 +204,13 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: generateCookies({
-        nonce: '__test_nonce__',
-        state: '__test_state__',
-      }),
+      cookies: generateCookies(
+        {
+          nonce: '__test_nonce__',
+          state: '__test_state__',
+        },
+        clientID
+      ),
       body: {
         state: '__test_state__',
         id_token: '__invalid_token__',
@@ -221,10 +230,13 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: generateCookies({
-        nonce: '__test_nonce__',
-        state: '__test_state__',
-      }),
+      cookies: generateCookies(
+        {
+          nonce: '__test_nonce__',
+          state: '__test_state__',
+        },
+        clientID
+      ),
       body: {
         state: '__test_state__',
         id_token: jose.JWT.sign({ sub: '__test_sub__' }, 'secret', {
@@ -243,10 +255,13 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: generateCookies({
-        nonce: '__test_nonce__',
-        state: '__test_state__',
-      }),
+      cookies: generateCookies(
+        {
+          nonce: '__test_nonce__',
+          state: '__test_state__',
+        },
+        clientID
+      ),
       body: {
         state: '__test_state__',
         id_token: makeIdToken({ iss: undefined }),
@@ -263,9 +278,12 @@ describe('callback response_mode: form_post', () => {
         body: { err },
       },
     } = await setup({
-      cookies: generateCookies({
-        state: '__test_state__',
-      }),
+      cookies: generateCookies(
+        {
+          state: '__test_state__',
+        },
+        clientID
+      ),
       body: {
         state: '__test_state__',
         id_token: makeIdToken(),
@@ -287,7 +305,9 @@ describe('callback response_mode: form_post', () => {
         legacySameSiteCookie: false,
       },
       cookies: {
-        _auth_verification: JSON.stringify({ state: '__test_state__' }),
+        ['_auth_verification.' + clientID]: JSON.stringify({
+          state: '__test_state__',
+        }),
       },
       body: {
         state: '__test_state__',
@@ -324,7 +344,7 @@ describe('callback response_mode: form_post', () => {
         identityClaimFilter: [],
       },
       cookies: {
-        _auth_verification: JSON.stringify({
+        ['_auth_verification.' + clientID]: JSON.stringify({
           state: expectedDefaultState,
           nonce: '__test_nonce__',
         }),
@@ -343,10 +363,13 @@ describe('callback response_mode: form_post', () => {
       authOpts: {
         identityClaimFilter: [],
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: makeIdToken(),
@@ -366,10 +389,13 @@ describe('callback response_mode: form_post', () => {
       currentUser,
       tokens,
     } = await setup({
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -408,10 +434,13 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -446,10 +475,13 @@ describe('callback response_mode: form_post', () => {
           response_type: 'code',
         },
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -504,10 +536,13 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -588,10 +623,13 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -666,10 +704,13 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -747,10 +788,13 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -790,10 +834,13 @@ describe('callback response_mode: form_post', () => {
           scope: 'openid profile email read:reports offline_access',
         },
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -824,10 +871,13 @@ describe('callback response_mode: form_post', () => {
         },
         clientAssertionSigningKey: privateKey,
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -859,10 +909,13 @@ describe('callback response_mode: form_post', () => {
         },
         clientAuthMethod: 'client_secret_jwt',
       },
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -886,11 +939,14 @@ describe('callback response_mode: form_post', () => {
     const jar = request.jar();
     jar.setCookie('skipSilentLogin=true', baseUrl);
     await setup({
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-        skipSilentLogin: '1',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+          skipSilentLogin: '1',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: idToken,
@@ -945,10 +1001,13 @@ describe('callback response_mode: form_post', () => {
             scope: 'openid profile email',
           },
         },
-        cookies: generateCookies({
-          state: expectedDefaultState,
-          nonce: '__test_nonce__',
-        }),
+        cookies: generateCookies(
+          {
+            state: expectedDefaultState,
+            nonce: '__test_nonce__',
+          },
+          clientID
+        ),
         body: {
           state: expectedDefaultState,
           id_token: idToken,
@@ -987,10 +1046,13 @@ describe('callback response_mode: form_post', () => {
       } = await setup({
         router: auth(authOpts),
         authOpts,
-        cookies: generateCookies({
-          state: expectedDefaultState,
-          nonce: '__test_nonce__',
-        }),
+        cookies: generateCookies(
+          {
+            state: expectedDefaultState,
+            nonce: '__test_nonce__',
+          },
+          clientID
+        ),
         body: {
           state: expectedDefaultState,
           id_token: idToken,
@@ -1004,10 +1066,13 @@ describe('callback response_mode: form_post', () => {
 
   it('should replace the cookie session when a new user is logging in over an existing different user', async () => {
     const { currentSession, currentUser } = await setup({
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: makeIdToken({ sub: 'bar' }),
@@ -1024,10 +1089,13 @@ describe('callback response_mode: form_post', () => {
 
   it('should preserve the cookie session when a new user is logging in over an anonymous session', async () => {
     const { currentSession, currentUser } = await setup({
-      cookies: generateCookies({
-        state: expectedDefaultState,
-        nonce: '__test_nonce__',
-      }),
+      cookies: generateCookies(
+        {
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        },
+        clientID
+      ),
       body: {
         state: expectedDefaultState,
         id_token: makeIdToken({ sub: 'foo' }),
@@ -1047,10 +1115,13 @@ describe('callback response_mode: form_post', () => {
     });
     const { currentSession, currentUser, existingSessionCookie, jar } =
       await setup({
-        cookies: generateCookies({
-          state: expectedDefaultState,
-          nonce: '__test_nonce__',
-        }),
+        cookies: generateCookies(
+          {
+            state: expectedDefaultState,
+            nonce: '__test_nonce__',
+          },
+          clientID
+        ),
         body: {
           state: expectedDefaultState,
           id_token: makeIdToken({ sub: 'foo' }),
@@ -1084,10 +1155,13 @@ describe('callback response_mode: form_post', () => {
     });
     const { currentSession, currentUser, existingSessionCookie, jar } =
       await setup({
-        cookies: generateCookies({
-          state: expectedDefaultState,
-          nonce: '__test_nonce__',
-        }),
+        cookies: generateCookies(
+          {
+            state: expectedDefaultState,
+            nonce: '__test_nonce__',
+          },
+          clientID
+        ),
         body: {
           state: expectedDefaultState,
           id_token: makeIdToken({ sub: 'foo' }),
@@ -1122,10 +1196,13 @@ describe('callback response_mode: form_post', () => {
     });
     const { currentSession, currentUser, existingSessionCookie, jar } =
       await setup({
-        cookies: generateCookies({
-          state: expectedDefaultState,
-          nonce: '__test_nonce__',
-        }),
+        cookies: generateCookies(
+          {
+            state: expectedDefaultState,
+            nonce: '__test_nonce__',
+          },
+          clientID
+        ),
         body: {
           state: expectedDefaultState,
           id_token: makeIdToken({ sub: 'bar' }),

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -287,7 +287,7 @@ describe('callback response_mode: form_post', () => {
         legacySameSiteCookie: false,
       },
       cookies: {
-        ['_auth_verification.']: JSON.stringify({
+        ['_auth_verification']: JSON.stringify({
           state: '__test_state__',
         }),
       },

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -187,6 +187,7 @@ describe('get config', () => {
       secret: ['__test_session_secret_1__', '__test_session_secret_2__'],
       transactionCookie: {
         sameSite: 'Strict',
+        name: 'auth_verification',
       },
       session: {
         name: '__test_custom_session_name__',
@@ -247,6 +248,7 @@ describe('get config', () => {
       secret: ['__test_session_secret_1__', '__test_session_secret_2__'],
       transactionCookie: {
         sameSite: 'Lax',
+        name: 'auth_verification',
       },
     });
   });
@@ -266,6 +268,7 @@ describe('get config', () => {
       secret: ['__test_session_secret_1__', '__test_session_secret_2__'],
       transactionCookie: {
         sameSite: 'Strict',
+        name: 'auth_verification',
       },
     });
   });
@@ -276,6 +279,7 @@ describe('get config', () => {
       secret: ['__test_session_secret_1__', '__test_session_secret_2__'],
       transactionCookie: {
         sameSite: 'Strict',
+        name: 'CustomTxnCookie',
       },
       session: {
         cookie: {
@@ -288,6 +292,7 @@ describe('get config', () => {
       secret: ['__test_session_secret_1__', '__test_session_secret_2__'],
       transactionCookie: {
         sameSite: 'Strict',
+        name: 'CustomTxnCookie',
       },
     });
   });

--- a/test/login.tests.js
+++ b/test/login.tests.js
@@ -20,7 +20,8 @@ const filterRoute = (method, path) => {
 const fetchAuthCookie = (res) => {
   const cookieHeaders = res.headers['set-cookie'];
   return cookieHeaders.filter(
-    (header) => header.split('=')[0] === 'auth_verification'
+    (header) =>
+      header.split('=')[0] === 'auth_verification.' + defaultConfig.clientID
   )[0];
 };
 
@@ -32,7 +33,9 @@ const fetchFromAuthCookie = (res, cookieName) => {
   }
 
   const decodedAuthCookie = querystring.decode(authCookie);
-  const cookieValuePart = decodedAuthCookie.auth_verification
+  const cookieValuePart = decodedAuthCookie[
+    'auth_verification.' + defaultConfig.clientID
+  ]
     .split('; ')[0]
     .split('.')[0];
   const authCookieParsed = JSON.parse(cookieValuePart);


### PR DESCRIPTION
… clients on same protocol and domain.

The key("auth_verification") of the cookie storing nonce/state is problematic in cases where multiple applications share a common protocol and domain.  In that case multiple concurrent logins can conflict with the login for one app clearing the auth_verification cookie intended for the other app.  I recalled the SPA SDK used to have a similar problem and for this reason clientId was added to the key of the nonce/state storage.

To solve this the same way I've appended .CLIENT_ID to the key of the cookie storing nonce.
