### PR TITLE
fix: #624 fix calculateExp functionality

### DIFF
--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -91,9 +91,11 @@ module.exports = (config) => {
       return iat + absoluteDuration;
     }
 
-    return Math.min(
-      ...[uat + rollingDuration, iat + absoluteDuration].filter(Boolean)
-    );
+    if (!absoluteDuration) {
+      return uat + rollingDuration;
+    }
+
+    return Math.min(uat + rollingDuration, iat + absoluteDuration);
   }
 
   function setCookie(


### PR DESCRIPTION
### Description
This PR fixes the session expiry calculation in appSession.js when rolling: true and absoluteDuration: false are set in the session configuration. Previously, sessions would expire immediately due to incorrect expiry logic in the calculateExp function. Now, the session will correctly expire only after the defined rollingDuration period of inactivity.

### Changes
- Updated calculateExp to use only rollingDuration when absoluteDuration is falsy.
- No changes to tests were required; existing tests now pass with the correct logic.

### Impact

- Users with rolling: true and absoluteDuration: false will have sessions that persist for the expected rolling duration.
- No breaking changes or version bumps.

### Related Issues
Fixes session expiry bug described in #624 