### PR TITLE
Remove dependency on `cb` lib

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -1,4 +1,3 @@
-const cb = require('cb');
 const url = require('url');
 const urlJoin = require('url-join');
 const { TokenSet } = require('openid-client');
@@ -6,6 +5,7 @@ const clone = require('clone');
 const { strict: assert } = require('assert');
 
 const debug = require('./debug')('context');
+const { once } = require('./once');
 const { get: getClient } = require('./client');
 const { encodeState } = require('../lib/hooks/getLoginState');
 const { cancelSilentLogin } = require('../middleware/attemptSilentLogin');
@@ -173,7 +173,7 @@ class ResponseContext {
 
   async login(options = {}) {
     let { config, req, res, next, transient } = weakRef(this);
-    next = cb(next).once();
+    next = once(next);
     try {
       const client = await getClient(config);
 
@@ -270,7 +270,7 @@ class ResponseContext {
 
   async logout(params = {}) {
     let { config, req, res, next } = weakRef(this);
-    next = cb(next).once();
+    next = once(next);
     let returnURL = params.returnTo || config.routes.postLogoutRedirect;
     debug('req.oidc.logout() with return url: %s', returnURL);
 

--- a/lib/once.js
+++ b/lib/once.js
@@ -1,0 +1,19 @@
+/**
+ * Given a callback, return a wrapped callback that will only run once regardless of calls.
+ */
+function once(callback) {
+  let called = false;
+  let value;
+
+  return (...args) => {
+    if (!called) {
+      value = callback(...args);
+    }
+
+    called = true;
+
+    return value;
+  };
+}
+
+module.exports = { once };

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,8 +1,8 @@
 const express = require('express');
-const cb = require('cb');
 const createError = require('http-errors');
 
 const debug = require('../lib/debug')('auth');
+const { once } = require('../lib/once');
 const { get: getConfig } = require('../lib/config');
 const { get: getClient } = require('../lib/client');
 const { requiresAuth } = require('./requiresAuth');
@@ -69,7 +69,7 @@ const auth = function (params) {
         next();
       },
       async (req, res, next) => {
-        next = cb(next).once();
+        next = once(next);
 
         client =
           client ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "base64url": "^3.0.1",
-        "cb": "^0.1.0",
         "clone": "^2.1.2",
         "cookie": "^0.5.0",
         "debug": "^4.3.4",
@@ -1439,14 +1438,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
-    },
-    "node_modules/cb": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cb/-/cb-0.1.0.tgz",
-      "integrity": "sha512-0hUMrsum1Ah7EUQY7MceCcAtwTD8/cJmATmfzLDM2oYDo6Gdqfv3kLkNOX+lmbIdPgUPdooA9wD+yx0pVHVBZA==",
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/chai": {
       "version": "4.3.6",
@@ -9004,11 +8995,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
       "dev": true
-    },
-    "cb": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cb/-/cb-0.1.0.tgz",
-      "integrity": "sha512-0hUMrsum1Ah7EUQY7MceCcAtwTD8/cJmATmfzLDM2oYDo6Gdqfv3kLkNOX+lmbIdPgUPdooA9wD+yx0pVHVBZA=="
     },
     "chai": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "base64url": "^3.0.1",
-    "cb": "^0.1.0",
     "clone": "^2.1.2",
     "cookie": "^0.5.0",
     "debug": "^4.3.4",


### PR DESCRIPTION
### Description

Remove dependency on 10 year old `cb` library. The downside of the supply chain security vector of this lib (especially when used in sensitive middle ware like this) outweighs the trivial utility that `express-oidc-connect` was getting from the dependency. It was being used only to memoize callbacks in 3 locations.

### References
Closes #423 

### Testing

All unit tests passing should cover this change as it is very straight-forward. Code inspection of the `cb` lib indicated that this should behave identically.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
