### PR TITLE
Remove unused nonce and code_verifier, do not memoize Issuer.discovery

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -18,8 +18,6 @@ function sortSpaceDelimitedString(string) {
   return string.split(' ').sort().join(' ');
 }
 
-const getIssuer = memoize((issuer) => Issuer.discover(issuer));
-
 async function get(config) {
   const defaultHttpOptions = (options) => {
     options.headers = {
@@ -41,7 +39,7 @@ async function get(config) {
     (entity[custom.http_options] = defaultHttpOptions);
 
   applyHttpOptionsCustom(Issuer);
-  const issuer = await getIssuer(config.issuerBaseURL);
+  const issuer = await Issuer.discover(config.issuerBaseURL);
   applyHttpOptionsCustom(issuer);
 
   const issuerTokenAlgs = Array.isArray(

--- a/lib/context.js
+++ b/lib/context.js
@@ -205,18 +205,9 @@ class ResponseContext {
       if (typeof stateValue !== 'object') {
         next(new Error('Custom state value must be an object.'));
       }
-      stateValue.nonce = transient.generateNonce();
+
       if (options.silent) {
         stateValue.attemptingSilentLogin = true;
-      }
-
-      const usePKCE =
-        options.authorizationParams.response_type.includes('code');
-      if (usePKCE) {
-        debug(
-          'response_type includes code, the authorization request will use PKCE'
-        );
-        stateValue.code_verifier = transient.generateCodeVerifier();
       }
 
       const validResponseTypes = ['id_token', 'code id_token', 'code'];
@@ -238,13 +229,19 @@ class ResponseContext {
             }
           : undefined),
       };
+
       const authParams = {
         ...options.authorizationParams,
         ...authVerification,
       };
 
+      const usePKCE =
+        options.authorizationParams.response_type.includes('code');
       if (usePKCE) {
-        authVerification.code_verifier = transient.generateNonce();
+        debug(
+          'response_type includes code, the authorization request will use PKCE'
+        );
+        authVerification.code_verifier = transient.generateCodeVerifier();
 
         authParams.code_challenge_method = 'S256';
         authParams.code_challenge = transient.calculateCodeChallenge(

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -25,7 +25,7 @@ describe('client initialization', function () {
     });
 
     let client;
-    before(async function () {
+    beforeEach(async function () {
       client = await getClient(config);
     });
 


### PR DESCRIPTION
### Description

f8e5307e4ba3daed48549dae8ed8b14c665ea523 - Given that `nonce` and `code_verifier` are now generated directly onto `authVerification` there is no need to generate them onto `stateValue` as they are unused

e4f4e5c97e950007c02d1ce9afebdb30c4c3c959 - The return value of get is already memoized so we do not need to memoize this also. Also moves the test setup to use `beforeEach` so that the mock in the top level suite is setup before the client is created (in mocha before runs before beforeEach)


### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
