### PR TITLE
Optionally add parameters to the /login redirect to support organization member invitations

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -221,6 +221,10 @@ class ResponseContext {
         redirect_uri: this.getRedirectUri(),
         ...config.authorizationParams,
         ...options.authorizationParams,
+        // Optionally add parameters to support organization member invitations
+        ...(req.query.invitation ? { invitation: req.query.invitation } : {}),
+        ...(req.query.organization ? { organization: req.query.organization } : {}),
+        ...(req.query.organization_name ? { organization_name: req.query.organization_name } : {}),
       };
 
       const stateValue = await config.getLoginState(req, options);


### PR DESCRIPTION
When users are invited to join an organization they receive an invitation link by email. This link redirects them to the configured default login route with invitation-specific parameters appended (see below). The problem is that the express-openid-connect module does not include these parameters on the redirect url. The proposed code change resolves this issue. 

The following parameters are now (optionally) included on the default login url:
invitation
organization
organization_name