### PR TITLE
fixes GitHub workflow script injection

### DIFF
--- a/.github/actions/rl-scanner/action.yml
+++ b/.github/actions/rl-scanner/action.yml
@@ -40,18 +40,23 @@ runs:
         RLSECURE_SITE_KEY: ${{ env.RLSECURE_SITE_KEY }}
         SIGNAL_HANDLER_TOKEN: ${{ env.SIGNAL_HANDLER_TOKEN }}
         PYTHONUNBUFFERED: 1
+        ARTIFACT_PATH: ${{ inputs.artifact-path }}
+        ARTIFACT_VERSION: ${{ inputs.version }}
+        REPO_NAME: ${{ github.event.repository.name }}
+        REPOSITORY: ${{ github.repository }}
+        COMMIT_SHA: ${{ github.sha }}
       run: |
-        if [ ! -f "${{ inputs.artifact-path }}" ]; then
-          echo "Artifact not found: ${{ inputs.artifact-path }}"
+        if [ ! -f "$ARTIFACT_PATH" ]; then
+          echo "Artifact not found: $ARTIFACT_PATH"
           exit 1
         fi
 
         rl-wrapper \
-          --artifact "${{ inputs.artifact-path }}" \
-          --name "${{ github.event.repository.name }}" \
-          --version "${{ inputs.version }}" \
-          --repository "${{ github.repository }}" \
-          --commit "${{ github.sha }}" \
+          --artifact "$ARTIFACT_PATH" \
+          --name "$REPO_NAME" \
+          --version "$ARTIFACT_VERSION" \
+          --repository "$REPOSITORY" \
+          --commit "$COMMIT_SHA" \
           --build-env "github_actions" \
           --suppress_output
 

--- a/.github/workflows/rl-secure.yml
+++ b/.github/workflows/rl-secure.yml
@@ -43,8 +43,10 @@ jobs:
           node: ${{ inputs.node-version }}
 
       - name: Create tgz build artifact
+        env:
+          ARTIFACT_NAME: ${{ inputs.artifact-name }}
         run: |
-          tar -czvf ${{ inputs.artifact-name }} *
+          tar -czvf "$ARTIFACT_NAME" *
 
       - id: get_version
         uses: ./.github/actions/get-version


### PR DESCRIPTION
## Fix Script Injection Vulnerability in GitHub Workflows

### Summary

This PR fixes a script injection vulnerability in two GitHub Actions workflow files. GitHub Actions expression syntax (`${{ }}`) is evaluated before the shell sees the script, meaning any user-controlled value containing shell metacharacters could be executed as code.

The fix moves all interpolated values into `env:` block variables and references them as shell variables (`$VAR`) in the `run:` block. Shell variables are treated as data by the time the shell parses them -- they cannot change the structure of the script.

Similar fix applied in [auth0/node-auth0#1287](https://github.com/auth0/node-auth0/pull/1287).

### Changes

**`.github/actions/rl-scanner/action.yml`**
- Moved `inputs.artifact-path`, `inputs.version`, `github.event.repository.name`, `github.repository`, and `github.sha` out of inline shell interpolation and into the `env:` block
- Updated shell script to reference `$ARTIFACT_PATH`, `$ARTIFACT_VERSION`, `$REPO_NAME`, `$REPOSITORY`, `$COMMIT_SHA`

**`.github/workflows/rl-secure.yml`**
- Moved `inputs.artifact-name` into an `env:` block on the "Create tgz build artifact" step
- Updated `tar` command to use `"$ARTIFACT_NAME"` instead of inline interpolation