### PR TITLE
Honor params passed to logout over defaults

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -324,9 +324,9 @@ class ResponseContext {
 
       returnURL = client.endSessionUrl({
         ...config.logoutParams,
-        ...params.logoutParams,
-        post_logout_redirect_uri: returnURL,
         id_token_hint,
+        post_logout_redirect_uri: returnURL,
+        ...params.logoutParams,
       });
     } catch (err) {
       return next(err);


### PR DESCRIPTION
### Description

Additional parameters passed to logout should override the defaults, eg

```js
router.get('/logout', (req, res) =>
      res.oidc.logout({ logoutParams: { id_token_hint: null } })
);
```

Should allow you to exclude the `id_token_hint` and force the logout prompt (or supply a `logout_hint`)

### References

fixes #530 
