### PR TITLE
Add preLogoutMiddleware config parameter, to have custom middleware functionality before logout

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -480,6 +480,28 @@ interface ConfigParams {
   authRequired?: boolean;
 
   /**
+   * Custom middleware function that will be called before logout.
+   * This can be used for deleting application-level session from storage upon logout,
+   * notifying other services about the user's logout in a multi-service architecture, etc.
+   *
+   * ```js
+   * app.use(auth({
+   *   ...
+   *   preLogoutMiddleware: async (req, res, next) => {
+   *     const userInfo = req.oidc.user
+   *     // Use the user session before it is destroyed.
+   *     next()
+   *   }
+   * }))
+   * ``
+   */
+  preLogoutMiddleware?: (
+    req: OpenidRequest,
+    res: OpenidResponse,
+    next: Function
+  ) => Promise<void> | void;
+
+  /**
    * Configuration for the login, logout, callback and postLogoutRedirect routes.
    */
   routes?: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,9 @@ const { defaultState: getLoginState } = require('./hooks/getLoginState');
 const isHttps = /^https:/i;
 
 const defaultSessionIdGenerator = () => crypto.randomBytes(16).toString('hex');
+const defaultMiddleware = (req, res, next) => {
+  next();
+};
 
 const paramsSchema = Joi.object({
   secret: Joi.alternatives([
@@ -185,6 +188,9 @@ const paramsSchema = Joi.object({
   issuerBaseURL: Joi.string().uri().required(),
   legacySameSiteCookie: Joi.boolean().optional().default(true),
   authRequired: Joi.boolean().optional().default(true),
+  preLogoutMiddleware: Joi.function()
+    .optional()
+    .default(() => defaultMiddleware),
   routes: Joi.object({
     login: Joi.alternatives([
       Joi.string().uri({ relativeOnly: true }),

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -49,7 +49,9 @@ const auth = function (params) {
   if (config.routes.logout) {
     const path = enforceLeadingSlash(config.routes.logout);
     debug('adding GET %s route', path);
-    router.get(path, (req, res) => res.oidc.logout());
+    router.get(path, config.preLogoutMiddleware, (req, res) =>
+      res.oidc.logout()
+    );
   } else {
     debug('logout handling route not applied');
   }

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -857,4 +857,18 @@ describe('get config', () => {
       });
     }
   });
+
+  it('should get config with custom function for preLogoutMiddleware', () => {
+    const customMiddleware = (req, res, next) => {
+      console.log('pre-logout test');
+      next();
+    };
+    const config = getConfig({
+      ...defaultConfig,
+      preLogoutMiddleware: customMiddleware,
+    });
+    assert.deepInclude(config, {
+      preLogoutMiddleware: customMiddleware,
+    });
+  });
 });


### PR DESCRIPTION
### Description

Added a new config parameter `preLogoutMiddleware` to serve the purpose of defining custom functionality to be executed prior to logout.
It can provide flexibility for when users need to do some actions prior to logout that requires access to user's current session, such as removing the application session from storage, or doing some pre-logout application level validations, notifying applications in other domains to delete the session, etc.

### References

Some similar issues have been raised in the community, that may possibly be solved using this extra middleware. It still depends on the intentions of the developer, and this extra functionality could be irrelevant to their situation.

- https://community.auth0.com/t/clear-session-at-application-level-after-auth0-logout/36706
- https://community.auth0.com/t/having-trouble-on-remove-auth0-session-when-logout-from-front-end/31307
- https://community.auth0.com/t/invalidating-an-access-token-when-user-logs-out/48365
- https://community.auth0.com/t/expire-access-token-when-logout/61266/3
- https://community.auth0.com/t/how-to-expire-the-token-once-user-clicks-log-out-from-my-application/13679
- https://community.auth0.com/t/ability-to-revoke-access-token-at-logout/66682

Relevant FAQ: https://community.auth0.com/t/invalidate-api-token-after-user-logout/101398

### Testing

A new test-case for verifying config parameters when defining a custom `preLogoutMiddleware` is included in the PR.
However, no additional integration test, or end-to-end testing is included due to limited domain knowledge about this repository. It has been manually tested with a sample application using custom middleware.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs : Updated typedoc in index.d.ts
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
