### PR TITLE
feat: add federated identity credential client authentication

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -695,9 +695,33 @@ interface ConfigParams {
   transactionCookie?: Pick<CookieConfigParams, 'sameSite'> & { name?: string };
 
   /**
-   * String value for the client's authentication method. Default is `none` when using response_type='id_token', `private_key_jwt` when using a `clientAssertionSigningKey`, otherwise `client_secret_basic`.
+   * String value for the client's authentication method. Default is `none` when using response_type='id_token', `client_assertion` when using a `clientAssertion`, `private_key_jwt` when using a `clientAssertionSigningKey`, otherwise `client_secret_basic`.
+   *
+   * Supported values: `client_secret_basic`, `client_secret_post`, `client_secret_jwt`, `private_key_jwt`, `client_assertion`, `none`.
    */
   clientAuthMethod?: string;
+
+  /**
+   * Authenticate to the token endpoint with a federated identity credential.
+   *
+   * Used with `clientAuthMethod: 'client_assertion'`. Instead of signing the
+   * client assertion locally with a private key (`private_key_jwt`), the
+   * assertion JWT is issued by a trusted external identity provider (e.g. AWS
+   * STS/IAM, GitHub Actions OIDC) and returned by this callback. It is invoked
+   * on every token endpoint request so short-lived federated tokens stay fresh.
+   *
+   * ```js
+   * app.use(auth({
+   *   ...
+   *   clientAuthMethod: 'client_assertion',
+   *   clientAssertion: async () => {
+   *     // obtain a federated token from your cloud provider, e.g. AWS STS
+   *     return getWebIdentityToken();
+   *   },
+   * }))
+   * ```
+   */
+  clientAssertion?: () => string | Promise<string>;
 
   /**
    * Private key for use with 'private_key_jwt' clients.

--- a/lib/client.js
+++ b/lib/client.js
@@ -77,6 +77,36 @@ function createCustomFetch(config) {
 }
 
 /**
+ * Builds an openid-client `ClientAuth` function that authenticates to the token
+ * endpoint with a federated identity credential.
+ *
+ * Instead of signing the client assertion locally with a private key
+ * (`private_key_jwt`), the assertion JWT is issued by a trusted external
+ * identity provider (e.g. AWS STS/IAM, GitHub Actions OIDC) and supplied by the
+ * user via the `clientAssertion` callback. The callback is invoked on every
+ * token endpoint request so that short-lived federated tokens stay fresh.
+ *
+ * @param {Function} getClientAssertion - `() => string | Promise<string>` resolving to the assertion JWT
+ * @returns {Function} openid-client ClientAuth function
+ */
+function federatedClientAssertion(getClientAssertion) {
+  return async (as, clientMetadata, body) => {
+    const assertion = await getClientAssertion();
+    if (typeof assertion !== 'string' || !assertion) {
+      throw new TypeError(
+        'The "clientAssertion" function must resolve to a non-empty string',
+      );
+    }
+    body.set('client_id', clientMetadata.client_id);
+    body.set(
+      'client_assertion_type',
+      'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+    );
+    body.set('client_assertion', assertion);
+  };
+}
+
+/**
  * Determines the client authentication method based on configuration.
  * @param {Object} config - Configuration object
  * @returns {Promise<Function>} Client authentication function
@@ -96,6 +126,8 @@ async function getClientAuth(config) {
       );
       return client.PrivateKeyJwt(privateKey);
     }
+    case 'client_assertion':
+      return federatedClientAssertion(config.clientAssertion);
     case 'none':
       return client.None();
     default:

--- a/lib/config.js
+++ b/lib/config.js
@@ -272,6 +272,7 @@ const paramsSchema = Joi.object({
       'client_secret_post',
       'client_secret_jwt',
       'private_key_jwt',
+      'client_assertion',
       'none',
     )
     .optional()
@@ -281,6 +282,9 @@ const paramsSchema = Joi.object({
         !parent.pushedAuthorizationRequests
       ) {
         return 'none';
+      }
+      if (parent.clientAssertion) {
+        return 'client_assertion';
       }
       if (parent.clientAssertionSigningKey) {
         return 'private_key_jwt';
@@ -304,6 +308,15 @@ const paramsSchema = Joi.object({
         'any.only': 'Public PAR clients are not supported.',
       }),
     }),
+  clientAssertion: Joi.function()
+    .optional()
+    .when(Joi.ref('clientAuthMethod'), {
+      is: 'client_assertion',
+      then: Joi.function().required().messages({
+        'any.required':
+          '"clientAssertion" is required for a "clientAuthMethod" of "client_assertion"',
+      }),
+    }), // () => string | Promise<string>
   clientAssertionSigningKey: Joi.any()
     .optional()
     .when(Joi.ref('clientAuthMethod'), {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -504,6 +504,111 @@ describe('client initialization', function () {
     });
   });
 
+  describe('client supports federated identity client_assertion', function () {
+    const baseConfig = {
+      secret: '__test_session_secret__',
+      clientID: '__test_client_id__',
+      issuerBaseURL: 'https://op.example.com',
+      baseURL: 'https://example.org',
+      authorizationParams: { response_type: 'code' },
+    };
+
+    // Intercepts the token endpoint and returns a closure to retrieve the
+    // client_assertion params that were sent in the request body.
+    function mockTokenEndpoint() {
+      let captured = {};
+      nock('https://op.example.com')
+        .post('/oauth/token')
+        .reply(200, function (uri, body) {
+          const params = new URLSearchParams(body);
+          captured = {
+            client_id: params.get('client_id'),
+            client_assertion_type: params.get('client_assertion_type'),
+            client_assertion: params.get('client_assertion'),
+          };
+          return { error: 'invalid_grant' };
+        });
+      return () => captured;
+    }
+
+    async function triggerTokenRequest(configuration) {
+      try {
+        await client.authorizationCodeGrant(
+          configuration,
+          new URL(
+            'https://op.example.com/callback?code=test_code&state=test_state',
+          ),
+          { expectedState: 'test_state', expectedNonce: 'test_nonce' },
+        );
+      } catch {
+        // token request failing is expected — we only care about what was sent
+      }
+    }
+
+    it('should default clientAuthMethod to client_assertion when clientAssertion is set', function () {
+      const config = getConfig({
+        ...baseConfig,
+        clientAssertion: async () => '__federated_token__',
+      });
+      assert.equal(config.clientAuthMethod, 'client_assertion');
+    });
+
+    it('should send the federated token as the client_assertion', async function () {
+      const getCaptured = mockTokenEndpoint();
+      const clientAssertion = sinon.stub().resolves('__federated_token__');
+      const config = getConfig({
+        ...baseConfig,
+        clientAuthMethod: 'client_assertion',
+        clientAssertion,
+      });
+      const { configuration } = await getClient(config);
+      await triggerTokenRequest(configuration);
+
+      sinon.assert.called(clientAssertion);
+      const captured = getCaptured();
+      assert.equal(captured.client_id, '__test_client_id__');
+      assert.equal(
+        captured.client_assertion_type,
+        'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+      );
+      assert.equal(captured.client_assertion, '__federated_token__');
+    });
+
+    it('should invoke the clientAssertion callback on each token request for fresh tokens', async function () {
+      const tokens = ['__token_1__', '__token_2__'];
+      const clientAssertion = sinon
+        .stub()
+        .callsFake(async () => tokens.shift());
+      const config = getConfig({
+        ...baseConfig,
+        clientAuthMethod: 'client_assertion',
+        clientAssertion,
+      });
+      const { configuration } = await getClient(config);
+
+      let first = mockTokenEndpoint();
+      await triggerTokenRequest(configuration);
+      assert.equal(first().client_assertion, '__token_1__');
+
+      let second = mockTokenEndpoint();
+      await triggerTokenRequest(configuration);
+      assert.equal(second().client_assertion, '__token_2__');
+    });
+
+    it('should reject when the clientAssertion callback does not resolve to a string', async function () {
+      const getCaptured = mockTokenEndpoint();
+      const config = getConfig({
+        ...baseConfig,
+        clientAuthMethod: 'client_assertion',
+        clientAssertion: async () => undefined,
+      });
+      const { configuration } = await getClient(config);
+      await triggerTokenRequest(configuration);
+      // nothing valid should have been sent
+      assert.isUndefined(getCaptured().client_assertion);
+    });
+  });
+
   describe('client cache has max age', function () {
     let config;
     const mins = 60 * 1000;

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -600,6 +600,32 @@ describe('get config', () => {
     assert.equal(getConfig(config).clientAuthMethod, 'private_key_jwt');
   });
 
+  it('should require "clientAssertion" when clientAuthMethod is "client_assertion"', () => {
+    const config = {
+      ...defaultConfig,
+      authorizationParams: {
+        response_type: 'code',
+      },
+      clientAuthMethod: 'client_assertion',
+    };
+    assert.throws(
+      () => getConfig(config),
+      TypeError,
+      '"clientAssertion" is required for a "clientAuthMethod" of "client_assertion"',
+    );
+  });
+
+  it('should default to "client_assertion" when "clientAssertion" is present', () => {
+    const config = {
+      ...defaultConfig,
+      authorizationParams: {
+        response_type: 'code',
+      },
+      clientAssertion: async () => '__token__',
+    };
+    assert.equal(getConfig(config).clientAuthMethod, 'client_assertion');
+  });
+
   it('should not allow "none" for idTokenSigningAlg', () => {
     let config = (idTokenSigningAlg) =>
       getConfig({


### PR DESCRIPTION
### Description

Our team was looking to implement Microsoft Entra ID / Azure AD authentication with `express-openid-connect` using federated identity credentials from AWS IAM roles. Documentation on this request type is available [on Microsoft's website](https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#third-case-access-token-request-with-a-federated-credential).

In this implementation, I was trying to keep things completely agnostic so any provider can be used, whether on the issuer or resource server side. This flow is very similar to the `private_key_jwt` assertion but does not require a local certificate to function.

I did use Claude Opus 4.8 to help generate this - I was not sure if AI-generated contributions are allowed in this project, so feel free to close this if not. But I figured since this was valuable to us, I would contribute it back to upstream. Happy to make tweaks as you see fit as well.

### Testing

We are using AWS's [GetWebIdentityCommand](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/client/sts/command/GetWebIdentityTokenCommand/) with [Outbound Identity Federation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_outbound_getting_started.html) enabled, and the issuer added in our Entra ID account.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
