### PR TITLE
[SDK-3873] Discovery cache max age

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -581,6 +581,11 @@ interface ConfigParams {
   tokenEndpointParams?: TokenParameters;
 
   /**
+   * Maximum time (in milliseconds) to wait before fetching the Identity Provider's Discovery document again. Default is 600000 (10 minutes).
+   */
+  discoveryCacheMaxAge?: number;
+
+  /**
    * Http timeout for oidc client requests in milliseconds.  Default is 5000.   Minimum is 500.
    */
   httpTimeout?: number;

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,4 @@
 const { Issuer, custom } = require('openid-client');
-const memoize = require('p-memoize');
 const url = require('url');
 const urlJoin = require('url-join');
 const pkg = require('../package.json');
@@ -138,4 +137,20 @@ async function get(config) {
   return client;
 }
 
-exports.get = memoize(get);
+const cache = new Map();
+let timestamp = 0;
+
+exports.get = (config) => {
+  const { discoveryCacheMaxAge: cacheMaxAge } = config;
+  const now = Date.now();
+  if (cache.has(config) && now < timestamp + cacheMaxAge) {
+    return cache.get(config);
+  }
+  timestamp = now;
+  const promise = get(config).catch((e) => {
+    cache.delete(config);
+    throw e;
+  });
+  cache.set(config, promise);
+  return promise;
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -255,6 +255,10 @@ const paramsSchema = Joi.object({
       'EdDSA'
     )
     .optional(),
+  discoveryCacheMaxAge: Joi.number()
+    .optional()
+    .min(0)
+    .default(10 * 60 * 1000),
   httpTimeout: Joi.number().optional().min(500).default(5000),
   httpUserAgent: Joi.string().optional(),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "jose": "^2.0.6",
         "on-headers": "^1.0.2",
         "openid-client": "^4.9.1",
-        "p-memoize": "^4.0.4",
         "url-join": "^4.0.1"
       },
       "devDependencies": {
@@ -4789,17 +4788,6 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
-    "node_modules/map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dependencies": {
-        "p-defer": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/map-obj": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -4967,14 +4955,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/mimic-response": {
@@ -6114,14 +6094,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/p-finally": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -6135,6 +6107,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -6187,49 +6160,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-memoize": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.4.tgz",
-      "integrity": "sha512-ijdh0DP4Mk6J4FXlOM6vPPoCjPytcEseW8p/k5SDTSSfGV3E9bpt9Yzfifvzp6iohIieoLTkXRb32OWV0fB2Lw==",
-      "dependencies": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.0.0",
-        "p-settle": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/p-memoize?sponsor=1"
-      }
-    },
-    "node_modules/p-reflect": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-2.1.0.tgz",
-      "integrity": "sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/p-settle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.1.1.tgz",
-      "integrity": "sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==",
-      "dependencies": {
-        "p-limit": "^2.2.2",
-        "p-reflect": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -12222,14 +12157,6 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
-    "map-age-cleaner": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "requires": {
-        "p-defer": "^1.0.0"
-      }
-    },
     "map-obj": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
@@ -12346,11 +12273,6 @@
       "requires": {
         "mime-db": "1.52.0"
       }
-    },
-    "mimic-fn": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-      "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -13213,11 +13135,6 @@
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
       "dev": true
     },
-    "p-defer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw=="
-    },
     "p-finally": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
@@ -13228,6 +13145,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -13261,34 +13179,11 @@
         "aggregate-error": "^3.0.0"
       }
     },
-    "p-memoize": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.4.tgz",
-      "integrity": "sha512-ijdh0DP4Mk6J4FXlOM6vPPoCjPytcEseW8p/k5SDTSSfGV3E9bpt9Yzfifvzp6iohIieoLTkXRb32OWV0fB2Lw==",
-      "requires": {
-        "map-age-cleaner": "^0.1.3",
-        "mimic-fn": "^3.0.0",
-        "p-settle": "^4.1.1"
-      }
-    },
-    "p-reflect": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-reflect/-/p-reflect-2.1.0.tgz",
-      "integrity": "sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg=="
-    },
-    "p-settle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.1.1.tgz",
-      "integrity": "sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==",
-      "requires": {
-        "p-limit": "^2.2.2",
-        "p-reflect": "^2.1.0"
-      }
-    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "package-hash": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "jose": "^2.0.6",
     "on-headers": "^1.0.2",
     "openid-client": "^4.9.1",
-    "p-memoize": "^4.0.4",
     "url-join": "^4.0.1"
   },
   "devDependencies": {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -224,4 +224,142 @@ describe('client initialization', function () {
       expect(alg).to.eq('RS384');
     });
   });
+
+  describe('client cache has max age', function () {
+    let config;
+    const mins = 60 * 1000;
+
+    this.beforeEach(() => {
+      config = getConfig({
+        secret: '__test_session_secret__',
+        clientID: '__test_cache_max_age_client_id__',
+        clientSecret: '__test_client_secret__',
+        issuerBaseURL: 'https://max-age-test.auth0.com',
+        baseURL: 'https://example.org',
+      });
+    });
+
+    it('should memoize get client call', async function () {
+      const spy = sinon.spy(() => wellKnown);
+      nock('https://max-age-test.auth0.com')
+        .persist()
+        .get('/.well-known/openid-configuration')
+        .reply(200, spy);
+
+      const client = await getClient(config);
+      await getClient(config);
+      await getClient(config);
+      expect(client.client_id).to.eq('__test_cache_max_age_client_id__');
+      expect(spy.callCount).to.eq(1);
+    });
+
+    it('should handle concurrent client calls', async function () {
+      const spy = sinon.spy(() => wellKnown);
+      nock('https://max-age-test.auth0.com')
+        .persist()
+        .get('/.well-known/openid-configuration')
+        .reply(200, spy);
+
+      await Promise.all([
+        getClient(config),
+        getClient(config),
+        getClient(config),
+      ]);
+      expect(spy.callCount).to.eq(1);
+    });
+
+    it('should make new calls for different config references', async function () {
+      const spy = sinon.spy(() => wellKnown);
+      nock('https://max-age-test.auth0.com')
+        .persist()
+        .get('/.well-known/openid-configuration')
+        .reply(200, spy);
+
+      const client = await getClient(config);
+      await getClient({ ...config });
+      await getClient({ ...config });
+      expect(client.client_id).to.eq('__test_cache_max_age_client_id__');
+      expect(spy.callCount).to.eq(3);
+    });
+
+    it('should make new calls after max age', async function () {
+      const clock = sinon.useFakeTimers({
+        now: Date.now(),
+        toFake: ['Date'],
+      });
+
+      const spy = sinon.spy(() => wellKnown);
+      nock('https://max-age-test.auth0.com')
+        .persist()
+        .get('/.well-known/openid-configuration')
+        .reply(200, spy);
+
+      const client = await getClient(config);
+      clock.tick(10 * mins + 1);
+      await getClient(config);
+      clock.tick(1 * mins);
+      await getClient(config);
+      expect(client.client_id).to.eq('__test_cache_max_age_client_id__');
+      expect(spy.callCount).to.eq(2);
+      clock.restore();
+    });
+
+    it('should honor configured max age', async function () {
+      const clock = sinon.useFakeTimers({
+        now: Date.now(),
+        toFake: ['Date'],
+      });
+
+      const spy = sinon.spy(() => wellKnown);
+      nock('https://max-age-test.auth0.com')
+        .persist()
+        .get('/.well-known/openid-configuration')
+        .reply(200, spy);
+
+      config = { ...config, discoveryCacheMaxAge: 20 * mins };
+      const client = await getClient(config);
+      clock.tick(10 * mins + 1);
+      await getClient(config);
+      expect(spy.callCount).to.eq(1);
+      clock.tick(10 * mins);
+      await getClient(config);
+      expect(client.client_id).to.eq('__test_cache_max_age_client_id__');
+      expect(spy.callCount).to.eq(2);
+      clock.restore();
+    });
+
+    it('should not cache failed discoveries', async function () {
+      const spy = sinon.spy(() => wellKnown);
+      nock('https://max-age-test.auth0.com')
+        .get('/.well-known/openid-configuration')
+        .reply(500)
+        .get('/.well-known/oauth-authorization-server')
+        .reply(500);
+      nock('https://max-age-test.auth0.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, spy);
+
+      await assert.isRejected(getClient(config));
+
+      const client = await getClient(config);
+      expect(client.client_id).to.eq('__test_cache_max_age_client_id__');
+    });
+
+    // // TODO: Confirm behaviour of failed concurrent requests
+    // it('should handle concurrent client calls with failures', async function () {
+    //   const spy = sinon.spy(() => wellKnown)
+    //   nock('https://max-age-test.auth0.com')
+    //     .get('/.well-known/openid-configuration')
+    //     .reply(500)
+    //     .get('/.well-known/oauth-authorization-server')
+    //     .reply(500);
+    //   nock('https://max-age-test.auth0.com')
+    //     .persist()
+    //     .get('/.well-known/openid-configuration')
+    //     .reply(200, spy);
+
+    //   await Promise.all([assert.isRejected(getClient(config)), getClient(config), getClient(config)]);
+    //   expect(spy.callCount).to.eq(2);
+    // });
+  });
 });


### PR DESCRIPTION
### Description

Currently the Discovery cache is in memory and permanent until the app is restarted.

Add logic to refresh it every so often so these can auto-heal if we have any bad configuration from the Discovery endpoint that is later corrected.

The default is 10mins and is configurable through the `discoveryCacheMaxAge` config (the Discovery endpoint is cached by cloudflare for 15 secs.)

