### PR TITLE
[SDK-3887] Always honor auth0Logout config

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -105,10 +105,11 @@ async function get(config) {
   applyHttpOptionsCustom(client);
   client[custom.clock_tolerance] = config.clockTolerance;
 
-  if (config.idpLogout && !issuer.end_session_endpoint) {
+  if (config.idpLogout) {
     if (
       config.auth0Logout ||
-      url.parse(issuer.issuer).hostname.match('\\.auth0\\.com$')
+      (url.parse(issuer.issuer).hostname.match('\\.auth0\\.com$') &&
+        config.auth0Logout !== false)
     ) {
       Object.defineProperty(client, 'endSessionUrl', {
         value(params) {
@@ -130,7 +131,7 @@ async function get(config) {
           return url.format(parsedUrl);
         },
       });
-    } else {
+    } else if (!issuer.end_session_endpoint) {
       debug('the issuer does not support RP-Initiated Logout');
     }
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -93,7 +93,7 @@ const paramsSchema = Joi.object({
   })
     .default()
     .unknown(false),
-  auth0Logout: Joi.boolean().optional().default(false),
+  auth0Logout: Joi.boolean().optional(),
   tokenEndpointParams: Joi.object().optional(),
   authorizationParams: Joi.object({
     response_type: Joi.string()

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -86,12 +86,12 @@ describe('get config', () => {
     });
   });
 
-  it('auth0Logout and idpLogout should default to false', () => {
+  it('auth0Logout should default to undefined and idpLogout should default to false', () => {
     const config = getConfig(defaultConfig);
     assert.include(config, {
-      auth0Logout: false,
       idpLogout: false,
     });
+    assert.isUndefined(config.auth0Logout);
   });
 
   it('should not set auth0Logout to true when idpLogout is true', () => {
@@ -100,9 +100,9 @@ describe('get config', () => {
       idpLogout: true,
     });
     assert.include(config, {
-      auth0Logout: false,
       idpLogout: true,
     });
+    assert.isUndefined(config.auth0Logout);
   });
 
   it('should set default route paths', () => {


### PR DESCRIPTION
### Description

The OIDC RP Initiated Logout endpoint is incompatible with Auth0's proprietary logout. Make sure this SDK does not use it if `auth0Logout` is configured and an `end_session_endpoint` is Discovered in the OIDC Discovery document.

### Testing

If `auth0Logout` is true -> use v2/logout regardless of discovery
If `auth0Logout` is false -> use discovered endpoint or nothing
If `auth0Logout` is not set -> use v2/logout if issuer is `auth0.com` else discovered endpoint if available

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
