### PR TITLE
[SDK-3911] Add support for providing a custom callback route

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -75,7 +75,7 @@ Full example at [routes.js](./examples/routes.js), to run it: `npm run start:exa
 
 If you need to customize the provided login, logout, and callback routes, you can disable the default routes and write your own route handler and pass custom paths to mount the handler at that path.
 
-When overriding the callback route your should pass a `authorizationParams.redirect_uri` value on `res.oidc.login` and a `redirectUri` value on your `res.oidc.callback` call.
+When overriding the callback route you should pass a `authorizationParams.redirect_uri` value on `res.oidc.login` and a `redirectUri` value on your `res.oidc.callback` call.
 
 ```js
 app.use(
@@ -104,13 +104,13 @@ app.get('/custom-logout', (req, res) => res.send('Bye!'));
 
 app.get('/callback', (req, res) =>
   res.oidc.callback({
-    redirect_uri: 'http://localhost:3000/callback',
+    redirectUri: 'http://localhost:3000/callback',
   })
 );
 
 app.post('/callback', express.urlencoded({ extended: false }), (req, res) =>
   res.oidc.callback({
-    redirect_uri: 'http://localhost:3000/callback',
+    redirectUri: 'http://localhost:3000/callback',
   })
 );
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -73,7 +73,9 @@ Full example at [routes.js](./examples/routes.js), to run it: `npm run start:exa
 
 ## 3. Route customization
 
-If you need to customize the provided login and logout routes, you can disable the default routes and write your own route handler and pass custom paths to mount the handler at that path:
+If you need to customize the provided login, logout, and callback routes, you can disable the default routes and write your own route handler and pass custom paths to mount the handler at that path.
+
+When overriding the callback route your should pass a `authorizationParams.redirect_uri` value on `res.oidc.login` and a `redirectUri` value on your `res.oidc.callback` call.
 
 ```js
 app.use(
@@ -84,13 +86,33 @@ app.use(
       // Pass a custom path to redirect users to a different
       // path after logout.
       postLogoutRedirect: '/custom-logout',
+      // Override the default callback route to use your own callback route as shown below
     },
   })
 );
 
-app.get('/login', (req, res) => res.oidc.login({ returnTo: '/profile' }));
+app.get('/login', (req, res) =>
+  res.oidc.login({
+    returnTo: '/profile',
+    authorizationParams: {
+      redirect_uri: 'http://localhost:3000/callback',
+    },
+  })
+);
 
 app.get('/custom-logout', (req, res) => res.send('Bye!'));
+
+app.get('/callback', (req, res) =>
+  res.oidc.callback({
+    redirect_uri: 'http://localhost:3000/callback',
+  })
+);
+
+app.post('/callback', express.urlencoded({ extended: false }), (req, res) =>
+  res.oidc.callback({
+    redirect_uri: 'http://localhost:3000/callback',
+  })
+);
 
 module.exports = app;
 ```

--- a/examples/custom-routes.js
+++ b/examples/custom-routes.js
@@ -13,6 +13,7 @@ app.use(
       // Pass a custom path to the postLogoutRedirect to redirect users to a different
       // path after login, this should be registered on your authorization server.
       postLogoutRedirect: '/custom-logout',
+      callback: false,
     },
   })
 );
@@ -23,8 +24,27 @@ app.get('/profile', requiresAuth(), (req, res) =>
   res.send(`hello ${req.oidc.user.sub}`)
 );
 
-app.get('/login', (req, res) => res.oidc.login({ returnTo: '/profile' }));
+app.get('/login', (req, res) =>
+  res.oidc.login({
+    returnTo: '/profile',
+    authorizationParams: {
+      redirect_uri: 'http://localhost:3000/callback',
+    },
+  })
+);
 
 app.get('/custom-logout', (req, res) => res.send('Bye!'));
+
+app.get('/callback', (req, res) =>
+  res.oidc.callback({
+    redirect_uri: 'http://localhost:3000/callback',
+  })
+);
+
+app.post('/callback', express.urlencoded({ extended: false }), (req, res) =>
+  res.oidc.callback({
+    redirect_uri: 'http://localhost:3000/callback',
+  })
+);
 
 module.exports = app;

--- a/examples/custom-routes.js
+++ b/examples/custom-routes.js
@@ -37,13 +37,13 @@ app.get('/custom-logout', (req, res) => res.send('Bye!'));
 
 app.get('/callback', (req, res) =>
   res.oidc.callback({
-    redirect_uri: 'http://localhost:3000/callback',
+    redirectUri: 'http://localhost:3000/callback',
   })
 );
 
 app.post('/callback', express.urlencoded({ extended: false }), (req, res) =>
   res.oidc.callback({
-    redirect_uri: 'http://localhost:3000/callback',
+    redirectUri: 'http://localhost:3000/callback',
   })
 );
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -175,6 +175,18 @@ interface ResponseContext {
    * ```
    */
   logout: (opts?: LogoutOptions) => Promise<void>;
+
+  /**
+   * Provided by default via the `/callback` route. Call this to override or have other
+   * callback routes with
+   *
+   * ```js
+   * app.get('/callback', (req, res) => {
+   *  res.oidc.callback({ redirectUri: 'https://example.com/callback' });
+   * });
+   * ```
+   */
+  callback: (opts?: CallbackOptions) => Promise<void>;
 }
 
 /**
@@ -197,7 +209,9 @@ declare global {
  */
 interface LoginOptions {
   /**
-   * Override the default {@link ConfigParams.authorizationParams authorizationParams}
+   * Override the default {@link ConfigParams.authorizationParams authorizationParams}, if also passing a custom callback
+   * route then  {@link AuthorizationParameters.redirect_uri redirect_uri} must be provided here or in
+   * {@link ConfigParams.authorizationParams config}
    */
   authorizationParams?: AuthorizationParameters;
 
@@ -225,6 +239,19 @@ interface LogoutOptions {
    * Additional custom parameters to pass to the logout endpoint.
    */
   logoutParams?: { [key: string]: any };
+}
+
+interface CallbackOptions {
+  /**
+   * This is useful to specify in addition to {@link ConfigParams.baseURL} when your app runs on multiple domains,
+   * it should match {@link LoginOptions.authorizationParams.redirect_uri}
+   */
+  redirectUri: string;
+
+  /**
+   * Additional request body properties to be sent to the `token_endpoint.
+   */
+  tokenEndpointParams?: TokenParameters;
 }
 
 /**

--- a/lib/config.js
+++ b/lib/config.js
@@ -194,7 +194,10 @@ const paramsSchema = Joi.object({
       Joi.string().uri({ relativeOnly: true }),
       Joi.boolean().valid(false),
     ]).default('/logout'),
-    callback: Joi.string().uri({ relativeOnly: true }).default('/callback'),
+    callback: Joi.alternatives([
+      Joi.string().uri({ relativeOnly: true }),
+      Joi.boolean().valid(false),
+    ]).default('/callback'),
     postLogoutRedirect: Joi.string().uri({ allowRelative: true }).default(''),
   })
     .default()

--- a/lib/context.js
+++ b/lib/context.js
@@ -3,13 +3,21 @@ const urlJoin = require('url-join');
 const { TokenSet } = require('openid-client');
 const clone = require('clone');
 const { strict: assert } = require('assert');
+const createError = require('http-errors');
 
 const debug = require('./debug')('context');
 const { once } = require('./once');
 const { get: getClient } = require('./client');
-const { encodeState } = require('../lib/hooks/getLoginState');
-const { cancelSilentLogin } = require('../middleware/attemptSilentLogin');
+const { encodeState, decodeState } = require('../lib/hooks/getLoginState');
+const {
+  cancelSilentLogin,
+  resumeSilentLogin,
+} = require('../middleware/attemptSilentLogin');
 const weakRef = require('./weakCache');
+const {
+  regenerateSessionStoreId,
+  replaceSession,
+} = require('../lib/appSession');
 
 function isExpired() {
   return tokenSet.call(this).expired();
@@ -160,7 +168,9 @@ class ResponseContext {
 
   getRedirectUri() {
     const { config } = weakRef(this);
-    return urlJoin(config.baseURL, config.routes.callback);
+    if (config.routes.callback) {
+      return urlJoin(config.baseURL, config.routes.callback);
+    }
   }
 
   silentLogin(options = {}) {
@@ -305,6 +315,77 @@ class ResponseContext {
 
     debug('logging out of identity provider, redirecting to %s', returnURL);
     res.redirect(returnURL);
+  }
+
+  async callback(options = {}) {
+    let { config, req, res, transient, next } = weakRef(this);
+    next = once(next);
+    try {
+      const client = await getClient(config);
+      const redirectUri = options.redirectUri || this.getRedirectUri();
+
+      let tokenSet;
+      try {
+        const callbackParams = client.callbackParams(req);
+        const authVerification = transient.getOnce(
+          config.transactionCookie.name,
+          req,
+          res
+        );
+
+        const checks = authVerification ? JSON.parse(authVerification) : {};
+
+        req.openidState = decodeState(checks.state);
+
+        tokenSet = await client.callback(redirectUri, callbackParams, checks, {
+          exchangeBody: {
+            ...(config && config.tokenEndpointParams),
+            ...options.tokenEndpointParams,
+          },
+        });
+      } catch (error) {
+        throw createError(400, error.message, {
+          error: error.error,
+          error_description: error.error_description,
+        });
+      }
+
+      let session = Object.assign({}, tokenSet); // Remove non-enumerable methods from the TokenSet
+
+      if (config.afterCallback) {
+        session = await config.afterCallback(
+          req,
+          res,
+          session,
+          req.openidState
+        );
+      }
+
+      if (req.oidc.isAuthenticated()) {
+        if (req.oidc.user.sub === tokenSet.claims().sub) {
+          // If it's the same user logging in again, just update the existing session.
+          Object.assign(req[config.session.name], session);
+        } else {
+          // If it's a different user, replace the session to remove any custom user
+          // properties on the session
+          replaceSession(req, session, config);
+          // And regenerate the session id so the previous user wont know the new user's session id
+          regenerateSessionStoreId(req, config);
+        }
+      } else {
+        // If a new user is replacing an anonymous session, update the existing session to keep
+        // any anonymous session state (eg. checkout basket)
+        Object.assign(req[config.session.name], session);
+        // But update the session store id so a previous anonymous user wont know the new user's session id
+        regenerateSessionStoreId(req, config);
+      }
+      resumeSilentLogin(req, res);
+    } catch (err) {
+      if (!req.openidState || !req.openidState.attemptingSilentLogin) {
+        return next(err);
+      }
+    }
+    res.redirect(req.openidState.returnTo || config.baseURL);
   }
 }
 

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -1206,11 +1206,6 @@ describe('callback response_mode: form_post', () => {
       },
     };
     const router = auth(config);
-    router.get('/callback', (req, res) => {
-      res.oidc.callback({
-        redirectUri: 'http://localhost:3000/callback',
-      });
-    });
 
     router.post('/callback', (req, res) => {
       res.set('foo', 'bar');

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -1197,4 +1197,41 @@ describe('callback response_mode: form_post', () => {
     );
     assert.notEqual(existingSessionCookie.value, newSessionCookie.value);
   });
+
+  it('should allow custom callback route', async () => {
+    const config = {
+      ...defaultConfig,
+      routes: {
+        callback: false,
+      },
+    };
+    const router = auth(config);
+    router.get('/callback', (req, res) => {
+      res.oidc.callback({
+        redirectUri: 'http://localhost:3000/callback',
+      });
+    });
+
+    router.post('/callback', (req, res) => {
+      res.set('foo', 'bar');
+      res.oidc.callback({
+        redirectUri: 'http://localhost:3000/callback',
+      });
+    });
+
+    const {
+      response: { headers },
+    } = await setup({
+      router,
+      cookies: generateCookies({
+        state: expectedDefaultState,
+        nonce: '__test_nonce__',
+      }),
+      body: {
+        state: expectedDefaultState,
+        id_token: makeIdToken(),
+      },
+    });
+    assert.equal(headers.foo, 'bar');
+  });
 });


### PR DESCRIPTION
### Description

Adds support for providing a custom callback route similar to the existing support for a custom login and logout route. When providing this route, the `login` route should always be provided so that the `authorizationParams.redirect_uri` value can be provided as this can no longer be inferred from config/defaults. 

The options for this accept a `tokenEndpointParams` that is the same as the existing config option of `tokenEndpointParams`, just with the added benefit that these can be configured per request not just once for the app.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
