### PR TITLE
docs: sync documentation with current API (automated)

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -258,8 +258,6 @@ app.use(
 
 The `afterCallback` hook can be used to do validation checks on claims after the ID token has been received in the callback phase.
 
-> ⚠️ **v3 behavior change** — In v3, `req.oidc` inside `afterCallback` reflects the **incoming** user's new tokens, not the previous session. If you need the prior session state, capture it before the callback flow starts. See the [V3 Migration Guide](./V3_MIGRATION_GUIDE.md#aftercallback-behavior-change) for details.
-
 ```js
 const { decodeJwt } = require('jose'); // jose v6 named export
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -258,11 +258,15 @@ app.use(
 
 The `afterCallback` hook can be used to do validation checks on claims after the ID token has been received in the callback phase.
 
+> ⚠️ **v3 behavior change** — In v3, `req.oidc` inside `afterCallback` reflects the **incoming** user's new tokens, not the previous session. If you need the prior session state, capture it before the callback flow starts. See the [V3 Migration Guide](./V3_MIGRATION_GUIDE.md#aftercallback-behavior-change) for details.
+
 ```js
+const { decodeJwt } = require('jose'); // jose v6 named export
+
 app.use(
   auth({
     afterCallback: (req, res, session) => {
-      const claims = jose.JWT.decode(session.id_token); // using jose library to decode JWT
+      const claims = decodeJwt(session.id_token);
       if (claims.org_id !== 'Required Organization') {
         throw new Error('User is not a part of the Required Organization');
       }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This library supports the following tooling versions:
 
 - Node.js `^20.19.0 || ^22.12.0 || >= 23.0.0`
 
+> ⚠️ **Upgrading from v2?** The `httpAgent` config option was removed in v3. To route OIDC requests through a proxy, use the `customFetch` option with `undici`'s `ProxyAgent` instead — see [Example #13](./EXAMPLES.md#13-use-a-proxy-for-oidc-requests). For all breaking changes see the [V3 Migration Guide](./V3_MIGRATION_GUIDE.md).
+
 ## Install
 
 Using [npm](https://npmjs.org) in your project directory, run the following command:


### PR DESCRIPTION
## Summary

Automated documentation drift fix. 3 findings addressed (2 P1 · 1 P2).

## Changes

- `EXAMPLES.md` — replaced `jose.JWT.decode()` (jose v2 API, removed in jose v6) with `decodeJwt` named import; added v3 `afterCallback` behavior callout (P1: breaks at runtime on v3)
- `README.md` — added `httpAgent` removal notice with pointer to `customFetch`/`ProxyAgent` migration path (P2: silent runtime no-op for v2 upgraders)

<details>
<summary>Full Drift Report</summary>

| # | Severity | File | Line | Issue |
|---|---|---|---|---|
| 1 | P1 | `EXAMPLES.md` | 265 | `jose.JWT.decode()` is jose v2 API — removed in jose v6 (current dependency). Use `decodeJwt` named export instead |
| 2 | P1 | `EXAMPLES.md` | ~275 | `afterCallback` v3 behavior change not documented — `req.oidc` now reflects incoming user, not prior session |
| 3 | P2 | `README.md` | — | `httpAgent` removed in v3 with no notice; `customFetch` is the replacement |

</details>

---
🤖 Generated with [syncing-docs](https://github.com/atko-cic/claude-marketplace) skill
