### PR TITLE
use `express()` instead of `express.Router()`

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -23,7 +23,7 @@ const enforceLeadingSlash = (path) => {
 const auth = function (params) {
   const config = getConfig(params);
   debug('configuration object processed, resulting configuration: %O', config);
-  const router = new express.Router();
+  const router = new express();
   const transient = new TransientCookieHandler(config);
 
   router.use(appSession(config));

--- a/test/login.tests.js
+++ b/test/login.tests.js
@@ -63,10 +63,10 @@ describe('auth', () => {
   it('should contain the default authentication routes', async () => {
     const router = auth(defaultConfig);
     server = await createServer(router);
-    assert.ok(router.stack.some(filterRoute('GET', '/login')));
-    assert.ok(router.stack.some(filterRoute('GET', '/logout')));
-    assert.ok(router.stack.some(filterRoute('POST', '/callback')));
-    assert.ok(router.stack.some(filterRoute('GET', '/callback')));
+    assert.ok(router._router.stack.some(filterRoute('GET', '/login')));
+    assert.ok(router._router.stack.some(filterRoute('GET', '/logout')));
+    assert.ok(router._router.stack.some(filterRoute('POST', '/callback')));
+    assert.ok(router._router.stack.some(filterRoute('GET', '/callback')));
   });
 
   it('should contain custom authentication routes', async () => {
@@ -79,10 +79,14 @@ describe('auth', () => {
       },
     });
     server = await createServer(router);
-    assert.ok(router.stack.some(filterRoute('GET', '/custom-login')));
-    assert.ok(router.stack.some(filterRoute('GET', '/custom-logout')));
-    assert.ok(router.stack.some(filterRoute('POST', '/custom-callback')));
-    assert.ok(router.stack.some(filterRoute('GET', '/custom-callback')));
+    assert.ok(router._router.stack.some(filterRoute('GET', '/custom-login')));
+    assert.ok(router._router.stack.some(filterRoute('GET', '/custom-logout')));
+    assert.ok(
+      router._router.stack.some(filterRoute('POST', '/custom-callback'))
+    );
+    assert.ok(
+      router._router.stack.some(filterRoute('GET', '/custom-callback'))
+    );
   });
 
   it('should redirect to the authorize url for /login', async () => {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

When we want to integrate/use this library with other frameworks (e.g. [unjs/h3](https://github.com/unjs/h3)), we need to create an express app first than we can use this library. In this case we have to install `express` package too.
For example when using with unjs/h3
```ts
import express from "express"

const expressApp = express()
app.use(fromNodeMiddleware(expressApp.use(auth(config))))
```

If we use it like this :
```ts
app.use(fromNodeMiddleware((auth(config)))
```
Than it will throw this errors
```
/home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/express@4.18.3/node_modules/express/lib/router/layer.js:95
    fn(req, res, next);
    ^
TypeError: req.get is not a function
    at /home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/express-openid-connect@2.17.1_express@4.18.3/node_modules/express-openid-connect/lib/appSession.js:289:37
    at Layer.handle [as handle_request] (/home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/express@4.18.3/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/express@4.18.3/node_modules/express/lib/router/index.js:328:13)
    at /home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/express@4.18.3/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/express@4.18.3/node_modules/express/lib/router/index.js:346:12)
    at next (/home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/express@4.18.3/node_modules/express/lib/router/index.js:280:10)
    at Function.handle (/home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/express@4.18.3/node_modules/express/lib/router/index.js:175:3)
    at router (/home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/express@4.18.3/node_modules/express/lib/router/index.js:47:12)
    at file:///home/phonzammi/Documents/vike-dev/practices/auth0/vike-h3-auth0/node_modules/.pnpm/h3@1.11.1/node_modules/h3/dist/index.mjs:2285:24
    at new Promise (<anonymous>)
```

With this changes, we can use this library with other frameworks without having to create an express app

### Testing

I have successfully tested this changes with `fastify` and `unjs/h3`

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
