### PR TITLE
docs: document min length for secret

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -330,7 +330,7 @@ interface ConfigParams {
   /**
    * REQUIRED. The secret(s) used to derive an encryption key for the user identity in a stateless session cookie,
    * to sign the transient cookies used by the login callback and to sign the custom session store cookies if
-   * {@Link signSessionStoreCookie} is `true`. Use a single string key or array of keys.
+   * {@Link signSessionStoreCookie} is `true`. Use a single string key or array of keys. Secrets must be at least 8 characters long.
    * If an array of secrets is provided, only the first element will be used to sign or encrypt the values, while all
    * the elements will be considered when decrypting or verifying the values.
    *


### PR DESCRIPTION
Currently `secret` is documented that it must be a string, but trying a short string for testing results in a confusing message that the wrong type of value has been provided. 

The issue is that Joi is used to provided some additional undocumented constraints to some values.

By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.


### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
