### PR TITLE
chore: update typedoc compiler options for ESM compatibility

### DIFF
--- a/typedoc.js
+++ b/typedoc.js
@@ -5,11 +5,6 @@ module.exports = {
   excludePrivate: true,
   hideGenerator: true,
   readme: 'none',
-  compilerOptions: {
-    target: 'ES2015',
-    moduleResolution: 'bundler',
-    module: 'esnext',
-  },
   externalSymbolLinkMappings: {
     '@types/express': {
       'Request.originalUrl':

--- a/typedoc.js
+++ b/typedoc.js
@@ -5,6 +5,11 @@ module.exports = {
   excludePrivate: true,
   hideGenerator: true,
   readme: 'none',
+  compilerOptions: {
+    target: 'ES2015',
+    moduleResolution: 'bundler',
+    module: 'esnext',
+  },
   externalSymbolLinkMappings: {
     '@types/express': {
       'Request.originalUrl':


### PR DESCRIPTION
### Description

Add compilerOptions to `typedoc.js` with target: `ES2015`. 
The migration of `jose` and `openid-client` from v4 to v6 (PR #785) moved both packages to ESM-only. This caused npm run docs to fail.

- jose v6 type definitions use private class fields, which require ES2015+ as the compiler target. The previous
  default was ES5.
- Both packages now use the exports field in package.json for resolution. The old default node module resolution strategy
  predates exports field support and couldn't locate them.

### Testing

- Run `npm run docs` and inspect generated docs
