### PR TITLE
Release v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v2.10.0](https://github.com/auth0/express-openid-connect/tree/v2.10.0) (2022-11-11)
+[Full Changelog](https://github.com/auth0/express-openid-connect/compare/v2.9.0...v2.10.0)
+
+**Added**
+- Add option to override transaction cookie name [\#414](https://github.com/auth0/express-openid-connect/pull/414) ([MatthewBacalakis](https://github.com/MatthewBacalakis))
+
 ## [v2.9.0](https://github.com/auth0/express-openid-connect/tree/v2.9.0) (2022-10-17)
 [Full Changelog](https://github.com/auth0/express-openid-connect/compare/v2.8.0...v2.9.0)
 

--- a/docs/functions/attemptSilentLogin.html
+++ b/docs/functions/attemptSilentLogin.html
@@ -26,7 +26,7 @@
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RequestHandler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L888">index.d.ts:888</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L888">index.d.ts:888</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/auth.html
+++ b/docs/functions/auth.html
@@ -33,7 +33,7 @@ and <a href="../interfaces/ConfigParams.html#issuerBaseURL">issuerBaseURL</a>.</
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> params: <a href="../interfaces/ConfigParams.html" class="tsd-signature-type" data-tsd-kind="Interface">ConfigParams</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RequestHandler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L788">index.d.ts:788</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L788">index.d.ts:788</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/claimCheck.html
+++ b/docs/functions/claimCheck.html
@@ -43,7 +43,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4></li></ul></li></ul></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RequestHandler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L868">index.d.ts:868</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L868">index.d.ts:868</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/claimEquals.html
+++ b/docs/functions/claimEquals.html
@@ -36,7 +36,7 @@
 </div></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RequestHandler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L829">index.d.ts:829</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L829">index.d.ts:829</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/claimIncludes.html
+++ b/docs/functions/claimIncludes.html
@@ -36,7 +36,7 @@
 </div></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RequestHandler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L849">index.d.ts:849</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L849">index.d.ts:849</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/functions/requiresAuth.html
+++ b/docs/functions/requiresAuth.html
@@ -42,7 +42,7 @@ on specific routes.</p>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4></li></ul></li></ul></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">RequestHandler</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L810">index.d.ts:810</a></li></ul></aside></li></ul></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L810">index.d.ts:810</a></li></ul></aside></li></ul></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/AccessToken.html
+++ b/docs/interfaces/AccessToken.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">AccessToken</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L717">index.d.ts:717</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L717">index.d.ts:717</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -45,14 +45,14 @@
 <div class="tsd-comment tsd-typography"><p>The access token itself, can be an opaque string, JWT, or non-JWT token.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L721">index.d.ts:721</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L721">index.d.ts:721</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="expires_in" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>expires_<wbr/>in</span><a href="#expires_in" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">expires_<wbr/>in<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 <div class="tsd-comment tsd-typography"><p>Number of seconds until the access token expires.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L731">index.d.ts:731</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L731">index.d.ts:731</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="isExpired" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>is<wbr/>Expired</span><a href="#isExpired" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">is<wbr/>Expired<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span></div>
@@ -67,14 +67,14 @@
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L736">index.d.ts:736</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L736">index.d.ts:736</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="token_type" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>token_<wbr/>type</span><a href="#token_type" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">token_<wbr/>type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>The type of access token, Usually &quot;Bearer&quot;.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L726">index.d.ts:726</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L726">index.d.ts:726</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface"><a id="refresh" class="tsd-anchor"></a>
@@ -93,7 +93,7 @@
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> params: <a href="RefreshParams.html" class="tsd-signature-type" data-tsd-kind="Interface">RefreshParams</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="AccessToken.html" class="tsd-signature-type" data-tsd-kind="Interface">AccessToken</a><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L748">index.d.ts:748</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L748">index.d.ts:748</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/ConfigParams.html
+++ b/docs/interfaces/ConfigParams.html
@@ -27,7 +27,7 @@ and <a href="ConfigParams.html#secret">secret</a> are required but can be config
 <ul class="tsd-hierarchy">
 <li><span class="target">ConfigParams</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L247">index.d.ts:247</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L247">index.d.ts:247</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -107,7 +107,7 @@ app.use(auth({
 <h5><span class="tsd-signature-symbol">[</span>key: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]: </span><span class="tsd-signature-type">any</span></h5></li></ul></li></ul></div>
 <h4 class="tsd-returns-title">Returns <a href="Session.html" class="tsd-signature-type" data-tsd-kind="Interface">Session</a><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><a href="Session.html" class="tsd-signature-type" data-tsd-kind="Interface">Session</a><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L410">index.d.ts:410</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L410">index.d.ts:410</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="attemptSilentLogin" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>attempt<wbr/>Silent<wbr/>Login</span><a href="#attemptSilentLogin" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">attempt<wbr/>Silent<wbr/>Login<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -119,21 +119,21 @@ show them a login/logout button for example.
 Default is <code>false</code></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L373">index.d.ts:373</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L373">index.d.ts:373</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="auth0Logout" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>auth0<wbr/>Logout</span><a href="#auth0Logout" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">auth0<wbr/>Logout<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
 <div class="tsd-comment tsd-typography"><p>Boolean value to enable idpLogout with an Auth0 custom domain</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L264">index.d.ts:264</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L264">index.d.ts:264</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="authRequired" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>auth<wbr/>Required</span><a href="#authRequired" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">auth<wbr/>Required<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
 <div class="tsd-comment tsd-typography"><p>Require authentication for all routes.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L448">index.d.ts:448</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L448">index.d.ts:448</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="authorizationParams" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>authorization<wbr/>Params</span><a href="#authorizationParams" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">authorization<wbr/>Params<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">AuthorizationParameters</span></div>
@@ -150,7 +150,7 @@ Default is <code>false</code></p>
 </code></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L311">index.d.ts:311</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L311">index.d.ts:311</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="baseURL" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>baseURL</span><a href="#baseURL" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">baseURL<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -162,7 +162,7 @@ will need to be bound relative to that path. I.e</p>
 </code></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L332">index.d.ts:332</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L332">index.d.ts:332</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="clientAssertionSigningAlg" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>client<wbr/>Assertion<wbr/>Signing<wbr/>Alg</span><a href="#clientAssertionSigningAlg" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">client<wbr/>Assertion<wbr/>Signing<wbr/>Alg<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">&quot;RS256&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;RS384&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;RS512&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;PS256&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;PS384&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;PS512&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;ES256&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;ES256K&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;ES384&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;ES512&quot;</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">&quot;EdDSA&quot;</span></div>
@@ -172,7 +172,7 @@ If the Authorization Server discovery document does not list <code>token_endpoin
 this property will be required.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L535">index.d.ts:535</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L535">index.d.ts:535</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="clientAssertionSigningKey" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>client<wbr/>Assertion<wbr/>Signing<wbr/>Key</span><a href="#clientAssertionSigningKey" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">client<wbr/>Assertion<wbr/>Signing<wbr/>Key<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">KeyObject</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">KeyInput</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">JSONWebKey</span></div>
@@ -188,14 +188,14 @@ this property will be required.</p>
 </code></pre>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L527">index.d.ts:527</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L527">index.d.ts:527</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="clientAuthMethod" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>client<wbr/>Auth<wbr/>Method</span><a href="#clientAuthMethod" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">client<wbr/>Auth<wbr/>Method<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>String value for the client&#39;s authentication method. Default is <code>none</code> when using response_type=&#39;id_token&#39;, <code>private_key_jwt</code> when using a <code>clientAssertionSigningKey</code>, otherwise <code>client_secret_basic</code>.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L485">index.d.ts:485</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L485">index.d.ts:485</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="clientID" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>clientID</span><a href="#clientID" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">clientID<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -203,7 +203,7 @@ this property will be required.</p>
 Can use env key CLIENT_ID instead.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L338">index.d.ts:338</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L338">index.d.ts:338</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="clientSecret" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>client<wbr/>Secret</span><a href="#clientSecret" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">client<wbr/>Secret<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -212,7 +212,7 @@ Required when requesting access tokens.
 Can use env key CLIENT_SECRET instead.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L345">index.d.ts:345</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L345">index.d.ts:345</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="clockTolerance" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>clock<wbr/>Tolerance</span><a href="#clockTolerance" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">clock<wbr/>Tolerance<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -220,7 +220,7 @@ Can use env key CLIENT_SECRET instead.</p>
 Default is 60</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L351">index.d.ts:351</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L351">index.d.ts:351</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="enableTelemetry" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>enable<wbr/>Telemetry</span><a href="#enableTelemetry" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">enable<wbr/>Telemetry<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -228,7 +228,7 @@ Default is 60</p>
 via the <code>Auth0-Client</code> header. Default is `true</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L357">index.d.ts:357</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L357">index.d.ts:357</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="errorOnRequiredAuth" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>error<wbr/>On<wbr/>Required<wbr/>Auth</span><a href="#errorOnRequiredAuth" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">error<wbr/>On<wbr/>Required<wbr/>Auth<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -236,7 +236,7 @@ via the <code>Auth0-Client</code> header. Default is `true</p>
 Default is <code>false</code></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L363">index.d.ts:363</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L363">index.d.ts:363</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="getLoginState" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>get<wbr/>Login<wbr/>State</span><a href="#getLoginState" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">get<wbr/>Login<wbr/>State<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><a href="OpenidRequest.html" class="tsd-signature-type" data-tsd-kind="Interface">OpenidRequest</a>, options<span class="tsd-signature-symbol">: </span><a href="LoginOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LoginOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">)</span></div>
@@ -270,28 +270,28 @@ app.use(auth({
 <h5>options: <a href="LoginOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LoginOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">object</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L391">index.d.ts:391</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L391">index.d.ts:391</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="httpTimeout" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>http<wbr/>Timeout</span><a href="#httpTimeout" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">http<wbr/>Timeout<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
 <div class="tsd-comment tsd-typography"><p>Http timeout for oidc client requests in milliseconds.  Default is 5000.   Minimum is 500.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L556">index.d.ts:556</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L556">index.d.ts:556</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="httpUserAgent" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>http<wbr/>User<wbr/>Agent</span><a href="#httpUserAgent" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">http<wbr/>User<wbr/>Agent<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>Optional User-Agent header value for oidc client requests.  Default is <code>express-openid-connect/{version}</code>.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L561">index.d.ts:561</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L561">index.d.ts:561</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="idTokenSigningAlg" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>id<wbr/>Token<wbr/>Signing<wbr/>Alg</span><a href="#idTokenSigningAlg" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">id<wbr/>Token<wbr/>Signing<wbr/>Alg<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>String value for the expected ID token algorithm. Default is &#39;RS256&#39;</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L431">index.d.ts:431</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L431">index.d.ts:431</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="identityClaimFilter" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>identity<wbr/>Claim<wbr/>Filter</span><a href="#identityClaimFilter" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">identity<wbr/>Claim<wbr/>Filter<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
@@ -299,14 +299,14 @@ app.use(auth({
 Default is <code>[&#39;aud&#39;, &#39;iss&#39;, &#39;iat&#39;, &#39;exp&#39;, &#39;nbf&#39;, &#39;nonce&#39;, &#39;azp&#39;, &#39;auth_time&#39;, &#39;s_hash&#39;, &#39;at_hash&#39;, &#39;c_hash&#39; ]</code></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L421">index.d.ts:421</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L421">index.d.ts:421</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="idpLogout" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>idp<wbr/>Logout</span><a href="#idpLogout" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">idp<wbr/>Logout<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
 <div class="tsd-comment tsd-typography"><p>Boolean value to log the user out from the identity provider on application logout. Default is <code>false</code></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L426">index.d.ts:426</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L426">index.d.ts:426</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="issuerBaseURL" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>issuer<wbr/>BaseURL</span><a href="#issuerBaseURL" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">issuer<wbr/>BaseURL<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -314,7 +314,7 @@ Default is <code>[&#39;aud&#39;, &#39;iss&#39;, &#39;iat&#39;, &#39;exp&#39;, &#
 Can use env key ISSUER_BASE_URL instead.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L437">index.d.ts:437</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L437">index.d.ts:437</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="legacySameSiteCookie" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>legacy<wbr/>Same<wbr/>Site<wbr/>Cookie</span><a href="#legacySameSiteCookie" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">legacy<wbr/>Same<wbr/>Site<wbr/>Cookie<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -322,7 +322,7 @@ Can use env key ISSUER_BASE_URL instead.</p>
 Default is true</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L443">index.d.ts:443</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L443">index.d.ts:443</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="logoutParams" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>logout<wbr/>Params</span><a href="#logoutParams" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">logout<wbr/>Params<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span>[key: <span class="tsd-signature-type">string</span>]<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span></div>
@@ -334,7 +334,7 @@ Default is true</p>
 <li class="tsd-parameter-index-signature">
 <h5><span class="tsd-signature-symbol">[</span>key: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]: </span><span class="tsd-signature-type">any</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L316">index.d.ts:316</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L316">index.d.ts:316</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="routes" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>routes</span><a href="#routes" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">routes<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span>callback<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span>    </span>login<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol">; </span><br/><span>    </span>logout<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol">; </span><br/><span>    </span>postLogoutRedirect<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span></div>
@@ -362,7 +362,7 @@ This value must be registered on the authorization server.
 The user will be redirected to this after a logout has been performed.</p>
 </div></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L453">index.d.ts:453</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L453">index.d.ts:453</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="secret" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>secret</span><a href="#secret" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">secret<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">[]</span></div>
@@ -372,28 +372,28 @@ Use a single string key or array of keys for an encrypted session cookie.
 Can use env key SECRET instead.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L254">index.d.ts:254</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L254">index.d.ts:254</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="session" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>session</span><a href="#session" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">session<span class="tsd-signature-symbol">?:</span> <a href="SessionConfigParams.html" class="tsd-signature-type" data-tsd-kind="Interface">SessionConfigParams</a></div>
 <div class="tsd-comment tsd-typography"><p>Object defining application session cookie attributes.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L259">index.d.ts:259</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L259">index.d.ts:259</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="tokenEndpointParams" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>token<wbr/>Endpoint<wbr/>Params</span><a href="#tokenEndpointParams" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">token<wbr/>Endpoint<wbr/>Params<span class="tsd-signature-symbol">?:</span> <a href="TokenParameters.html" class="tsd-signature-type" data-tsd-kind="Interface">TokenParameters</a></div>
 <div class="tsd-comment tsd-typography"><p>Additional request body properties to be sent to the <code>token_endpoint</code> during authorization code exchange or token refresh.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L551">index.d.ts:551</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L551">index.d.ts:551</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="transactionCookie" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>transaction<wbr/>Cookie</span><a href="#transactionCookie" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
-<div class="tsd-signature">transaction<wbr/>Cookie<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><a href="CookieConfigParams.html" class="tsd-signature-type" data-tsd-kind="Interface">CookieConfigParams</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;sameSite&quot;</span><span class="tsd-signature-symbol">&gt;</span></div>
+<div class="tsd-signature">transaction<wbr/>Cookie<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><a href="CookieConfigParams.html" class="tsd-signature-type" data-tsd-kind="Interface">CookieConfigParams</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">&quot;sameSite&quot;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-symbol">{ </span><br/><span>    </span>name<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span></div>
 <div class="tsd-comment tsd-typography"><p>Configuration parameters used for the transaction cookie.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L480">index.d.ts:480</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L480">index.d.ts:480</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/CookieConfigParams.html
+++ b/docs/interfaces/CookieConfigParams.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">CookieConfigParams</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L676">index.d.ts:676</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L676">index.d.ts:676</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -44,7 +44,7 @@
 Passed to the <a href="https://expressjs.com/en/api.html#res.cookie">Response cookie</a> as <code>domain</code></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L681">index.d.ts:681</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L681">index.d.ts:681</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="httpOnly" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>http<wbr/>Only</span><a href="#httpOnly" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">http<wbr/>Only<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -53,7 +53,7 @@ Passed to the <a href="https://expressjs.com/en/api.html#res.cookie">Response co
 Defaults to <code>true</code>.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L700">index.d.ts:700</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L700">index.d.ts:700</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="path" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>path</span><a href="#path" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">path<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -61,7 +61,7 @@ Defaults to <code>true</code>.</p>
 Passed to the <a href="https://expressjs.com/en/api.html#res.cookie">Response cookie</a> as <code>path</code></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L687">index.d.ts:687</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L687">index.d.ts:687</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="sameSite" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>same<wbr/>Site</span><a href="#sameSite" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">same<wbr/>Site<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -70,7 +70,7 @@ Passed to the <a href="https://expressjs.com/en/api.html#res.cookie">Response co
 Defaults to &quot;Lax&quot; but will be adjusted based on AuthorizationParameters.response_type.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L714">index.d.ts:714</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L714">index.d.ts:714</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="secure" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>secure</span><a href="#secure" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">secure<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -79,7 +79,7 @@ Passed to the <a href="https://expressjs.com/en/api.html#res.cookie">Response co
 Defaults to the protocol of <a href="ConfigParams.html#baseURL">baseURL</a>.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L707">index.d.ts:707</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L707">index.d.ts:707</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="transient" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>transient</span><a href="#transient" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">transient<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -87,7 +87,7 @@ Defaults to the protocol of <a href="ConfigParams.html#baseURL">baseURL</a>.</p>
 Default is <code>false</code></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L693">index.d.ts:693</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L693">index.d.ts:693</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/LoginOptions.html
+++ b/docs/interfaces/LoginOptions.html
@@ -23,7 +23,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">LoginOptions</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L198">index.d.ts:198</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L198">index.d.ts:198</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -43,21 +43,21 @@
 <div class="tsd-comment tsd-typography"><p>Override the default <a href="ConfigParams.html#authorizationParams">authorizationParams</a></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L202">index.d.ts:202</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L202">index.d.ts:202</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="returnTo" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>return<wbr/>To</span><a href="#returnTo" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">return<wbr/>To<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>URL to return to after login, overrides the Default is <a href="https://expressjs.com/en/4x/api.html#req.originalUrl">Request.originalUrl</a></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L207">index.d.ts:207</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L207">index.d.ts:207</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="silent" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>silent</span><a href="#silent" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">silent<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
 <div class="tsd-comment tsd-typography"><p>Used by <a href="ConfigParams.html#attemptSilentLogin">attemptSilentLogin</a> to swallow callback errors on silent login.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L212">index.d.ts:212</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L212">index.d.ts:212</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/LogoutOptions.html
+++ b/docs/interfaces/LogoutOptions.html
@@ -23,7 +23,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">LogoutOptions</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L218">index.d.ts:218</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L218">index.d.ts:218</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -47,14 +47,14 @@
 <li class="tsd-parameter-index-signature">
 <h5><span class="tsd-signature-symbol">[</span>key: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]: </span><span class="tsd-signature-type">any</span></h5></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L227">index.d.ts:227</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L227">index.d.ts:227</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="returnTo" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>return<wbr/>To</span><a href="#returnTo" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">return<wbr/>To<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>URL to returnTo after logout, overrides the Default in <a href="ConfigParams.html#routes">routes.postLogoutRedirect</a></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L222">index.d.ts:222</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L222">index.d.ts:222</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/OpenidRequest.html
+++ b/docs/interfaces/OpenidRequest.html
@@ -30,7 +30,7 @@ been extended and now includes a built in <code>oidc</code> param.</p>
 <ul class="tsd-hierarchy">
 <li><span class="target">OpenidRequest</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L42">index.d.ts:42</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L42">index.d.ts:42</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -49,7 +49,7 @@ been extended and now includes a built in <code>oidc</code> param.</p>
 </div><aside class="tsd-sources">
 <p>Overrides Request.oidc</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L46">index.d.ts:46</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L46">index.d.ts:46</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/OpenidResponse.html
+++ b/docs/interfaces/OpenidResponse.html
@@ -30,7 +30,7 @@ been extended and now includes a built in <code>oidc</code> param.</p>
 <ul class="tsd-hierarchy">
 <li><span class="target">OpenidResponse</span></li></ul></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L63">index.d.ts:63</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L63">index.d.ts:63</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -49,7 +49,7 @@ been extended and now includes a built in <code>oidc</code> param.</p>
 </div><aside class="tsd-sources">
 <p>Overrides Response.oidc</p>
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L67">index.d.ts:67</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L67">index.d.ts:67</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/RefreshParams.html
+++ b/docs/interfaces/RefreshParams.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">RefreshParams</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L751">index.d.ts:751</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L751">index.d.ts:751</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -36,7 +36,7 @@
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>token<wbr/>Endpoint<wbr/>Params</span><a href="#tokenEndpointParams" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
 <div class="tsd-signature">token<wbr/>Endpoint<wbr/>Params<span class="tsd-signature-symbol">?:</span> <a href="TokenParameters.html" class="tsd-signature-type" data-tsd-kind="Interface">TokenParameters</a></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L752">index.d.ts:752</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L752">index.d.ts:752</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/RequestContext.html
+++ b/docs/interfaces/RequestContext.html
@@ -26,7 +26,7 @@ OpenID Connect auth middleware is added to your application.</p>
 <ul class="tsd-hierarchy">
 <li><span class="target">RequestContext</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L83">index.d.ts:83</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L83">index.d.ts:83</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -54,7 +54,7 @@ OpenID Connect auth middleware is added to your application.</p>
 <p>See: <a href="https://auth0.com/docs/protocols/oidc#access-tokens">https://auth0.com/docs/protocols/oidc#access-tokens</a></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L101">index.d.ts:101</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L101">index.d.ts:101</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="idToken" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>id<wbr/>Token</span><a href="#idToken" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">id<wbr/>Token<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -62,14 +62,14 @@ OpenID Connect auth middleware is added to your application.</p>
 <p>See: <a href="https://auth0.com/docs/protocols/oidc#id-tokens">https://auth0.com/docs/protocols/oidc#id-tokens</a></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L94">index.d.ts:94</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L94">index.d.ts:94</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="idTokenClaims" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>id<wbr/>Token<wbr/>Claims</span><a href="#idTokenClaims" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">id<wbr/>Token<wbr/>Claims<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">IdTokenClaims</span></div>
 <div class="tsd-comment tsd-typography"><p>An object containing all the claims of the ID Token.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L113">index.d.ts:113</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L113">index.d.ts:113</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="isAuthenticated" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>is<wbr/>Authenticated</span><a href="#isAuthenticated" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">is<wbr/>Authenticated<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span></div>
@@ -84,7 +84,7 @@ OpenID Connect auth middleware is added to your application.</p>
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L87">index.d.ts:87</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L87">index.d.ts:87</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="refreshToken" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>refresh<wbr/>Token</span><a href="#refreshToken" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">refresh<wbr/>Token<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -92,7 +92,7 @@ OpenID Connect auth middleware is added to your application.</p>
 <p>See: <a href="https://auth0.com/docs/tokens/concepts/refresh-tokens">https://auth0.com/docs/tokens/concepts/refresh-tokens</a></p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L108">index.d.ts:108</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L108">index.d.ts:108</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="user" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>user</span><a href="#user" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">user<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">Record</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">any</span><span class="tsd-signature-symbol">&gt;</span></div>
@@ -100,7 +100,7 @@ OpenID Connect auth middleware is added to your application.</p>
 specified in <a href="ConfigParams.html#identityClaimFilter">identityClaimFilter</a> removed.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L119">index.d.ts:119</a></li></ul></aside></section></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L119">index.d.ts:119</a></li></ul></aside></section></section>
 <section class="tsd-panel-group tsd-member-group">
 <h2>Methods</h2>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface"><a id="fetchUserInfo" class="tsd-anchor"></a>
@@ -114,7 +114,7 @@ specified in <a href="ConfigParams.html#identityClaimFilter">identityClaimFilter
 </div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UserinfoResponse</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">UnknownObject</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">UnknownObject</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L134">index.d.ts:134</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L134">index.d.ts:134</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/ResponseContext.html
+++ b/docs/interfaces/ResponseContext.html
@@ -26,7 +26,7 @@ OpenID Connect auth middleware is added to your application.</p>
 <ul class="tsd-hierarchy">
 <li><span class="target">ResponseContext</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L149">index.d.ts:149</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L149">index.d.ts:149</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -61,7 +61,7 @@ login routes with custom <a href="ConfigParams.html#authorizationParams">authori
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> opts: <a href="LoginOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LoginOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L165">index.d.ts:165</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L165">index.d.ts:165</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="logout" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>logout</span><a href="#logout" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">logout<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>opts<span class="tsd-signature-symbol">?: </span><a href="LogoutOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LogoutOptions</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></div>
@@ -84,7 +84,7 @@ logout routes with custom returnTo</p>
 <h5><code class="tsd-tag ts-flagOptional">Optional</code> opts: <a href="LogoutOptions.html" class="tsd-signature-type" data-tsd-kind="Interface">LogoutOptions</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">&gt;</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L177">index.d.ts:177</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L177">index.d.ts:177</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/Session.html
+++ b/docs/interfaces/Session.html
@@ -26,7 +26,7 @@
 <h4 class="tsd-before-signature">Indexable</h4>
 <div class="tsd-signature"><span class="tsd-signature-symbol">[</span>key: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]: </span><span class="tsd-signature-type">any</span></div></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L15">index.d.ts:15</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L15">index.d.ts:15</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -46,29 +46,29 @@
 <h3 class="tsd-anchor-link"><span>access_<wbr/>token</span><a href="#access_token" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none" id="icon-anchor-a"></path><path d="M10 14a3.5 3.5 0 0 0 5 0l4 -4a3.5 3.5 0 0 0 -5 -5l-.5 .5" id="icon-anchor-b"></path><path d="M14 10a3.5 3.5 0 0 0 -5 0l-4 4a3.5 3.5 0 0 0 5 5l.5 -.5" id="icon-anchor-c"></path></svg></a></h3>
 <div class="tsd-signature">access_<wbr/>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L20">index.d.ts:20</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L20">index.d.ts:20</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="expires_at" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>expires_<wbr/>at</span><a href="#expires_at" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">expires_<wbr/>at<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L23">index.d.ts:23</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L23">index.d.ts:23</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="id_token" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>id_<wbr/>token</span><a href="#id_token" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">id_<wbr/>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 <div class="tsd-comment tsd-typography"><p>Values stored in an authentication session</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L19">index.d.ts:19</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L19">index.d.ts:19</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="refresh_token" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>refresh_<wbr/>token</span><a href="#refresh_token" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">refresh_<wbr/>token<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L21">index.d.ts:21</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L21">index.d.ts:21</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="token_type" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>token_<wbr/>type</span><a href="#token_type" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">token_<wbr/>type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L22">index.d.ts:22</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L22">index.d.ts:22</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/SessionConfigParams.html
+++ b/docs/interfaces/SessionConfigParams.html
@@ -23,7 +23,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">SessionConfigParams</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L615">index.d.ts:615</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L615">index.d.ts:615</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -50,14 +50,14 @@ Set this to <code>false</code> if you don&#39;t want an absolute duration on you
 Default is 604800 seconds (7 days).</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L668">index.d.ts:668</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L668">index.d.ts:668</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="cookie" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>cookie</span><a href="#cookie" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">cookie<span class="tsd-signature-symbol">?:</span> <a href="CookieConfigParams.html" class="tsd-signature-type" data-tsd-kind="Interface">CookieConfigParams</a></div>
 <div class="tsd-comment tsd-typography"><p>Configuration parameters used for the session cookie and transient cookies.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L673">index.d.ts:673</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L673">index.d.ts:673</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="genid" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>genid</span><a href="#genid" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">genid<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span>req<span class="tsd-signature-symbol">: </span><a href="OpenidRequest.html" class="tsd-signature-type" data-tsd-kind="Interface">OpenidRequest</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span></div>
@@ -84,7 +84,7 @@ and reduce the ability to hijack a session by guessing the session ID.</p>
 <h5>req: <a href="OpenidRequest.html" class="tsd-signature-type" data-tsd-kind="Interface">OpenidRequest</a></h5></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">string</span></h4></li></ul></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L644">index.d.ts:644</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L644">index.d.ts:644</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="name" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>name</span><a href="#name" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">name<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">string</span></div>
@@ -93,7 +93,7 @@ This value must only include letters, numbers, and underscores.
 Default is <code>appSession</code>.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L621">index.d.ts:621</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L621">index.d.ts:621</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="rolling" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>rolling</span><a href="#rolling" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">rolling<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">boolean</span></div>
@@ -104,7 +104,7 @@ regardless of activity, set this to <code>false</code>
 Default is <code>true</code>.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L653">index.d.ts:653</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L653">index.d.ts:653</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="rollingDuration" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>rolling<wbr/>Duration</span><a href="#rollingDuration" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">rolling<wbr/>Duration<span class="tsd-signature-symbol">?:</span> <span class="tsd-signature-type">number</span></div>
@@ -113,7 +113,7 @@ The amount of time for which the user must be idle for then to be logged out.
 Default is 86400 seconds (1 day).</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L660">index.d.ts:660</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L660">index.d.ts:660</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="store" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><code class="tsd-tag ts-flagOptional">Optional</code> <span>store</span><a href="#store" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">store<span class="tsd-signature-symbol">?:</span> <a href="SessionStore.html" class="tsd-signature-type" data-tsd-kind="Interface">SessionStore</a></div>
@@ -124,7 +124,7 @@ have <code>get</code>, <code>set</code> and <code>destroy</code> methods, making
 with <a href="https://github.com/expressjs/session#session-store-implementation">express-session stores</a>.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L630">index.d.ts:630</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L630">index.d.ts:630</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/SessionStore.html
+++ b/docs/interfaces/SessionStore.html
@@ -23,7 +23,7 @@
 <h4 class="tsd-before-signature">Indexable</h4>
 <div class="tsd-signature"><span class="tsd-signature-symbol">[</span>key: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]: </span><span class="tsd-signature-type">any</span></div></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L586">index.d.ts:586</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L586">index.d.ts:586</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -64,7 +64,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L607">index.d.ts:607</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L607">index.d.ts:607</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface"><a id="get" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>get</span><a href="#get" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
@@ -94,7 +94,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L590">index.d.ts:590</a></li></ul></aside></li></ul></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L590">index.d.ts:590</a></li></ul></aside></li></ul></section>
 <section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-interface"><a id="set" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>set</span><a href="#set" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <ul class="tsd-signatures tsd-kind-method tsd-parent-kind-interface">
@@ -124,7 +124,7 @@
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4></li></ul></li></ul></li></ul></div>
 <h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L598">index.d.ts:598</a></li></ul></aside></li></ul></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L598">index.d.ts:598</a></li></ul></aside></li></ul></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/SessionStorePayload.html
+++ b/docs/interfaces/SessionStorePayload.html
@@ -20,7 +20,7 @@
 <ul class="tsd-hierarchy">
 <li><span class="target">SessionStorePayload</span></li></ul></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L564">index.d.ts:564</a></li></ul></aside>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L564">index.d.ts:564</a></li></ul></aside>
 <section class="tsd-panel-group tsd-index-group">
 <section class="tsd-panel tsd-index-panel">
 <details class="tsd-index-content tsd-index-accordion" open><summary class="tsd-accordion-summary tsd-index-summary">
@@ -39,7 +39,7 @@
 <div class="tsd-comment tsd-typography"><p>The session data.</p>
 </div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L583">index.d.ts:583</a></li></ul></aside></section>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L583">index.d.ts:583</a></li></ul></aside></section>
 <section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface"><a id="header" class="tsd-anchor"></a>
 <h3 class="tsd-anchor-link"><span>header</span><a href="#header" aria-label="Permalink" class="tsd-anchor-icon"><svg class="icon icon-tabler icon-tabler-link" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><use href="#icon-anchor-a"></use><use href="#icon-anchor-b"></use><use href="#icon-anchor-c"></use></svg></a></h3>
 <div class="tsd-signature">header<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{ </span><br/><span>    </span>exp<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span><br/><span>    </span>iat<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span><br/><span>    </span>uat<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">; </span><br/><span class="tsd-signature-symbol">}</span></div>
@@ -59,7 +59,7 @@
 <div class="tsd-comment tsd-typography"><p>timestamp (in secs) when the session was last touched.</p>
 </div></li></ul></div><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L565">index.d.ts:565</a></li></ul></aside></section></section></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L565">index.d.ts:565</a></li></ul></aside></section></section></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/docs/interfaces/TokenParameters.html
+++ b/docs/interfaces/TokenParameters.html
@@ -23,7 +23,7 @@
 <h4 class="tsd-before-signature">Indexable</h4>
 <div class="tsd-signature"><span class="tsd-signature-symbol">[</span>key: <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">]: </span><span class="tsd-signature-type">unknown</span></div></section><aside class="tsd-sources">
 <ul>
-<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/231b044/index.d.ts#L755">index.d.ts:755</a></li></ul></aside></div>
+<li>Defined in <a href="https://github.com/auth0/express-openid-connect/blob/2330a68/index.d.ts#L755">index.d.ts:755</a></li></ul></aside></div>
 <div class="col-4 col-menu menu-sticky-wrap menu-highlight">
 <div class="tsd-navigation settings">
 <details class="tsd-index-accordion"><summary class="tsd-accordion-summary">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "express-openid-connect",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "express-openid-connect",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "license": "MIT",
       "dependencies": {
         "base64url": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-openid-connect",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Express middleware to protect web applications using OpenID Connect.",
   "homepage": "https://github.com/auth0/express-openid-connect",
   "license": "MIT",


### PR DESCRIPTION
**Added**
- Add option to override transaction cookie name [\#414](https://github.com/auth0/express-openid-connect/pull/414) ([MatthewBacalakis](https://github.com/MatthewBacalakis))
