### PR TITLE
Add httpAgent option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,7 @@
 // Type definitions for express-openid-connect
 
+import type { Agent as HttpAgent } from 'http';
+import type { Agent as HttpsAgent } from 'https';
 import {
   AuthorizationParameters,
   IdTokenClaims,
@@ -589,6 +591,22 @@ interface ConfigParams {
    * Http timeout for oidc client requests in milliseconds.  Default is 5000.   Minimum is 500.
    */
   httpTimeout?: number;
+
+  /**
+   * Specify an Agent or Agents to pass to the underlying http client https://github.com/sindresorhus/got/
+   *
+   * An object representing `http`, `https` and `http2` keys for [`http.Agent`](https://nodejs.org/api/http.html#http_class_http_agent),
+   * [`https.Agent`](https://nodejs.org/api/https.html#https_class_https_agent) and [`http2wrapper.Agent`](https://github.com/szmarczak/http2-wrapper#new-http2agentoptions) instance.
+   *
+   * See https://github.com/sindresorhus/got/blob/v11.8.6/readme.md#agent
+   *
+   * For a proxy agent see https://www.npmjs.com/package/proxy-agent
+   */
+  httpAgent?: {
+    http?: HttpAgent | false;
+    https?: HttpsAgent | false;
+    http2?: unknown | false;
+  };
 
   /**
    * Optional User-Agent header value for oidc client requests.  Default is `express-openid-connect/{version}`.

--- a/lib/client.js
+++ b/lib/client.js
@@ -31,6 +31,7 @@ async function get(config) {
         : undefined),
     };
     options.timeout = config.httpTimeout;
+    options.agent = config.httpAgent;
     return options;
   };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -261,6 +261,7 @@ const paramsSchema = Joi.object({
     .default(10 * 60 * 1000),
   httpTimeout: Joi.number().optional().min(500).default(5000),
   httpUserAgent: Joi.string().optional(),
+  httpAgent: Joi.object().optional(),
 });
 
 module.exports.get = function (config = {}) {


### PR DESCRIPTION
### Description

Pass the `agent` option along to the underlying http client to support managing connections, keepalive, proxies etc.

### References

https://github.com/sindresorhus/got/blob/v11.8.6/readme.md#agent