### PR TITLE
fix: improve error message when transaction cookie state is missing

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -486,8 +486,7 @@ class ResponseContext {
         if (!checks.state) {
           throw new Error(
             `Missing state in the ${config.transactionCookie.name} cookie. ` +
-              'This can occur when the transaction cookie is not present in the callback request - ' +
-              'check your sameSite and secure cookie configuration.',
+              'This can occur when the transaction cookie is not present in the callback request.',
           );
         }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -483,6 +483,14 @@ class ResponseContext {
 
         const checks = authVerification ? JSON.parse(authVerification) : {};
 
+        if (!checks.state) {
+          throw new Error(
+            `Missing state in the ${config.transactionCookie.name} cookie. ` +
+              'This can occur when the transaction cookie is not present in the callback request - ' +
+              'check your sameSite and secure cookie configuration.',
+          );
+        }
+
         req.openidState = decodeState(checks.state);
 
         tokenSet = await client.callback(redirectUri, callbackParams, checks, {


### PR DESCRIPTION
### Description

Replaces the cryptic `checks.state argument is missing` error from `openid-client` with a descriptive message that identifies the affected cookie by name.

### References


### Testing
