### PR TITLE
fix: restore on-headers for session cookie to support streaming responses

### DIFF
--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -1,13 +1,18 @@
 const { strict: assert, AssertionError } = require('assert');
 const {
-  CompactEncrypt,
   compactDecrypt,
   errors: { JOSEError },
 } = require('jose');
+const onHeaders = require('on-headers');
 const safePromisify = require('./utils/promisifyCompat');
 const cookie = require('cookie');
 const COOKIES = require('./cookies');
-const { getKeyStore, verifyCookie, signCookie } = require('./crypto');
+const {
+  getKeyStore,
+  verifyCookie,
+  signCookieSync,
+  encryptSync,
+} = require('./crypto');
 const debug = require('./debug')('appSession');
 
 const { epoch } = require('./utils/epoch');
@@ -73,14 +78,6 @@ module.exports = (config) => {
   let [current, keystore] = getKeyStore(config.secret, true);
   // keystore is now an array of keys or a single key buffer
 
-  async function encrypt(payload, headers) {
-    const encoder = new TextEncoder();
-    const protectedHeader = { alg, enc, ...headers };
-    return await new CompactEncrypt(encoder.encode(payload))
-      .setProtectedHeader(protectedHeader)
-      .encrypt(current);
-  }
-
   async function decrypt(jwe) {
     let lastError;
 
@@ -124,7 +121,7 @@ module.exports = (config) => {
     return exp;
   }
 
-  async function setCookie(
+  function setCookie(
     req,
     res,
     {
@@ -133,13 +130,6 @@ module.exports = (config) => {
       exp = calculateExp(iat, uat, req[sessionName]?.sessionExpiresAt),
     },
   ) {
-    if (res.headersSent) {
-      // If headers were already flushed before res.end() the
-      // session cookie will not be persisted for this response.
-      debug('session cookie could not be set: headers already sent');
-      return;
-    }
-
     const cookies = req[COOKIES];
     const { transient: cookieTransient, ...cookieOptions } = cookieConfig;
     cookieOptions.expires = cookieTransient ? 0 : new Date(exp * 1000);
@@ -161,7 +151,7 @@ module.exports = (config) => {
         sessionName,
       );
 
-      const value = await encrypt(JSON.stringify(req[sessionName]), {
+      const value = encryptSync(JSON.stringify(req[sessionName]), current, {
         iat,
         uat,
         exp,
@@ -219,8 +209,8 @@ module.exports = (config) => {
       return req[COOKIES][sessionName];
     }
 
-    async setCookie(req, res, iat) {
-      await setCookie(req, res, iat);
+    setCookie(req, res, iat) {
+      setCookie(req, res, iat);
     }
   }
 
@@ -284,7 +274,7 @@ module.exports = (config) => {
       return req[COOKIES][sessionName];
     }
 
-    async setCookie(
+    setCookie(
       id,
       req,
       res,
@@ -294,14 +284,8 @@ module.exports = (config) => {
         exp = calculateExp(iat, uat, req[sessionName]?.sessionExpiresAt),
       },
     ) {
-      if (res.headersSent) {
-        // If headers were already flushed before res.end() the
-        // session cookie will not be persisted for this response.
-        debug('session cookie could not be set: headers already sent');
-        return;
-      }
       if (!req[sessionName] || !Object.keys(req[sessionName]).length) {
-        if (req[COOKIES][sessionName] && !res.headersSent) {
+        if (req[COOKIES][sessionName]) {
           clearCookie(sessionName, res);
         }
       } else {
@@ -312,12 +296,9 @@ module.exports = (config) => {
         delete cookieOptions.transient;
         let value = id;
         if (signSessionStoreCookie) {
-          value = await signCookie(sessionName, id, this._current);
+          value = signCookieSync(sessionName, id, this._current);
         }
-        // Check again after async operation in case headers were sent
-        if (!res.headersSent) {
-          res.cookie(sessionName, value, cookieOptions);
-        }
+        res.cookie(sessionName, value, cookieOptions);
       }
     }
   }
@@ -449,19 +430,19 @@ module.exports = (config) => {
       attachSessionObject(req, sessionName, {});
     }
 
-    const { end: origEnd } = res;
-
     if (isCustomStore) {
       const id = existingSessionValue || (await generateId(req));
 
+      onHeaders(res, () =>
+        store.setCookie(req[REGENERATED_SESSION_ID] || id, req, res, { iat }),
+      );
+
+      const { end: origEnd } = res;
       res.end = async function resEnd(...args) {
         try {
           // Persist session data first, then set cookie only if persistence succeeds.
           // This prevents sending a cookie pointing to data that was never persisted.
           await store.set(id, req, res, {
-            iat,
-          });
-          await store.setCookie(req[REGENERATED_SESSION_ID] || id, req, res, {
             iat,
           });
           origEnd.call(res, ...args);
@@ -473,15 +454,7 @@ module.exports = (config) => {
         }
       };
     } else {
-      res.end = async function resEnd(...args) {
-        try {
-          await store.setCookie(req, res, { iat });
-          origEnd.call(res, ...args);
-        } catch (e) {
-          res.end = origEnd;
-          process.nextTick(() => next(e));
-        }
-      };
+      onHeaders(res, () => store.setCookie(req, res, { iat }));
     }
 
     return next();

--- a/lib/appSession.js
+++ b/lib/appSession.js
@@ -440,8 +440,6 @@ module.exports = (config) => {
       const { end: origEnd } = res;
       res.end = async function resEnd(...args) {
         try {
-          // Persist session data first, then set cookie only if persistence succeeds.
-          // This prevents sending a cookie pointing to data that was never persisted.
           await store.set(id, req, res, {
             iat,
           });

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -47,14 +47,16 @@ const getKeyStore = (secret, forEncryption) => {
 
 const header = { alg: ALG, b64: false, crit: CRITICAL_HEADER_PARAMS };
 
+const PROTECTED_HEADER_B64 = Buffer.from(JSON.stringify(header))
+  .toString('base64')
+  .replace(/=/g, '')
+  .replace(/\+/g, '-')
+  .replace(/\//g, '_');
+
 const getPayload = (cookie, value) => Buffer.from(`${cookie}=${value}`);
 
 const flattenedJWSFromCookie = (cookie, value, signature) => ({
-  protected: Buffer.from(JSON.stringify(header))
-    .toString('base64')
-    .replace(/=/g, '')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_'),
+  protected: PROTECTED_HEADER_B64,
   payload: getPayload(cookie, value),
   signature,
 });
@@ -65,6 +67,20 @@ const generateSignature = async (cookie, value, key) => {
     .setProtectedHeader(header)
     .sign(key);
   return jws.signature;
+};
+
+const generateSignatureSync = (cookie, value, key) => {
+  const payload = getPayload(cookie, value);
+  // JWS signing input for b64:false = ASCII(protectedHeader) + '.' + payload bytes (RFC 7797)
+  const signingInput = Buffer.concat([
+    Buffer.from(PROTECTED_HEADER_B64, 'ascii'),
+    Buffer.from('.'),
+    payload,
+  ]);
+  return crypto
+    .createHmac('sha256', key)
+    .update(signingInput)
+    .digest('base64url');
 };
 
 const verifySignature = async (cookie, value, signature, keystore) => {
@@ -103,8 +119,59 @@ const signCookie = async (cookie, value, key) => {
   return `${value}.${signature}`;
 };
 
+const signCookieSync = (cookie, value, key) => {
+  const signature = generateSignatureSync(cookie, value, key);
+  return `${value}.${signature}`;
+};
+
+/**
+ * Synchronous AES-256-GCM JWE (alg=dir, enc=A256GCM) in Compact Serialization format.
+ *
+ * Produces output identical in format to jose v6 CompactEncrypt — jose v6 compactDecrypt
+ * can decrypt tokens produced by this function transparently.
+ *
+ * The JWE Compact format is five base64url segments: header..iv.ciphertext.tag
+ * The encrypted-key segment (index 1) is empty for alg=dir (key IS the CEK).
+ * AAD is the ASCII bytes of the base64url-encoded protected header (RFC 7516 §5.1 step 14).
+ *
+ * @param {string} payload   UTF-8 plaintext (typically JSON)
+ * @param {Buffer} key       32-byte AES-256 CEK (HKDF-derived)
+ * @param {object} headers   Additional fields merged into the protected header
+ * @returns {string}         JWE Compact Serialization string
+ */
+const encryptSync = (payload, key, headers) => {
+  const protectedHeader = Buffer.from(
+    JSON.stringify({ alg: 'dir', enc: 'A256GCM', ...headers }),
+  )
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+  cipher.setAAD(Buffer.from(protectedHeader, 'ascii'));
+
+  const ciphertext = Buffer.concat([
+    cipher.update(Buffer.from(payload, 'utf8')),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag(); // 16 bytes (128-bit tag) by default
+
+  const b64url = (buf) =>
+    buf
+      .toString('base64')
+      .replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+
+  return `${protectedHeader}..${b64url(iv)}.${b64url(ciphertext)}.${b64url(tag)}`;
+};
+
 module.exports.signCookie = signCookie;
+module.exports.signCookieSync = signCookieSync;
 module.exports.verifyCookie = verifyCookie;
+module.exports.encryptSync = encryptSync;
 
 module.exports.getKeyStore = getKeyStore;
 module.exports.encryption = encryption;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "http-errors": "^1.8.1",
     "joi": "^17.13.3",
     "jose": "^6.1.3",
+    "on-headers": "^1.1.0",
     "openid-client": "^6.1.3",
     "url-join": "^4.0.1",
     "util-promisify": "3.0.0"

--- a/test/appSession.customStore.tests.js
+++ b/test/appSession.customStore.tests.js
@@ -268,6 +268,8 @@ describe('appSession custom store', () => {
     assert.isTrue(
       res.headers['set-cookie'].some((c) => c.startsWith('appSession=')),
     );
+    // store.set() runs async in res.end, verify session was persisted to the store
+    assert.equal(await redisClient.asyncDbsize(), 1);
   });
 
   it('should send Set-Cookie even when store.set() fails (cookie written before persist at writeHead time)', async () => {

--- a/test/appSession.customStore.tests.js
+++ b/test/appSession.customStore.tests.js
@@ -235,6 +235,74 @@ describe('appSession custom store', () => {
     assert.equal(await redisClient.asyncDbsize(), 1);
   });
 
+  it('should write session cookie even when headers are flushed before res.end() (streaming)', async () => {
+    const { client, store } = getRedisStore();
+    redisClient = client;
+
+    const conf = getConfig({
+      ...defaultConfig,
+      session: { ...defaultConfig.session, store },
+    });
+
+    const app = express();
+    app.use(appSession(conf));
+    app.get('/stream', (req, res) => {
+      Object.assign(req.appSession, { sub: '__stream_user__' });
+      res.write('chunk');
+      res.end();
+    });
+
+    // eslint-disable-next-line no-unused-vars
+    app.use((err, req, res, next) => {
+      res.status(err.status || 500).json({ err: { message: err.message } });
+    });
+
+    server = await new Promise((resolve) => {
+      const s = app.listen(3000, () => resolve(s));
+    });
+
+    const jar = request.jar();
+    const res = await request.get('/stream', { baseUrl, jar });
+    // on-headers fires at writeHead time, so cookie must be set even for streaming responses
+    assert.property(res.headers, 'set-cookie');
+    assert.isTrue(
+      res.headers['set-cookie'].some((c) => c.startsWith('appSession=')),
+    );
+  });
+
+  it('should send Set-Cookie even when store.set() fails (cookie written before persist at writeHead time)', async () => {
+    const store = {
+      get(id, cb) {
+        process.nextTick(() => cb(null, null));
+      },
+      async set() {
+        throw new Error('storage error');
+      },
+      async destroy(id, cb) {
+        process.nextTick(() => cb());
+      },
+    };
+
+    const conf = getConfig({
+      ...defaultConfig,
+      session: { store },
+    });
+
+    server = await createServer(appSession(conf));
+
+    const jar = request.jar();
+    // Post a session to trigger a write
+    const res = await request.post('/session', {
+      baseUrl,
+      jar,
+      json: { sub: '__foo_user__' },
+    });
+    // store.set() throws → 500, but Set-Cookie was already written at writeHead time
+    // This is consistent with v2 behaviour — cookie is written before persistence
+    assert.equal(res.statusCode, 500);
+    assert.property(res.headers, 'set-cookie');
+  });
+
   it('should handle storage errors', async () => {
     const store = {
       get(id, cb) {

--- a/test/appSession.tests.js
+++ b/test/appSession.tests.js
@@ -465,27 +465,25 @@ describe('appSession', () => {
     clock.restore();
   });
 
-  it('should not write session cookie when headers are already sent before res.end()', async () => {
+  it('should write session cookie even when headers are flushed before res.end()', async () => {
     /*
-     * If headers are flushed before res.end(), the session cookie cannot be written.
-     * This can happen in several scenarios, e.g.:
-     *   - res.write() is called before res.end() (streaming/chunked responses)
-     *   - res.writeHead() or res.flushHeaders() is called explicitly
-     *   - res.sendFile() / res.download() which pipe a stream and flush headers early
-     *   - a prior middleware calls res.json() / res.send() before res.end()
+     * Session cookie is now written via on-headers (fires at writeHead time), so it is
+     * set correctly regardless of whether the response is buffered or streamed.
+     * Scenarios covered: res.write(), res.flushHeaders(), res.writeHead(), res.sendFile(),
+     * res.download(), or stream.pipe(res).
      */
     server = await createServer((req, res) => {
       appSession(getConfig(defaultConfig))(req, res, () => {
         // Modify the session so setCookie would normally write a cookie
         Object.assign(req.appSession, { sub: '__test_sub__' });
-        // Flush headers before res.end() — simulates the above scenarios
+        // Flush headers before res.end() — simulates streaming SSR and similar patterns
         res.write('chunk');
         res.end();
       });
     });
     const res = await request.get('/session', { baseUrl });
-    // Headers were already sent by res.write(), so the session cookie must not be set
-    assert.notProperty(res.headers, 'set-cookie');
+    // on-headers fires at writeHead time, so the session cookie must be set
+    assert.property(res.headers, 'set-cookie');
   });
 
   it('should throw for duplicate mw', async () => {

--- a/test/appSession.tests.js
+++ b/test/appSession.tests.js
@@ -291,6 +291,7 @@ describe('appSession', () => {
     jar.setCookie('appSession.1=bar', baseUrl);
     const res = await request.get('/session', { baseUrl, json: true, jar });
     assert.equal(res.statusCode, 200);
+    assert.isEmpty(res.body);
   });
 
   it('should set the default cookie options over http', async () => {
@@ -484,6 +485,9 @@ describe('appSession', () => {
     const res = await request.get('/session', { baseUrl });
     // on-headers fires at writeHead time, so the session cookie must be set
     assert.property(res.headers, 'set-cookie');
+    assert.isTrue(
+      res.headers['set-cookie'].some((c) => c.startsWith('appSession=')),
+    );
   });
 
   it('should throw for duplicate mw', async () => {

--- a/test/crypto.tests.js
+++ b/test/crypto.tests.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const assert = require('chai').assert;
+const crypto = require('crypto');
+const { compactDecrypt, decodeProtectedHeader } = require('jose');
+
+const {
+  encryptSync,
+  signCookieSync,
+  verifyCookie,
+  getKeyStore,
+} = require('../lib/crypto');
+
+describe('crypto', () => {
+  describe('encryptSync', () => {
+    const makeKey = () => crypto.randomBytes(32);
+
+    it('produces a 5-part JWE compact serialization', () => {
+      const jwe = encryptSync('hello', makeKey(), {});
+      assert.equal(jwe.split('.').length, 5);
+    });
+
+    it('encrypted key segment is empty (alg=dir has no wrapped key)', () => {
+      const jwe = encryptSync('hello', makeKey(), {});
+      assert.equal(jwe.split('.')[1], '');
+    });
+
+    it('IV is 12 bytes (96 bits as required by AES-GCM)', () => {
+      const jwe = encryptSync('hello', makeKey(), {});
+      const iv = Buffer.from(jwe.split('.')[2], 'base64url');
+      assert.equal(iv.length, 12);
+    });
+
+    it('auth tag is 16 bytes (128-bit tag)', () => {
+      const jwe = encryptSync('hello', makeKey(), {});
+      const tag = Buffer.from(jwe.split('.')[4], 'base64url');
+      assert.equal(tag.length, 16);
+    });
+
+    it('protected header contains alg=dir and enc=A256GCM', () => {
+      const jwe = encryptSync('hello', makeKey(), {});
+      const header = JSON.parse(
+        Buffer.from(jwe.split('.')[0], 'base64url').toString(),
+      );
+      assert.equal(header.alg, 'dir');
+      assert.equal(header.enc, 'A256GCM');
+    });
+
+    it('merges extra fields into the protected header', () => {
+      const jwe = encryptSync('hello', makeKey(), {
+        iat: 1000,
+        uat: 2000,
+        exp: 3000,
+      });
+      const header = JSON.parse(
+        Buffer.from(jwe.split('.')[0], 'base64url').toString(),
+      );
+      assert.equal(header.iat, 1000);
+      assert.equal(header.uat, 2000);
+      assert.equal(header.exp, 3000);
+    });
+
+    it('jose v6 compactDecrypt can decrypt the output', async () => {
+      const key = makeKey();
+      const payload = JSON.stringify({ sub: 'user123', iat: 1000 });
+      const jwe = encryptSync(payload, key, {
+        iat: 1000,
+        uat: 1000,
+        exp: 9999999999,
+      });
+      const { plaintext } = await compactDecrypt(jwe, key, {
+        contentEncryptionAlgorithms: ['A256GCM'],
+        keyManagementAlgorithms: ['dir'],
+      });
+      assert.equal(new TextDecoder().decode(plaintext), payload);
+    });
+
+    it('jose v6 exposes the extra header fields after decryption', async () => {
+      const key = makeKey();
+      const jwe = encryptSync('payload', key, { iat: 100, uat: 200, exp: 999 });
+      const { protectedHeader } = await compactDecrypt(jwe, key, {
+        contentEncryptionAlgorithms: ['A256GCM'],
+        keyManagementAlgorithms: ['dir'],
+      });
+      assert.equal(protectedHeader.iat, 100);
+      assert.equal(protectedHeader.uat, 200);
+      assert.equal(protectedHeader.exp, 999);
+    });
+
+    it('decryption fails with a different key', async () => {
+      const key = makeKey();
+      const jwe = encryptSync('hello', key, {});
+      try {
+        await compactDecrypt(jwe, makeKey(), {
+          contentEncryptionAlgorithms: ['A256GCM'],
+          keyManagementAlgorithms: ['dir'],
+        });
+        assert.fail('expected decryption to fail');
+      } catch (e) {
+        assert.notEqual(e.message, 'expected decryption to fail');
+      }
+    });
+
+    it('handles unicode payload (UTF-8 encoding)', async () => {
+      const key = makeKey();
+      const payload = JSON.stringify({ name: 'José', emoji: '🔐' });
+      const jwe = encryptSync(payload, key, {});
+      const { plaintext } = await compactDecrypt(jwe, key, {
+        contentEncryptionAlgorithms: ['A256GCM'],
+        keyManagementAlgorithms: ['dir'],
+      });
+      assert.equal(new TextDecoder().decode(plaintext), payload);
+    });
+
+    it('produces unique ciphertext on each call due to random IV', () => {
+      const key = makeKey();
+      const jwe1 = encryptSync('same payload', key, {});
+      const jwe2 = encryptSync('same payload', key, {});
+      assert.notEqual(jwe1, jwe2);
+    });
+
+    it('jose v6 decodeProtectedHeader parses the header segment', () => {
+      const jwe = encryptSync('hello', makeKey(), { iat: 1, uat: 2, exp: 3 });
+      const header = decodeProtectedHeader(jwe);
+      assert.equal(header.alg, 'dir');
+      assert.equal(header.enc, 'A256GCM');
+      assert.equal(header.iat, 1);
+    });
+
+    it('output has same structure as jose v6 CompactEncrypt (segment count, IV size, tag size)', async () => {
+      const { CompactEncrypt } = require('jose');
+      const key = makeKey();
+      const payload = 'test payload';
+
+      const joseJwe = await new CompactEncrypt(
+        new TextEncoder().encode(payload),
+      )
+        .setProtectedHeader({ alg: 'dir', enc: 'A256GCM' })
+        .encrypt(key);
+
+      const syncJwe = encryptSync(payload, key, {});
+
+      const joseParts = joseJwe.split('.');
+      const syncParts = syncJwe.split('.');
+
+      assert.equal(syncParts.length, joseParts.length);
+      assert.equal(syncParts[1], '');
+      assert.equal(
+        Buffer.from(syncParts[2], 'base64url').length,
+        Buffer.from(joseParts[2], 'base64url').length,
+      );
+      assert.equal(
+        Buffer.from(syncParts[4], 'base64url').length,
+        Buffer.from(joseParts[4], 'base64url').length,
+      );
+    });
+  });
+
+  describe('signCookieSync', () => {
+    let key;
+
+    beforeEach(() => {
+      [key] = getKeyStore('__test_secret__');
+    });
+
+    it('returns value.signature format', () => {
+      const signed = signCookieSync('appSession', 'session-id-123', key);
+      assert.match(signed, /^session-id-123\.[A-Za-z0-9_-]+$/);
+    });
+
+    it('produces a signature verifiable by verifyCookie', async () => {
+      const [key, keystore] = getKeyStore('__test_secret__');
+      const signed = signCookieSync('appSession', 'session-id-123', key);
+      const result = await verifyCookie('appSession', signed, keystore);
+      assert.equal(result, 'session-id-123');
+    });
+
+    it('verification fails when cookie name differs', async () => {
+      const [key, keystore] = getKeyStore('__test_secret__');
+      const signed = signCookieSync('appSession', 'session-id-123', key);
+      const result = await verifyCookie('differentName', signed, keystore);
+      assert.isUndefined(result);
+    });
+
+    it('verification fails when value is tampered', async () => {
+      const [key, keystore] = getKeyStore('__test_secret__');
+      const signed = signCookieSync('appSession', 'session-id-123', key);
+      const tampered = 'tampered-id.' + signed.split('.')[1];
+      const result = await verifyCookie('appSession', tampered, keystore);
+      assert.isUndefined(result);
+    });
+
+    it('verification fails with a different secret', async () => {
+      const [key] = getKeyStore('__test_secret__');
+      const [, otherKeystore] = getKeyStore('__other_secret__');
+      const signed = signCookieSync('appSession', 'session-id-123', key);
+      const result = await verifyCookie('appSession', signed, otherKeystore);
+      assert.isUndefined(result);
+    });
+
+    it('produces the same result as async signCookie', async () => {
+      const { signCookie } = require('../lib/crypto');
+      const [key] = getKeyStore('__test_secret__');
+      const syncSigned = signCookieSync('appSession', 'abc', key);
+      const asyncSigned = await signCookie('appSession', 'abc', key);
+      // signatures should be deterministic for same inputs
+      assert.equal(syncSigned, asyncSigned);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the silent session cookie loss introduced in v3 for any response that flushes headers before `res.end()` — including streaming SSR, `res.flushHeaders()`, `res.write()`, `res.sendFile()`, and `stream.pipe(res)`.

Closes #835

## Problem

v3 moved session cookie persistence from an `on-headers` hook to a `res.end()` wrapper. This was necessary because `jose` v6 moved to an async-only encryption API, and `on-headers` requires a synchronous callback. The consequence was that any response that flushes headers early (a standard SSR performance pattern) silently dropped the session cookie with no error or warning.

## Solution

Restore `on-headers` as the mechanism for writing the session cookie, and introduce two synchronous crypto primitives (using Node's built-in `crypto` module) to work around the async constraint:

- **`encryptSync`** — synchronous AES-256-GCM JWE (`alg=dir`, `enc=A256GCM`) in Compact Serialization format. Produces output byte-for-byte compatible with `jose` v6 `compactDecrypt` — existing sessions decrypt transparently with no migration needed.
- **`signCookieSync`** — synchronous HMAC-SHA256 JWS signature for signed custom store session ID cookies. Compatible with the existing `verifyCookie` verification path.

Both are standard cryptographic primitives — no novel crypto, just calling `crypto.createCipheriv` and `crypto.createHmac` directly, which are the same underlying operations `jose` performs internally.

## Behaviour restored

- Cookie-based sessions: `on-headers` → `encryptSync` → `res.setHeader('Set-Cookie', ...)`
- Custom store sessions: `on-headers` → `signCookieSync` (if signing enabled) → `res.setHeader('Set-Cookie', ...)`, plus `res.end` wrapper for the async `store.set()` persistence
- Streaming responses (`res.write()`, `res.flushHeaders()`, `res.sendFile()`, `stream.pipe(res)`): session cookie is now correctly set in all cases

## Testing

- 341 tests passing (19 new unit tests for `encryptSync` and `signCookieSync` in `test/crypto.tests.js`)
- Updated `test/appSession.tests.js` to assert the fixed behaviour (cookie IS written on streaming responses)
- Added streaming test to `test/appSession.customStore.tests.js` — verifies `Set-Cookie` is present when `res.write()` is called before `res.end()` on the custom store path
- Added test documenting that `Set-Cookie` is sent even when `store.set()` fails — consistent with v2 behaviour (cookie written at `writeHead` time, before persistence)
- Cross-compatibility verified: `encryptSync` output decrypted by `jose` v6 `compactDecrypt` ✓, `signCookieSync` output verified by existing `verifyCookie` 

## Test plan

- All existing tests pass
- New `crypto.tests.js` suite passes (`encryptSync` + `signCookieSync`)
- Streaming test passes for both cookie store and custom store paths
- Manual verification: streaming SSR route sets session cookie correctly after `res.write()` / `res.flushHeaders()`
- Existing sessions (encrypted by jose v6) are still readable after upgrade

## Smoke Testing

Tested manually against a real Auth0 tenant.

**CookieStore (default)**
- Login → session established, JWE cookie set correctly
- Session readable across requests (decrypt round-trip verified)
- Session mutation persists on subsequent requests
- Logout → session cleared, cookie absent

**CustomStore (signed session cookie)**
- Login → short session ID + HMAC signature written to cookie, session data persisted to store
- Session readable across requests (store lookup + signature verification)
- Session mutation → store updated, cookie re-signed
- Logout → store entry destroyed, cookie cleared

**Streaming fix (core regression — both store modes)**
- `res.write()` before `res.end()` → `Set-Cookie: appSession=` present in response headers 
- `res.flushHeaders()` before write → `Set-Cookie: appSession=` present 
- `stream.pipe(res)` → `Set-Cookie: appSession=` present 

All three streaming scenarios failed silently (no `Set-Cookie`) in v3.0.0 before this fix.