### PR TITLE
Typing fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -501,7 +501,7 @@ interface ConfigParams {
     /**
      * Relative path to the application callback to process the response from the authorization server.
      */
-    callback?: string;
+    callback?: string | false;
   };
 
   /**


### PR DESCRIPTION
As shown in [one of your examples](https://github.com/auth0/express-openid-connect/blob/master/examples/custom-routes.js#L16), the routes.callback property in the middleware should be able to be equal to `false`. However, the type definitions currently don't allow this.