### PR TITLE
Add loginRedirectCallback

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -226,6 +226,25 @@ interface LoginOptions {
    *  Used by {@link ConfigParams.attemptSilentLogin} to swallow callback errors on silent login.
    */
   silent?: boolean;
+
+  /**
+   * Function for custom redirect response handling.
+   * This can be used for handling login redirection response different from default 302 response
+   *
+   * ```js
+   * app.get('/login', (req, res) => {
+   *  res.oidc.login({ loginRedirectCallback: async (res, authorizationUrl) => {
+   *    res.set('x-custom-header', 'custom-header-value');
+   *    res.set('x-custom-authorization-url', authorizationUrl);
+   *    res.status(204).send();
+   *  });
+   * });
+   * ```
+   */
+  loginRedirectCallback?: (
+    res: Response,
+    authorizationUrl: string
+  ) => Promise<void>;
 }
 
 /**

--- a/lib/context.js
+++ b/lib/context.js
@@ -275,8 +275,13 @@ class ResponseContext {
       });
 
       const authorizationUrl = client.authorizationUrl(authParams);
-      debug('redirecting to %s', authorizationUrl);
-      res.redirect(authorizationUrl);
+      if (options.loginRedirectCallback) {
+        debug('calling login redirect callback with %s', authorizationUrl);
+        await options.loginRedirectCallback(res, authorizationUrl);
+      } else {
+        debug('redirecting to %s', authorizationUrl);
+        res.redirect(authorizationUrl);
+      }
     } catch (err) {
       next(err);
     }


### PR DESCRIPTION
### Description

> Some frameworks, such as Remix, after generating the first rendering of the website on the backend, use a custom navigation for the page change on the client.
> In this case, an http 302 is not possible, as it will be misinterpreted and does not correspond to the framework flow. To deal with this situation, an optional parameter in the login can be used to customize the redirect response on the authorization url.
>
> No breaking change is involved in this change, as the parameter is optional and the default flow is retained.

### References

> - [Remix redirect response handling](https://github.com/remix-run/remix/blob/main/packages/remix-server-runtime/server.ts#L140)

### Testing

> I've created an example project for testing purposes. Here's how to test it:
>

```bash
git clone https://github.com/gyx1000/remix-express-oidc-redirect
cd remix-express-oidc-redirect
npm i
#
# Configure .env with :
COOKIE_SECRET=
CLIENT_ID=
ISSUER=

npm run dev
```
>
> You can then go to http://localhost:3000 and click on the dashboard link. An error will occur, as Remix will not be able to interpret the 302 response.
> If you install the modified express-openid-connect version of the PR, the authentication process will work.

