### PR TITLE
Make genid async

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -696,7 +696,7 @@ interface SessionConfigParams {
    * cryptographically strong random value of sufficient size or sign the cookie
    * by setting {@Link signSessionStoreCookie} to `true`.
    */
-  genid?: (req: OpenidRequest) => string;
+  genid?: (req: OpenidRequest) => Promise<string>;
 
   /**
    * Sign the session store cookies to reduce the chance of collisions

--- a/index.d.ts
+++ b/index.d.ts
@@ -696,7 +696,7 @@ interface SessionConfigParams {
    * cryptographically strong random value of sufficient size or sign the cookie
    * by setting {@Link signSessionStoreCookie} to `true`.
    */
-  genid?: (req: OpenidRequest) => Promise<string>;
+  genid?: (req: OpenidRequest) => Promise<string> | string;
 
   /**
    * Sign the session store cookies to reduce the chance of collisions

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -33,9 +33,9 @@ function attachSessionObject(req, sessionName, value) {
   });
 }
 
-function regenerateSessionStoreId(req, config) {
+async function regenerateSessionStoreId(req, config) {
   if (config.session.store) {
-    req[REGENERATED_SESSION_ID] = config.session.genid(req);
+    req[REGENERATED_SESSION_ID] = await config.session.genid(req);
   }
 }
 
@@ -367,7 +367,7 @@ module.exports = (config) => {
     }
 
     if (isCustomStore) {
-      const id = existingSessionValue || generateId(req);
+      const id = existingSessionValue || (await generateId(req));
 
       onHeaders(res, () =>
         store.setCookie(req[REGENERATED_SESSION_ID] || id, req, res, { iat })

--- a/lib/context.js
+++ b/lib/context.js
@@ -370,14 +370,14 @@ class ResponseContext {
           // properties on the session
           replaceSession(req, session, config);
           // And regenerate the session id so the previous user wont know the new user's session id
-          regenerateSessionStoreId(req, config);
+          await regenerateSessionStoreId(req, config);
         }
       } else {
         // If a new user is replacing an anonymous session, update the existing session to keep
         // any anonymous session state (eg. checkout basket)
         Object.assign(req[config.session.name], session);
         // But update the session store id so a previous anonymous user wont know the new user's session id
-        regenerateSessionStoreId(req, config);
+        await regenerateSessionStoreId(req, config);
       }
       resumeSilentLogin(req, res);
     } catch (err) {

--- a/test/appSession.customStore.tests.js
+++ b/test/appSession.customStore.tests.js
@@ -219,7 +219,7 @@ describe('appSession custom store', () => {
   it('uses custom session id generator when provided', async () => {
     const immId = 'apple';
     await setup({
-      session: { genid: () => immId },
+      session: { genid: () => Promise.resolve(immId) },
     });
     const jar = await login({
       sub: '__foo_user__',


### PR DESCRIPTION
### Description

Turn `genid` to async in order to use async operations to generate a custom id.


### References

Linked to https://github.com/auth0/express-openid-connect/issues/463. 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
