### PR TITLE
feat: Add CTE impersonation via Session Transfer Token

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -12,8 +12,9 @@
 10. [Use a custom session store](#10-use-a-custom-session-store)
 11. [Back-Channel Logout](#11-back-channel-logout)
 12. [Custom Token Exchange](#12-custom-token-exchange)
-13. [Use a proxy for OIDC requests](#13-use-a-proxy-for-oidc-requests)
-14. [Session expiry from upstream IdP (IPSIE `session_expiry`)](#14-session-expiry-from-upstream-idp-ipsie-session_expiry)
+13. [Impersonation via Session Transfer Token](#13-impersonation-via-session-transfer-token)
+14. [Use a proxy for OIDC requests](#14-use-a-proxy-for-oidc-requests)
+15. [Session expiry from upstream IdP (IPSIE `session_expiry`)](#15-session-expiry-from-upstream-idp-ipsie-session_expiry)
 
 ## 1. Basic setup
 
@@ -450,7 +451,117 @@ const tokenSet = await req.oidc.customTokenExchange({
 });
 ```
 
-## 13. Use a proxy for OIDC requests
+## 13. Impersonation via Session Transfer Token
+
+Custom Token Exchange Impersonation via Session Transfer lets a support or admin application log a user into a target web application as a customer — so a support engineer can reproduce the customer's exact experience without knowing their password. The agent is recorded in the `act` claim on the impersonated session, making every impersonation auditable.
+
+The flow involves two roles:
+
+- **Initiator** — your support/admin app. It requests a short-lived, single-use Session Transfer Token (STT) and redirects the user's browser to the target app carrying the STT.
+- **Target** — the customer's web app. It forwards the STT to `/authorize`, where Auth0 redeems it and establishes a session as the customer.
+
+> **Prerequisites (configured via Management API / Dashboard):**
+>
+> - Feature flag `cte_session_transfer_token` must be enabled on the tenant.
+> - The issuing (initiator) client needs `can_create_session_transfer_token: true` and a Custom Token Exchange Action that calls `setActor`.
+> - The redeeming (target) client needs `allow_delegated_access: true` and `"query"` in its allowed authentication methods.
+
+### Initiator: requesting an STT and redirecting
+
+The user must be logged in to the initiator app — the SDK sources the actor from the session's ID token by default (refreshing it automatically if expired). Run your own authorization check before calling the SDK.
+
+```js
+const { auth, requiresAuth } = require('express-openid-connect');
+
+app.post('/impersonate', requiresAuth(), async (req, res, next) => {
+  try {
+    // Your own proof of which customer to impersonate — validated by your Action.
+    const { customerToken, customerTokenType } = req.body;
+
+    const result = await req.oidc.requestSessionTransferToken({
+      subject_token: customerToken,
+      subject_token_type: customerTokenType,
+      // Optional: pass custom context to your Action via event.request.body
+      extra: { reason: 'Investigating ticket TCK-1234' },
+    });
+
+    // targetLoginUrl must be a trusted, app-controlled value — never derived from
+    // untrusted input such as a returnTo param, or the STT could leak to an attacker host.
+    const redirectUrl = req.oidc.buildSessionTransferRedirect(
+      'https://app.example.com/auth/login',
+      result,
+    );
+
+    res.redirect(redirectUrl);
+  } catch (err) {
+    // err.error === 'actor_unavailable'        — user not logged in or session expired
+    // err.error === 'setactor_required'        — Action did not call setActor
+    // err.error === 'session_transfer_disabled' — tenant feature flag is off
+    next(err);
+  }
+});
+```
+
+The STT is opaque, single-use, and lives ~60 seconds. The SDK never stores it — hand it straight to `buildSessionTransferRedirect` and discard it.
+
+If the customer belongs to an organization, forward it on the redirect:
+
+```js
+const redirectUrl = req.oidc.buildSessionTransferRedirect(
+  'https://app.example.com/auth/login',
+  result,
+  { organization: 'org_globex' },
+);
+```
+
+To supply the acting party explicitly instead of using the session ID token:
+
+```js
+const result = await req.oidc.requestSessionTransferToken({
+  subject_token: customerToken,
+  subject_token_type: customerTokenType,
+  actor_token: agentIdToken,
+  actor_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+});
+```
+
+### Target: redeeming the STT
+
+On the target app, forward the `session_transfer_token` query parameter (and `organization` when present) to `/authorize` through the existing `res.oidc.login()` call — no new SDK methods required:
+
+```js
+app.get('/auth/login', async (req, res) => {
+  const authorizationParams = {};
+
+  if (req.query.session_transfer_token) {
+    authorizationParams.session_transfer_token =
+      req.query.session_transfer_token;
+  }
+  if (req.query.organization) {
+    authorizationParams.organization = req.query.organization;
+  }
+
+  await res.oidc.login({ authorizationParams });
+});
+```
+
+The established session is short-lived (hard-capped at 2 hours) and cannot mint a refresh token.
+
+### Reading the `act` claim
+
+Once the impersonation session is established, the acting party is available as `req.oidc.user.act`:
+
+```js
+app.get('/dashboard', requiresAuth(), (req, res) => {
+  const actor = req.oidc.user.act; // { sub: 'support-agent-007' } when impersonated
+  if (actor) {
+    // Render an impersonation banner so the agent knows they are acting as the customer.
+  }
+  res.render('dashboard');
+});
+```
+
+## 14. Use a proxy for OIDC requests
 
 If you need to route all OIDC HTTP requests (discovery, token, userinfo, etc.) through a proxy, use the `customFetch` option with `undici`'s `ProxyAgent`:
 
@@ -473,7 +584,7 @@ app.use(
 
 The SDK wraps your `customFetch` function to add required headers (User-Agent, Auth0-Client telemetry) before making requests.
 
-## 14. Session expiry from upstream IdP (IPSIE `session_expiry`)
+## 15. Session expiry from upstream IdP (IPSIE `session_expiry`)
 
 When an upstream IdP supports the IPSIE SL1 spec, it can include a `session_expiry` claim in the ID token — an absolute Unix timestamp (seconds) marking the latest moment the IdP considers the session valid.
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -453,18 +453,16 @@ const tokenSet = await req.oidc.customTokenExchange({
 
 ## 13. Impersonation via Session Transfer Token
 
-Custom Token Exchange Impersonation via Session Transfer lets a support or admin application log a user into a target web application as a customer — so a support engineer can reproduce the customer's exact experience without knowing their password. The agent is recorded in the `act` claim on the impersonated session, making every impersonation auditable.
+Custom Token Exchange Impersonation via Session Transfer lets a support or admin application log a user into a target web application as a customer — so a support engineer can reproduce the customer's exact experience without knowing their password. The initiator is recorded in the `act` claim on the impersonated session, making every impersonation auditable.
 
 The flow involves two roles:
 
 - **Initiator** — your support/admin app. It requests a short-lived, single-use Session Transfer Token (STT) and redirects the user's browser to the target app carrying the STT.
-- **Target** — the customer's web app. It forwards the STT to `/authorize`, where Auth0 redeems it and establishes a session as the customer.
+- **Target** — the customer's web app. It forwards the STT to `/authorize`, where Auth0 redeems it and establishes an ephemeral session as the customer, recording the initiator in the `act` (actor) claim.
 
-> **Prerequisites (configured via Management API / Dashboard):**
->
-> - Feature flag `cte_session_transfer_token` must be enabled on the tenant.
-> - The issuing (initiator) client needs `can_create_session_transfer_token: true` and a Custom Token Exchange Action that calls `setActor`.
-> - The redeeming (target) client needs `allow_delegated_access: true` and `"query"` in its allowed authentication methods.
+The STT is **opaque, single-use, and short-lived (~60s)**. The SDK requests it, surfaces it, and helps you build the redirect — it never decodes, validates, caches, or persists it.
+
+> **Prerequisites:** See [Custom Token Exchange docs](https://auth0.com/docs/authenticate/custom-token-exchange) for prerequisites and setup.
 
 ### Initiator: requesting an STT and redirecting
 
@@ -496,13 +494,13 @@ app.post('/impersonate', requiresAuth(), async (req, res, next) => {
   } catch (err) {
     // err.error === 'actor_unavailable'        — user not logged in or session expired
     // err.error === 'setactor_required'        — Action did not call setActor
-    // err.error === 'session_transfer_disabled' — tenant feature flag is off
     next(err);
   }
 });
 ```
 
-The STT is opaque, single-use, and lives ~60 seconds. The SDK never stores it — hand it straight to `buildSessionTransferRedirect` and discard it.
+> [!IMPORTANT]
+> An actor is mandatory for an STT — that is what makes this auditable impersonation ("X acting as Y") rather than a silent takeover. If no explicit `actor_token` is passed and no usable session ID token can be resolved (user not logged in, or expired ID token with no refresh token), the SDK throws with `err.error === 'actor_unavailable'` before any network call. The session ID token must also be unexpired; the SDK refreshes it automatically when a refresh token is available.
 
 > **Branch on `result.issued_token_type`**, not `result.token_type`. The `token_type` field is `"N_A"` for an STT response — it is informational only. `issued_token_type` is always `"urn:auth0:params:oauth:token-type:session_transfer_token"` for a successful STT exchange, and `buildSessionTransferRedirect` requires exactly that value.
 
@@ -550,6 +548,9 @@ app.get('/auth/login', async (req, res) => {
 ```
 
 The established session is short-lived (hard-capped at 2 hours) and cannot mint a refresh token.
+
+> [!NOTE]
+> Because the STT travels as a query parameter, it can land in places that log or retain full URLs — web-server access logs, proxy/CDN logs, and the browser's history. This is inherent to the redemption mechanism and is mitigated by the token being single-use and short-lived (~60s): a leaked STT is worthless once redeemed or expired. Even so, avoid logging redemption URLs verbatim, and never persist or forward the STT beyond the immediate redirect.
 
 ### Reading the `act` claim
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -504,6 +504,8 @@ app.post('/impersonate', requiresAuth(), async (req, res, next) => {
 
 The STT is opaque, single-use, and lives ~60 seconds. The SDK never stores it — hand it straight to `buildSessionTransferRedirect` and discard it.
 
+> **Branch on `result.issued_token_type`**, not `result.token_type`. The `token_type` field is `"N_A"` for an STT response — it is informational only. `issued_token_type` is always `"urn:auth0:params:oauth:token-type:session_transfer_token"` for a successful STT exchange, and `buildSessionTransferRedirect` requires exactly that value.
+
 If the customer belongs to an organization, forward it on the redirect:
 
 ```js
@@ -524,6 +526,8 @@ const result = await req.oidc.requestSessionTransferToken({
   actor_token_type: 'urn:ietf:params:oauth:token-type:id_token',
 });
 ```
+
+> **Explicit `actor_token` requirements:** Auth0 validates the actor token server-side before running the exchange. It must be unexpired and signed with an asymmetric algorithm (RS256 or PS256) — an HS256 token or an expired token will be rejected. An Auth0 session ID token already satisfies both requirements; if you source `actor_token` from elsewhere, ensure it meets them.
 
 ### Target: redeeming the STT
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -529,9 +529,19 @@ const result = await req.oidc.requestSessionTransferToken({
 
 ### Target: redeeming the STT
 
-On the target app, forward the `session_transfer_token` query parameter (and `organization` when present) to `/authorize` through the existing `res.oidc.login()` call — no new SDK methods required:
+On the target app, forward the `session_transfer_token` query parameter (and `organization` when present) to `/authorize` through the existing `res.oidc.login()` call — no new SDK methods required.
+
+The target app must set `authRequired: false` on the `auth()` middleware so the custom login route handles the request directly. Without it, the middleware intercepts the unauthenticated request to `/login` and stashes the STT in `returnTo` state instead of forwarding it to `/authorize`.
 
 ```js
+app.use(
+  auth({
+    // ... your other config
+    authRequired: false, // required — lets the custom /login route run freely
+    routes: { login: false },
+  }),
+);
+
 app.get('/auth/login', async (req, res) => {
   const authorizationParams = {};
 
@@ -543,7 +553,9 @@ app.get('/auth/login', async (req, res) => {
     authorizationParams.organization = req.query.organization;
   }
 
-  await res.oidc.login({ authorizationParams });
+  // returnTo: '/' prevents a redirect loop after the callback —
+  // without it the SDK redirects back to /login?session_transfer_token=...
+  await res.oidc.login({ authorizationParams, returnTo: '/' });
 });
 ```
 

--- a/examples/cte-session-transfer.js
+++ b/examples/cte-session-transfer.js
@@ -1,0 +1,220 @@
+'use strict';
+
+/**
+ * CTE Session Transfer — impersonation via Session Transfer Token (STT)
+ *
+ * Demonstrates the full initiator → target flow across two Express apps running
+ * in the same process:
+ *
+ *   Initiator (PORT 3000) — the support/admin console. The agent logs in here
+ *     and requests an STT on behalf of a customer via Custom Token Exchange.
+ *
+ *   Target (PORT 3001) — the customer-facing app. It receives the STT as a
+ *     query parameter on its /login route and forwards it to /authorize to
+ *     establish an impersonation session as the subject user.
+ *
+ * Prerequisites (Auth0 tenant configuration):
+ *   - Initiator client: session_transfer.can_create_session_transfer_token = true
+ *     and a CTE profile of type custom_authentication that calls setActor()
+ *   - Target client: session_transfer.delegation.allow_delegated_access = true,
+ *     allowed_authentication_methods = ["query"], jwt_configuration.alg = "RS256"
+ *   - The target's callback URL must be a routable HTTPS URL (not localhost) —
+ *     use a tunnel (e.g. cloudflared) for local development and set TARGET_BASE_URL
+ *
+ * This example runs two servers from a single file and cannot be launched via
+ * `npm run start:example`. Run it directly:
+ *
+ *   ISSUER_BASE_URL=https://YOUR_DOMAIN            \
+ *   INITIATOR_CLIENT_ID=...                        \
+ *   INITIATOR_CLIENT_SECRET=...                    \
+ *   TARGET_CLIENT_ID=...                           \
+ *   TARGET_CLIENT_SECRET=...                       \
+ *   SUBJECT_TOKEN=YOUR_SUBJECT_USER_ID             \
+ *   SUBJECT_TOKEN_TYPE=urn:yourcompany:token-type  \
+ *   SECRET=LONG_RANDOM_VALUE                       \
+ *   node examples/cte-session-transfer.js
+ *
+ * Or with a .env file:
+ *   node -r dotenv/config examples/cte-session-transfer.js dotenv_config_path=.env
+ */
+
+const express = require('express');
+const { auth, requiresAuth } = require('../');
+
+const {
+  ISSUER_BASE_URL,
+  SECRET = 'LONG_RANDOM_VALUE',
+  INITIATOR_CLIENT_ID,
+  INITIATOR_CLIENT_SECRET,
+  TARGET_CLIENT_ID,
+  TARGET_CLIENT_SECRET,
+  INITIATOR_PORT = 3000,
+  TARGET_PORT = 3001,
+  // Optional: public HTTPS base URL for the target (required when localhost
+  // callbacks are not accepted by the AS for STT redemption).
+  TARGET_BASE_URL,
+  // The subject token your CTE Action uses to identify the customer.
+  SUBJECT_TOKEN,
+  // The subject_token_type registered in your CTE profile.
+  SUBJECT_TOKEN_TYPE,
+} = process.env;
+
+// ---------------------------------------------------------------------------
+// Initiator app
+// ---------------------------------------------------------------------------
+const initiator = express();
+
+initiator.use(
+  auth({
+    issuerBaseURL: ISSUER_BASE_URL,
+    clientID: INITIATOR_CLIENT_ID,
+    clientSecret: INITIATOR_CLIENT_SECRET,
+    baseURL: `http://localhost:${INITIATOR_PORT}`,
+    secret: SECRET,
+    // Distinct session name avoids cookie collision when both apps share a domain.
+    session: { name: 'appSession.initiator' },
+    authorizationParams: {
+      response_type: 'code',
+      // offline_access is required so the SDK can refresh the id_token used as
+      // the actor_token when it expires before the STT is requested.
+      scope: 'openid profile email offline_access',
+    },
+  }),
+);
+
+initiator.get('/', requiresAuth(), (req, res) => {
+  const { sub, name, email } = req.oidc.user;
+  res.send(`
+    <h2>Initiator App (support console)</h2>
+    <p>Logged in as: <strong>${name || email || sub}</strong> (${sub})</p>
+    <form method="POST" action="/impersonate">
+      <p>Subject token: <input name="subjectToken" value="${SUBJECT_TOKEN || ''}" size="40" /></p>
+      <p>Reason: <input name="reason" value="" size="40" /></p>
+      <button type="submit">Impersonate customer →</button>
+    </form>
+    <hr/>
+    <a href="/logout">Logout</a>
+  `);
+});
+
+initiator.use(express.urlencoded({ extended: false }));
+initiator.post('/impersonate', requiresAuth(), async (req, res, next) => {
+  try {
+    const subjectToken = req.body.subjectToken;
+    const reason = req.body.reason;
+
+    const result = await req.oidc.requestSessionTransferToken({
+      subject_token: subjectToken,
+      subject_token_type: SUBJECT_TOKEN_TYPE,
+      ...(reason && { extra: { reason } }),
+    });
+
+    const targetLoginUrl = TARGET_BASE_URL
+      ? `${TARGET_BASE_URL}/login`
+      : `http://localhost:${TARGET_PORT}/login`;
+
+    const redirectUrl = req.oidc.buildSessionTransferRedirect(
+      targetLoginUrl,
+      result,
+    );
+
+    res.redirect(redirectUrl);
+  } catch (err) {
+    // err.error contains the OAuth error code, err.message the description.
+    next(err);
+  }
+});
+
+initiator.get('/logout', (req, res) => {
+  res.oidc.logout({ returnTo: `http://localhost:${INITIATOR_PORT}` });
+});
+
+// ---------------------------------------------------------------------------
+// Target app
+// ---------------------------------------------------------------------------
+const target = express();
+
+target.use(
+  auth({
+    issuerBaseURL: ISSUER_BASE_URL,
+    clientID: TARGET_CLIENT_ID,
+    clientSecret: TARGET_CLIENT_SECRET,
+    baseURL: TARGET_BASE_URL || `http://localhost:${TARGET_PORT}`,
+    secret: SECRET,
+    session: { name: 'appSession.target' },
+    // authRequired: false is required so the custom /login route below runs
+    // freely. With the default (true) the auth middleware intercepts
+    // unauthenticated requests to /login before the route handler fires,
+    // stashing the STT in returnTo state instead of forwarding it to /authorize.
+    authRequired: false,
+    routes: {
+      login: false,
+    },
+    authorizationParams: {
+      response_type: 'code',
+      scope: 'openid profile email',
+    },
+  }),
+);
+
+// Custom /login — forwards the STT (and optional organization) to /authorize.
+target.get('/login', async (req, res, next) => {
+  try {
+    const authorizationParams = {};
+
+    if (req.query.session_transfer_token) {
+      authorizationParams.session_transfer_token =
+        req.query.session_transfer_token;
+    }
+    if (req.query.organization) {
+      authorizationParams.organization = req.query.organization;
+    }
+
+    // returnTo: '/' prevents an infinite redirect loop: without it the SDK
+    // stores /login?session_transfer_token=... as the post-callback destination,
+    // which triggers another login cycle after the callback completes.
+    await res.oidc.login({ authorizationParams, returnTo: '/' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+target.get('/', requiresAuth(), (req, res) => {
+  const user = req.oidc.user;
+  const actor = user.act;
+
+  res.send(`
+    <h2>Target App (customer app)</h2>
+    ${
+      actor
+        ? `<div style="background:#fff3cd;padding:12px;border:1px solid #ffc107;margin-bottom:16px">
+             ⚠️ <strong>Impersonation session</strong> — acting as customer on behalf of agent<br/>
+             Actor: <code>${JSON.stringify(actor)}</code>
+           </div>`
+        : '<p>(No impersonation — normal session)</p>'
+    }
+    <h3>Session (sub = customer)</h3>
+    <pre>${JSON.stringify(user, null, 2)}</pre>
+    <hr/>
+    <a href="/logout">Logout</a>
+  `);
+});
+
+target.get('/logout', (req, res) => {
+  res.oidc.logout({
+    returnTo: TARGET_BASE_URL || `http://localhost:${TARGET_PORT}`,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Start both servers
+// ---------------------------------------------------------------------------
+initiator.listen(INITIATOR_PORT, () =>
+  console.log(`[initiator] http://localhost:${INITIATOR_PORT}`),
+);
+
+target.listen(TARGET_PORT, () =>
+  console.log(
+    `[target]    ${TARGET_BASE_URL || `http://localhost:${TARGET_PORT}`}`,
+  ),
+);

--- a/index.d.ts
+++ b/index.d.ts
@@ -379,10 +379,11 @@ interface RequestContext {
    * });
    * ```
    *
-   * **Errors thrown (HTTP 400):**
-   * - `error: 'actor_unavailable'` — no actor resolved (agent not authenticated or session expired with no refresh token)
-   * - `error: 'setactor_required'` — CTE Action did not call `setActor`
-   * - `error: 'session_transfer_disabled'` — tenant feature flag is off
+   * **Errors thrown:**
+   * - `error: 'actor_unavailable'` (HTTP 400) — no actor resolved (agent not authenticated or session expired with no refresh token)
+   * - `error: 'setactor_required'` (HTTP 400) — CTE Action did not call `setActor`
+   * - `error: 'session_transfer_disabled'` (HTTP 400) — tenant feature flag is off
+   * - `error: 'invalid_token_response'` (HTTP 500) — AS returned an unexpected `issued_token_type` (not the STT URN)
    */
   requestSessionTransferToken?: (
     options: SessionTransferTokenOptions,
@@ -403,8 +404,9 @@ interface RequestContext {
    *
    * The `targetLoginUrl` must be a trusted, app-controlled value — never derive it
    * from untrusted input such as a query parameter, as the STT would be forwarded to
-   * an attacker-controlled host. Use an `https:` URL in production to prevent the
-   * token from being exposed over plaintext.
+   * an attacker-controlled host. The URL must use `https:` (`http:` is accepted only
+   * for `localhost`, `127.0.0.1`, and `[::1]` to support local development); any other
+   * scheme or non-loopback `http:` host throws a `TypeError`.
    */
   buildSessionTransferRedirect?: (
     targetLoginUrl: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -258,10 +258,11 @@ interface SessionTransferTokenOptions {
   /** Scopes for the established session's tokens. */
   scope?: string;
   /**
-   * Optional reason for the exchange. Included in the `act` claim when your CTE Action
-   * passes it to `setActor(...)`.
+   * Additional parameters forwarded to the token endpoint and available in your CTE Action
+   * via `event.request.body` (e.g. `{ reason: 'Investigating TCK-1234' }`).
+   * Cannot override reserved OAuth parameters.
    */
-  reason?: string;
+  extra?: Record<string, string | string[] | number | boolean>;
 }
 
 /**
@@ -376,7 +377,7 @@ interface RequestContext {
    *   const result = await req.oidc.requestSessionTransferToken({
    *     subject_token: req.body.customerToken,
    *     subject_token_type: 'urn:mycompany:customer-subject',
-   *     reason: 'Investigating ticket TCK-1234',
+   *     extra: { reason: 'Investigating ticket TCK-1234' },
    *   });
    *   res.redirect(req.oidc.buildSessionTransferRedirect('https://app.example.com/login', result));
    * });

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,6 +127,10 @@ interface ActClaim {
   [key: string]: unknown;
 }
 
+/** @internal Token-type URI constants for use with STT and CTE methods. */
+export const SESSION_TRANSFER_TOKEN_IDENTIFIER: 'urn:auth0:params:oauth:token-type:session_transfer_token';
+export const ID_TOKEN_IDENTIFIER: 'urn:ietf:params:oauth:token-type:id_token';
+
 /**
  * Options for {@link RequestContext.customTokenExchange}.
  * All fields are optional — unset fields fall back to `authorizationParams` config or
@@ -205,6 +209,70 @@ interface TokenExchangeResponse {
   act?: ActClaim;
   /** Vendor-specific or extension fields returned by the authorization server. */
   [key: string]: unknown;
+}
+
+/**
+ * Result of a successful {@link RequestContext.requestSessionTransferToken} call.
+ * The STT is opaque, single-use, and expires in ~60 seconds.
+ * Pass it directly to {@link RequestContext.buildSessionTransferRedirect} — never decode or store it.
+ */
+interface SessionTransferTokenResult {
+  /** The opaque session transfer token. Hand to `buildSessionTransferRedirect`. */
+  session_transfer_token: string;
+  /**
+   * The issued token type URN. Always `"urn:auth0:params:oauth:token-type:session_transfer_token"`.
+   * Branch on this field, not `token_type`.
+   */
+  issued_token_type: string;
+  /** Token lifetime in seconds (~60). */
+  expires_in: number;
+  /** Informational only — typically `"N_A"`. Never branch on this. */
+  token_type?: string;
+  /** Granted scopes, if returned by the authorization server. */
+  scope?: string;
+}
+
+/**
+ * Options for {@link RequestContext.requestSessionTransferToken}.
+ */
+interface SessionTransferTokenOptions {
+  /**
+   * Your proof of which customer to impersonate. Validated by your CTE Action.
+   * The SDK never produces this — you supply it.
+   */
+  subject_token: string;
+  /**
+   * URI identifying the type of `subject_token` (routes to your CTE Action).
+   */
+  subject_token_type: string;
+  /**
+   * Override the acting party's token. Omit to use the agent session's id_token (default).
+   * When provided, `actor_token_type` is required.
+   * Actor resolution order: explicit `actor_token` → session id_token (refreshed if expired) → `ACTOR_UNAVAILABLE`.
+   */
+  actor_token?: string;
+  /**
+   * URI identifying the type of `actor_token`.
+   * Defaults to `urn:ietf:params:oauth:token-type:id_token` when `actor_token` is provided.
+   */
+  actor_token_type?: string;
+  /** Organization ID or name; forwarded to `/authorize` by `buildSessionTransferRedirect`. */
+  organization?: string;
+  /** Scopes for the target session's tokens. */
+  scope?: string;
+  /**
+   * Audit reason forwarded to your CTE Action as `event.request.body.reason`.
+   * Your Action must include it in `setActor(...)` for it to appear as `act.reason`.
+   */
+  reason?: string;
+}
+
+/**
+ * Options for {@link RequestContext.buildSessionTransferRedirect}.
+ */
+interface SessionTransferRedirectOptions {
+  /** Organization to append to the redirect URL (when the STT is org-scoped). */
+  organization?: string;
 }
 
 /**
@@ -295,6 +363,59 @@ interface RequestContext {
   customTokenExchange?: (
     options?: CustomTokenExchangeOptions,
   ) => Promise<TokenExchangeResponse>;
+
+  /**
+   * Requests a Session Transfer Token (STT) for impersonation via session transfer.
+   *
+   * Performs a CTE call against the `urn:{domain}:session_transfer` audience.
+   * The agent's session id_token is used as the actor automatically (refreshed if expired);
+   * pass `actor_token` to override.
+   *
+   * The returned STT is opaque and single-use (~60s). Pass it to
+   * `buildSessionTransferRedirect` — never decode or store it.
+   *
+   * ```js
+   * app.post('/impersonate', requiresAuth(), async (req, res) => {
+   *   const result = await req.oidc.requestSessionTransferToken({
+   *     subject_token: req.body.customerToken,
+   *     subject_token_type: 'urn:mycompany:customer-subject',
+   *     reason: 'Investigating ticket TCK-1234',
+   *   });
+   *   res.redirect(req.oidc.buildSessionTransferRedirect('https://app.example.com/login', result));
+   * });
+   * ```
+   *
+   * **Errors thrown (HTTP 400):**
+   * - `error: 'actor_unavailable'` — no actor resolved (agent not authenticated or session expired with no refresh token)
+   * - `error: 'setactor_required'` — CTE Action did not call `setActor`
+   * - `error: 'session_transfer_disabled'` — tenant feature flag is off
+   */
+  requestSessionTransferToken?: (
+    options: SessionTransferTokenOptions,
+  ) => Promise<SessionTransferTokenResult>;
+
+  /**
+   * Builds the redirect URL that hands the STT to the target app's login endpoint.
+   *
+   * Returns `targetLoginUrl?session_transfer_token=<encoded>[&organization=…]`.
+   * The developer passes the returned URL to `res.redirect()`.
+   *
+   * ```js
+   * const url = req.oidc.buildSessionTransferRedirect('https://app.example.com/login', result, {
+   *   organization: 'org_globex',
+   * });
+   * res.redirect(url);
+   * ```
+   *
+   * The `targetLoginUrl` must be a trusted, app-controlled value — never derive it
+   * from untrusted input such as a query parameter, as the STT would be forwarded to
+   * an attacker-controlled host.
+   */
+  buildSessionTransferRedirect?: (
+    targetLoginUrl: string,
+    result: SessionTransferTokenResult,
+    opts?: SessionTransferRedirectOptions,
+  ) => string;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -221,12 +221,11 @@ interface SessionTransferTokenResult {
   session_transfer_token: string;
   /**
    * The issued token type URN. Always `"urn:auth0:params:oauth:token-type:session_transfer_token"`.
-   * Branch on this field, not `token_type`.
    */
   issued_token_type: string;
   /** Token lifetime in seconds (~60). */
   expires_in: number;
-  /** Informational only — typically `"N_A"`. Never branch on this. */
+  /** Informational only — typically `"N_A"`. */
   token_type?: string;
   /** Granted scopes, if returned by the authorization server. */
   scope?: string;
@@ -237,18 +236,16 @@ interface SessionTransferTokenResult {
  */
 interface SessionTransferTokenOptions {
   /**
-   * Your proof of which customer to impersonate. Validated by your CTE Action.
-   * The SDK never produces this — you supply it.
+   * The token identifying the subject of the exchange. Validated by your CTE Action.
    */
   subject_token: string;
   /**
-   * URI identifying the type of `subject_token` (routes to your CTE Action).
+   * URI identifying the type of `subject_token`.
    */
   subject_token_type: string;
   /**
-   * Override the acting party's token. Omit to use the agent session's id_token (default).
-   * When provided, `actor_token_type` is required.
-   * Actor resolution order: explicit `actor_token` → session id_token (refreshed if expired) → `ACTOR_UNAVAILABLE`.
+   * The acting party's token. Omit to use the current session's id_token (default).
+   * When provided, `actor_token_type` defaults to `urn:ietf:params:oauth:token-type:id_token`.
    */
   actor_token?: string;
   /**
@@ -258,11 +255,11 @@ interface SessionTransferTokenOptions {
   actor_token_type?: string;
   /** Organization ID or name; forwarded to `/authorize` by `buildSessionTransferRedirect`. */
   organization?: string;
-  /** Scopes for the target session's tokens. */
+  /** Scopes for the established session's tokens. */
   scope?: string;
   /**
-   * Audit reason forwarded to your CTE Action as `event.request.body.reason`.
-   * Your Action must include it in `setActor(...)` for it to appear as `act.reason`.
+   * Optional reason for the exchange. Included in the `act` claim when your CTE Action
+   * passes it to `setActor(...)`.
    */
   reason?: string;
 }
@@ -409,7 +406,8 @@ interface RequestContext {
    *
    * The `targetLoginUrl` must be a trusted, app-controlled value — never derive it
    * from untrusted input such as a query parameter, as the STT would be forwarded to
-   * an attacker-controlled host.
+   * an attacker-controlled host. Use an `https:` URL in production to prevent the
+   * token from being exposed over plaintext.
    */
   buildSessionTransferRedirect?: (
     targetLoginUrl: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,10 +127,6 @@ interface ActClaim {
   [key: string]: unknown;
 }
 
-/** @internal Token-type URI constants for use with STT and CTE methods. */
-export const SESSION_TRANSFER_TOKEN_IDENTIFIER: 'urn:auth0:params:oauth:token-type:session_transfer_token';
-export const ID_TOKEN_IDENTIFIER: 'urn:ietf:params:oauth:token-type:id_token';
-
 /**
  * Options for {@link RequestContext.customTokenExchange}.
  * All fields are optional — unset fields fall back to `authorizationParams` config or

--- a/lib/context.js
+++ b/lib/context.js
@@ -474,28 +474,28 @@ class RequestContext {
       resolvedActorToken = actor_token;
       resolvedActorTokenType = actor_token_type || ID_TOKEN_IDENTIFIER;
     } else {
-      // Source actor from the current agent session id_token.
+      // Source actor from the current session id_token.
       // If the token set is expired and there's a refresh token, refresh first.
       const ts = tokenSet.call(this);
 
       if (!ts) {
         throw createError(
           400,
-          'No actor available: agent is not authenticated. Log in or pass an explicit actor_token.',
+          'No actor available: no active session. Log in or pass an explicit actor_token.',
           { error: 'actor_unavailable' },
         );
       }
 
       if (ts.expired() && ts.refresh_token) {
         debug(
-          'requestSessionTransferToken: id_token expired, refreshing agent session',
+          'requestSessionTransferToken: id_token expired, refreshing session',
         );
         try {
           await refresh.call(this);
         } catch {
           throw createError(
             400,
-            'No actor available: agent session expired and could not be refreshed.',
+            'No actor available: session expired and could not be refreshed.',
             { error: 'actor_unavailable' },
           );
         }
@@ -503,11 +503,9 @@ class RequestContext {
 
       const idToken = this.idToken;
       if (!idToken) {
-        throw createError(
-          400,
-          'No actor available: no id_token in agent session.',
-          { error: 'actor_unavailable' },
-        );
+        throw createError(400, 'No actor available: no id_token in session.', {
+          error: 'actor_unavailable',
+        });
       }
 
       resolvedActorToken = idToken;

--- a/lib/context.js
+++ b/lib/context.js
@@ -90,6 +90,9 @@ const TOKEN_EXCHANGE_GRANT_TYPE =
   'urn:ietf:params:oauth:grant-type:token-exchange';
 const ACCESS_TOKEN_EXCHANGE_IDENTIFIER =
   'urn:ietf:params:oauth:token-type:access_token';
+const ID_TOKEN_IDENTIFIER = 'urn:ietf:params:oauth:token-type:id_token';
+const SESSION_TRANSFER_TOKEN_IDENTIFIER =
+  'urn:auth0:params:oauth:token-type:session_transfer_token';
 
 /**
  * Parameters that cannot be supplied via the `extra` option.
@@ -441,6 +444,150 @@ class RequestContext {
         error_description: error.error_description,
       });
     }
+  }
+
+  async requestSessionTransferToken(options = {}) {
+    const { config } = weakRef(this);
+
+    const {
+      subject_token,
+      subject_token_type,
+      actor_token,
+      actor_token_type,
+      organization,
+      scope,
+      reason,
+    } = options;
+
+    validateSubjectToken(subject_token);
+
+    // Resolve actor: explicit actor_token → session id_token (refreshed if expired) → ACTOR_UNAVAILABLE
+    let resolvedActorToken;
+    let resolvedActorTokenType;
+
+    if (actor_token !== undefined) {
+      if (!actor_token.trim()) {
+        throw createError(400, 'actor_token must not be blank', {
+          error: 'actor_unavailable',
+        });
+      }
+      resolvedActorToken = actor_token;
+      resolvedActorTokenType = actor_token_type || ID_TOKEN_IDENTIFIER;
+    } else {
+      // Source actor from the current agent session id_token.
+      // If the token set is expired and there's a refresh token, refresh first.
+      const ts = tokenSet.call(this);
+
+      if (!ts) {
+        throw createError(
+          400,
+          'No actor available: agent is not authenticated. Log in or pass an explicit actor_token.',
+          { error: 'actor_unavailable' },
+        );
+      }
+
+      if (ts.expired() && ts.refresh_token) {
+        debug(
+          'requestSessionTransferToken: id_token expired, refreshing agent session',
+        );
+        try {
+          await refresh.call(this);
+        } catch {
+          throw createError(
+            400,
+            'No actor available: agent session expired and could not be refreshed.',
+            { error: 'actor_unavailable' },
+          );
+        }
+      }
+
+      const idToken = this.idToken;
+      if (!idToken) {
+        throw createError(
+          400,
+          'No actor available: no id_token in agent session.',
+          { error: 'actor_unavailable' },
+        );
+      }
+
+      resolvedActorToken = idToken;
+      resolvedActorTokenType = ID_TOKEN_IDENTIFIER;
+    }
+
+    // Build the session_transfer audience from the configured issuer domain.
+    const issuerHostname = new url.URL(config.issuerBaseURL).hostname;
+    const audience = `urn:${issuerHostname}:session_transfer`;
+
+    debug(
+      'requestSessionTransferToken() audience=%s scope=%s',
+      audience,
+      scope,
+    );
+
+    const { configuration } = await getClient(config);
+
+    const parameters = {
+      subject_token,
+      subject_token_type,
+      actor_token: resolvedActorToken,
+      actor_token_type: resolvedActorTokenType,
+      audience,
+      ...(scope !== undefined && { scope }),
+      ...(organization !== undefined && { organization }),
+      ...(reason !== undefined && { reason }),
+    };
+
+    try {
+      const exchanged = await oidcClient.genericGrantRequest(
+        configuration,
+        TOKEN_EXCHANGE_GRANT_TYPE,
+        parameters,
+      );
+
+      return {
+        session_transfer_token: exchanged.access_token,
+        issued_token_type:
+          exchanged.issued_token_type || SESSION_TRANSFER_TOKEN_IDENTIFIER,
+        expires_in: exchanged.expires_in,
+        token_type: exchanged.token_type,
+        ...(exchanged.scope !== undefined && { scope: exchanged.scope }),
+      };
+    } catch (error) {
+      debug(
+        'requestSessionTransferToken() failed: %s - %s',
+        error.error,
+        error.error_description,
+      );
+      throw createError(400, error.message, {
+        error: error.error,
+        error_description: error.error_description,
+      });
+    }
+  }
+
+  buildSessionTransferRedirect(targetLoginUrl, result, opts = {}) {
+    if (!targetLoginUrl || typeof targetLoginUrl !== 'string') {
+      throw createError(400, 'targetLoginUrl must be a non-empty string');
+    }
+    if (!result || !result.session_transfer_token) {
+      throw createError(
+        400,
+        'result must be a SessionTransferTokenResult with a session_transfer_token',
+      );
+    }
+
+    const parsed = new url.URL(targetLoginUrl);
+    parsed.searchParams.set(
+      'session_transfer_token',
+      result.session_transfer_token,
+    );
+
+    const org = opts.organization;
+    if (org) {
+      parsed.searchParams.set('organization', org);
+    }
+
+    return parsed.toString();
   }
 }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -553,20 +553,13 @@ class RequestContext {
       ...validateTokenExchangeExtras(extra),
     };
 
+    let exchanged;
     try {
-      const exchanged = await oidcClient.genericGrantRequest(
+      exchanged = await oidcClient.genericGrantRequest(
         configuration,
         TOKEN_EXCHANGE_GRANT_TYPE,
         parameters,
       );
-
-      return {
-        session_transfer_token: exchanged.access_token,
-        issued_token_type: exchanged.issued_token_type || '',
-        expires_in: exchanged.expires_in,
-        token_type: exchanged.token_type,
-        ...(exchanged.scope !== undefined && { scope: exchanged.scope }),
-      };
     } catch (error) {
       debug(
         'requestSessionTransferToken() failed: %s - %s',
@@ -578,6 +571,22 @@ class RequestContext {
         error_description: error.error_description,
       });
     }
+
+    if (exchanged.issued_token_type !== SESSION_TRANSFER_TOKEN_IDENTIFIER) {
+      throw createError(
+        500,
+        `Unexpected issued_token_type: expected "${SESSION_TRANSFER_TOKEN_IDENTIFIER}", got "${exchanged.issued_token_type ?? ''}"`,
+        { error: 'invalid_token_response' },
+      );
+    }
+
+    return {
+      session_transfer_token: exchanged.access_token,
+      issued_token_type: exchanged.issued_token_type,
+      expires_in: exchanged.expires_in,
+      token_type: exchanged.token_type,
+      ...(exchanged.scope !== undefined && { scope: exchanged.scope }),
+    };
   }
 
   buildSessionTransferRedirect(targetLoginUrl, result, opts = {}) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -37,6 +37,7 @@ const {
   extractSessionExpiry,
   isSessionExpiryReached,
   isSessionExpiryInPast,
+  isIdTokenExpired,
 } = require('./utils/sessionExpiry');
 
 // Caches one RemoteJWKSet instance per auth() configuration for backchannel logout token verification.
@@ -456,7 +457,7 @@ class RequestContext {
       actor_token_type,
       organization,
       scope,
-      reason,
+      extra,
     } = options;
 
     validateSubjectToken(subject_token);
@@ -475,7 +476,6 @@ class RequestContext {
       resolvedActorTokenType = actor_token_type || ID_TOKEN_IDENTIFIER;
     } else {
       // Source actor from the current session id_token.
-      // If the token set is expired and there's a refresh token, refresh first.
       const ts = tokenSet.call(this);
 
       if (!ts) {
@@ -486,7 +486,24 @@ class RequestContext {
         );
       }
 
-      if (ts.expired() && ts.refresh_token) {
+      const idToken = this.idToken;
+      if (!idToken) {
+        throw createError(
+          400,
+          'No actor available: session exists but contains no id_token. Ensure the session was established with the openid scope, or pass an explicit actor_token.',
+          { error: 'actor_unavailable' },
+        );
+      }
+
+      const { exp } = ts.claims();
+      if (isIdTokenExpired(exp)) {
+        if (!ts.refresh_token) {
+          throw createError(
+            400,
+            'No actor available: id_token has expired and no refresh token is available.',
+            { error: 'actor_unavailable' },
+          );
+        }
         debug(
           'requestSessionTransferToken: id_token expired, refreshing session',
         );
@@ -501,14 +518,7 @@ class RequestContext {
         }
       }
 
-      const idToken = this.idToken;
-      if (!idToken) {
-        throw createError(400, 'No actor available: no id_token in session.', {
-          error: 'actor_unavailable',
-        });
-      }
-
-      resolvedActorToken = idToken;
+      resolvedActorToken = this.idToken;
       resolvedActorTokenType = ID_TOKEN_IDENTIFIER;
     }
 
@@ -532,7 +542,7 @@ class RequestContext {
       audience,
       ...(scope !== undefined && { scope }),
       ...(organization !== undefined && { organization }),
-      ...(reason !== undefined && { reason }),
+      ...validateTokenExchangeExtras(extra),
     };
 
     try {
@@ -544,8 +554,7 @@ class RequestContext {
 
       return {
         session_transfer_token: exchanged.access_token,
-        issued_token_type:
-          exchanged.issued_token_type || SESSION_TRANSFER_TOKEN_IDENTIFIER,
+        issued_token_type: exchanged.issued_token_type || '',
         expires_in: exchanged.expires_in,
         token_type: exchanged.token_type,
         ...(exchanged.scope !== undefined && { scope: exchanged.scope }),

--- a/lib/context.js
+++ b/lib/context.js
@@ -516,6 +516,14 @@ class RequestContext {
             { error: 'actor_unavailable' },
           );
         }
+        const refreshedExp = tokenSet.call(this)?.claims()?.exp;
+        if (!this.idToken || isIdTokenExpired(refreshedExp)) {
+          throw createError(
+            400,
+            'No actor available: refresh did not return a new id_token.',
+            { error: 'actor_unavailable' },
+          );
+        }
       }
 
       resolvedActorToken = this.idToken;

--- a/lib/context.js
+++ b/lib/context.js
@@ -495,7 +495,7 @@ class RequestContext {
         );
       }
 
-      const { exp } = ts.claims();
+      const { exp } = ts.claims() || {};
       if (isIdTokenExpired(exp)) {
         if (!ts.refresh_token) {
           throw createError(

--- a/lib/context.js
+++ b/lib/context.js
@@ -515,7 +515,7 @@ class RequestContext {
     }
 
     // Build the session_transfer audience from the configured issuer domain.
-    const issuerHostname = new url.URL(config.issuerBaseURL).hostname;
+    const issuerHostname = new URL(config.issuerBaseURL).hostname;
     const audience = `urn:${issuerHostname}:session_transfer`;
 
     debug(
@@ -566,28 +566,40 @@ class RequestContext {
   }
 
   buildSessionTransferRedirect(targetLoginUrl, result, opts = {}) {
-    if (!targetLoginUrl || typeof targetLoginUrl !== 'string') {
-      throw createError(400, 'targetLoginUrl must be a non-empty string');
+    if (result?.issued_token_type !== SESSION_TRANSFER_TOKEN_IDENTIFIER) {
+      throw new TypeError(
+        `result.issued_token_type must be "${SESSION_TRANSFER_TOKEN_IDENTIFIER}"`,
+      );
     }
-    if (!result || !result.session_transfer_token) {
-      throw createError(
-        400,
+
+    if (
+      typeof result.session_transfer_token !== 'string' ||
+      !result.session_transfer_token
+    ) {
+      throw new TypeError(
         'result must be a SessionTransferTokenResult with a session_transfer_token',
       );
     }
 
-    const parsed = new url.URL(targetLoginUrl);
-    parsed.searchParams.set(
+    let redirectUrl;
+    try {
+      redirectUrl = new URL(targetLoginUrl);
+    } catch {
+      throw new TypeError('targetLoginUrl must be a valid URL');
+    }
+    redirectUrl.searchParams.set(
       'session_transfer_token',
       result.session_transfer_token,
     );
 
     const org = opts.organization;
-    if (org) {
-      parsed.searchParams.set('organization', org);
+    if (org !== undefined) {
+      if (typeof org !== 'string' || !org.trim())
+        throw new TypeError('organization must be a non-empty string');
+      redirectUrl.searchParams.set('organization', org);
     }
 
-    return parsed.toString();
+    return redirectUrl.toString();
   }
 }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -39,6 +39,7 @@ const {
   isSessionExpiryInPast,
   isIdTokenExpired,
 } = require('./utils/sessionExpiry');
+const { extractOidcError } = require('./utils/oidcError');
 
 // Caches one RemoteJWKSet instance per auth() configuration for backchannel logout token verification.
 const jwksClientCache = new Map();
@@ -561,14 +562,15 @@ class RequestContext {
         parameters,
       );
     } catch (error) {
+      const extracted = extractOidcError(error);
       debug(
         'requestSessionTransferToken() failed: %s - %s',
-        error.error,
-        error.error_description,
+        extracted.error,
+        extracted.error_description,
       );
-      throw createError(400, error.message, {
-        error: error.error,
-        error_description: error.error_description,
+      throw createError(400, extracted.message, {
+        error: extracted.error,
+        error_description: extracted.error_description,
       });
     }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -611,6 +611,20 @@ class RequestContext {
     } catch {
       throw new TypeError('targetLoginUrl must be a valid URL');
     }
+
+    const isLoopback =
+      redirectUrl.hostname === 'localhost' ||
+      redirectUrl.hostname === '127.0.0.1' ||
+      redirectUrl.hostname === '[::1]';
+    if (
+      redirectUrl.protocol !== 'https:' &&
+      !(redirectUrl.protocol === 'http:' && isLoopback)
+    ) {
+      throw new TypeError(
+        'targetLoginUrl must use https (http is allowed only for localhost/loopback). ' +
+          'The session transfer token is a single-use credential and must not be sent over an insecure or untrusted URL.',
+      );
+    }
     redirectUrl.searchParams.set(
       'session_transfer_token',
       result.session_transfer_token,

--- a/lib/utils/oidcError.js
+++ b/lib/utils/oidcError.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/**
+ * Extracts a meaningful message and OAuth error fields from openid-client v6 /
+ * oauth4webapi errors.
+ *
+ * Error classes from those libraries fall into two categories:
+ *  - ResponseBodyError / AuthorizationResponseError: populated from the AS
+ *    response body — .error and .error_description are the authoritative fields.
+ *  - ClientError (codes: INVALID_RESPONSE, RESPONSE_IS_NOT_CONFORM, etc.):
+ *    .message is always a generic constant string; the useful detail is in
+ *    .cause.message (e.g. 'unexpected JWT "alg" header parameter') with
+ *    additional context in .cause.cause (e.g. { header, expected, reason }).
+ *  - Anything else: fall back to .message.
+ */
+function extractOidcError(error) {
+  if (error.error_description) {
+    return {
+      message: error.error_description,
+      error: error.error,
+      error_description: error.error_description,
+    };
+  }
+  if (error.cause?.message && error.cause.message !== error.message) {
+    const detail = error.cause.cause;
+    const suffix =
+      detail && typeof detail === 'object' && !Array.isArray(detail)
+        ? ` (${Object.entries(detail)
+            .filter(([, v]) => v !== undefined)
+            .map(([k, v]) => `${k}: ${JSON.stringify(v)}`)
+            .join(', ')})`
+        : '';
+    return {
+      message: `${error.cause.message}${suffix}`,
+      error: error.error || error.code,
+      error_description: `${error.cause.message}${suffix}`,
+    };
+  }
+  return {
+    message: error.message,
+    error: error.error || error.code,
+    error_description: error.message,
+  };
+}
+
+module.exports = { extractOidcError };

--- a/lib/utils/sessionExpiry.js
+++ b/lib/utils/sessionExpiry.js
@@ -56,6 +56,7 @@ function isSessionExpiryInPast(sessionExpiresAt, issuedAt) {
  * @param {number} exp - the `exp` claim from the decoded ID token
  */
 function isIdTokenExpired(exp) {
+  if (typeof exp !== 'number' || !Number.isFinite(exp)) return true;
   return exp <= epoch() + SESSION_EXPIRY_LEEWAY;
 }
 

--- a/lib/utils/sessionExpiry.js
+++ b/lib/utils/sessionExpiry.js
@@ -50,9 +50,19 @@ function isSessionExpiryInPast(sessionExpiresAt, issuedAt) {
   return isSessionExpiryReached(sessionExpiresAt, reference);
 }
 
+/**
+ * Returns whether an ID token's `exp` claim is expired, applying a forward skew so a token
+ * about to expire is treated as already expired and refreshed before being sent as an actor token.
+ * @param {number} exp - the `exp` claim from the decoded ID token
+ */
+function isIdTokenExpired(exp) {
+  return exp <= epoch() + SESSION_EXPIRY_LEEWAY;
+}
+
 module.exports = {
   SESSION_EXPIRY_LEEWAY,
   extractSessionExpiry,
   isSessionExpiryReached,
   isSessionExpiryInPast,
+  isIdTokenExpired,
 };

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -293,6 +293,7 @@ describe('client initialization', function () {
         httpTimeout: 500,
       });
       await expect(getClient(config)).to.be.rejectedWith('operation timed out');
+      nock.cleanAll();
     });
   });
 

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -293,7 +293,6 @@ describe('client initialization', function () {
         httpTimeout: 500,
       });
       await expect(getClient(config)).to.be.rejectedWith('operation timed out');
-      nock.cleanAll();
     });
   });
 

--- a/test/sessionTransferToken.tests.js
+++ b/test/sessionTransferToken.tests.js
@@ -828,4 +828,49 @@ describe('buildSessionTransferRedirect', () => {
       /result must be a SessionTransferTokenResult with a session_transfer_token/,
     );
   });
+
+  it('throws TypeError when targetLoginUrl uses http with a non-loopback host', async () => {
+    const response = await setupRedirect('http://app.example.com/login', {
+      session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    });
+    assert.equal(response.statusCode, 500);
+    assert.match(response.body.err.message, /must use https/);
+  });
+
+  it('throws TypeError when targetLoginUrl uses a non-http/https scheme', async () => {
+    const response = await setupRedirect('ftp://app.example.com/login', {
+      session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    });
+    assert.equal(response.statusCode, 500);
+    assert.match(response.body.err.message, /must use https/);
+  });
+
+  it('allows http for localhost', async () => {
+    const response = await setupRedirect('http://localhost:3001/login', {
+      session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    });
+    assert.equal(response.statusCode, 200);
+    assert.include(response.body.url, 'session_transfer_token=__test_stt__');
+  });
+
+  it('allows http for 127.0.0.1', async () => {
+    const response = await setupRedirect('http://127.0.0.1:3001/login', {
+      session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    });
+    assert.equal(response.statusCode, 200);
+    assert.include(response.body.url, 'session_transfer_token=__test_stt__');
+  });
+
+  it('allows http for [::1]', async () => {
+    const response = await setupRedirect('http://[::1]:3001/login', {
+      session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    });
+    assert.equal(response.statusCode, 200);
+    assert.include(response.body.url, 'session_transfer_token=__test_stt__');
+  });
 });

--- a/test/sessionTransferToken.tests.js
+++ b/test/sessionTransferToken.tests.js
@@ -1,0 +1,595 @@
+const assert = require('chai').assert;
+const nock = require('nock');
+const qs = require('querystring');
+const express = require('express');
+const request = require('request-promise-native').defaults({
+  simple: false,
+  resolveWithFullResponse: true,
+});
+
+const { auth } = require('..');
+const { create: createServer } = require('./fixture/server');
+const { makeIdToken } = require('./fixture/cert');
+
+const baseUrl = 'http://localhost:3000';
+
+const SESSION_TRANSFER_TOKEN_IDENTIFIER =
+  'urn:auth0:params:oauth:token-type:session_transfer_token';
+const ID_TOKEN_IDENTIFIER = 'urn:ietf:params:oauth:token-type:id_token';
+
+const defaultConfig = {
+  secret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  baseURL: 'http://example.org',
+  issuerBaseURL: 'https://op.example.com',
+  authRequired: false,
+};
+
+const defaultSession = () => ({
+  id_token: makeIdToken(),
+  access_token: '__test_access_token__',
+  token_type: 'Bearer',
+  expires_at: Math.floor(Date.now() / 1000) + 86400,
+});
+
+const defaultSTTResponse = () => ({
+  issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+  access_token: '__test_stt__',
+  token_type: 'N_A',
+  expires_in: 60,
+});
+
+// ---------------------------------------------------------------------------
+// requestSessionTransferToken tests
+// ---------------------------------------------------------------------------
+
+describe('requestSessionTransferToken', () => {
+  let server;
+
+  afterEach(() => {
+    nock.cleanAll();
+    if (server) {
+      server.close();
+    }
+  });
+
+  const setup = async ({
+    authConfig = {},
+    sttOptions = {},
+    mockTokenResponse = null,
+    sessionData = null,
+  } = {}) => {
+    const config = { ...defaultConfig, ...authConfig };
+
+    const router = express.Router();
+    router.use(auth(config));
+    router.get('/stt', async (req, res, next) => {
+      try {
+        const result = await req.oidc.requestSessionTransferToken(sttOptions);
+        res.json(result);
+      } catch (err) {
+        next(err);
+      }
+    });
+
+    server = await createServer(router);
+    const jar = request.jar();
+
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: sessionData !== null ? sessionData : defaultSession(),
+    });
+
+    let capturedBody;
+    if (mockTokenResponse !== false) {
+      nock('https://op.example.com')
+        .post('/oauth/token')
+        .reply(
+          mockTokenResponse ? mockTokenResponse.status : 200,
+          function (uri, body) {
+            capturedBody = qs.parse(body);
+            return mockTokenResponse
+              ? mockTokenResponse.body
+              : defaultSTTResponse();
+          },
+        );
+    }
+
+    const response = await request.get('/stt', { baseUrl, jar, json: true });
+    return { response, capturedBody };
+  };
+
+  // -------------------------------------------------------------------------
+  // Actor resolution
+  // -------------------------------------------------------------------------
+
+  it('sources actor_token from the agent session id_token when not explicitly provided', async () => {
+    const idToken = makeIdToken();
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      sessionData: {
+        id_token: idToken,
+        access_token: '__test_access_token__',
+        token_type: 'Bearer',
+        expires_at: Math.floor(Date.now() / 1000) + 86400,
+      },
+    });
+    assert.equal(capturedBody.actor_token, idToken);
+    assert.equal(capturedBody.actor_token_type, ID_TOKEN_IDENTIFIER);
+  });
+
+  it('uses explicit actor_token and actor_token_type when provided', async () => {
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+        actor_token: '__explicit_actor_token__',
+        actor_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+      },
+    });
+    assert.equal(capturedBody.actor_token, '__explicit_actor_token__');
+    assert.equal(
+      capturedBody.actor_token_type,
+      'urn:ietf:params:oauth:token-type:access_token',
+    );
+  });
+
+  it('defaults actor_token_type to id_token URN when actor_token provided without type', async () => {
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+        actor_token: '__explicit_actor_token__',
+      },
+    });
+    assert.equal(capturedBody.actor_token, '__explicit_actor_token__');
+    assert.equal(capturedBody.actor_token_type, ID_TOKEN_IDENTIFIER);
+  });
+
+  it('throws 400 with actor_unavailable when agent has no session', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      sessionData: {},
+      mockTokenResponse: false,
+    });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.err.error, 'actor_unavailable');
+  });
+
+  it('throws 400 with actor_unavailable when explicit actor_token is blank', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+        actor_token: '   ',
+      },
+      mockTokenResponse: false,
+    });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.err.error, 'actor_unavailable');
+  });
+
+  // -------------------------------------------------------------------------
+  // subject_token validation (reuses validateSubjectToken)
+  // -------------------------------------------------------------------------
+
+  it('throws 400 when subject_token is missing', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      mockTokenResponse: false,
+    });
+    assert.equal(response.statusCode, 400);
+    assert.match(response.body.err.message, /subject_token is required/);
+  });
+
+  it('throws 400 when subject_token has leading or trailing whitespace', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '  token  ',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      mockTokenResponse: false,
+    });
+    assert.equal(response.statusCode, 400);
+    assert.match(response.body.err.message, /whitespace/);
+  });
+
+  it("throws 400 when subject_token includes a 'Bearer ' prefix", async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: 'Bearer __test__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      mockTokenResponse: false,
+    });
+    assert.equal(response.statusCode, 400);
+    assert.match(response.body.err.message, /Bearer/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Audience construction
+  // -------------------------------------------------------------------------
+
+  it('sets audience to urn:{issuer-hostname}:session_transfer', async () => {
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+    });
+    assert.equal(capturedBody.audience, 'urn:op.example.com:session_transfer');
+  });
+
+  it('strips protocol from issuerBaseURL when building audience', async () => {
+    // The audience must be urn:{hostname}:session_transfer — not including https://
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+    });
+    // issuerBaseURL is 'https://op.example.com' → audience must be urn:op.example.com:session_transfer
+    assert.notMatch(capturedBody.audience, /https?:\/\//);
+    assert.equal(capturedBody.audience, 'urn:op.example.com:session_transfer');
+  });
+
+  // -------------------------------------------------------------------------
+  // Optional parameters
+  // -------------------------------------------------------------------------
+
+  it('sends scope when provided', async () => {
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+        scope: 'openid profile',
+      },
+    });
+    assert.equal(capturedBody.scope, 'openid profile');
+  });
+
+  it('sends organization when provided', async () => {
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+        organization: 'org_abc123',
+      },
+    });
+    assert.equal(capturedBody.organization, 'org_abc123');
+  });
+
+  it('sends reason when provided', async () => {
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+        reason: 'Investigating TCK-4821',
+      },
+    });
+    assert.equal(capturedBody.reason, 'Investigating TCK-4821');
+  });
+
+  it('omits scope, organization, and reason when not provided', async () => {
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+    });
+    assert.isUndefined(capturedBody.scope);
+    assert.isUndefined(capturedBody.organization);
+    assert.isUndefined(capturedBody.reason);
+  });
+
+  // -------------------------------------------------------------------------
+  // Result shape
+  // -------------------------------------------------------------------------
+
+  it('returns session_transfer_token from access_token in response', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+    });
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.body.session_transfer_token, '__test_stt__');
+  });
+
+  it('returns issued_token_type from AS response', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+    });
+    assert.equal(
+      response.body.issued_token_type,
+      SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    );
+  });
+
+  it('falls back to SESSION_TRANSFER_TOKEN_IDENTIFIER when issued_token_type is absent', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      mockTokenResponse: {
+        status: 200,
+        body: {
+          access_token: '__test_stt__',
+          token_type: 'N_A',
+          expires_in: 60,
+          // no issued_token_type
+        },
+      },
+    });
+    assert.equal(response.statusCode, 200);
+    assert.equal(
+      response.body.issued_token_type,
+      SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    );
+  });
+
+  it('result has no access_token field — STT is in session_transfer_token', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+    });
+    assert.isUndefined(response.body.access_token);
+    assert.isString(response.body.session_transfer_token);
+  });
+
+  it('result has no act claim — act is not on the STT response', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+    });
+    assert.isUndefined(response.body.act);
+  });
+
+  // -------------------------------------------------------------------------
+  // STT is never written to the session
+  // -------------------------------------------------------------------------
+
+  it('does not persist the STT to the session', async () => {
+    const router = express.Router();
+    router.use(auth({ ...defaultConfig }));
+    router.get('/stt', async (req, res, next) => {
+      try {
+        await req.oidc.requestSessionTransferToken({
+          subject_token: '__test_subject__',
+          subject_token_type: 'urn:mycompany:test-token',
+        });
+        res.json(req.appSession);
+      } catch (err) {
+        next(err);
+      }
+    });
+
+    server = await createServer(router);
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: defaultSession(),
+    });
+
+    nock('https://op.example.com')
+      .post('/oauth/token')
+      .reply(200, defaultSTTResponse());
+
+    const response = await request.get('/stt', { baseUrl, jar, json: true });
+    assert.equal(response.statusCode, 200);
+    assert.notProperty(response.body, 'session_transfer_token');
+    assert.notProperty(response.body, 'issued_token_type');
+  });
+
+  // -------------------------------------------------------------------------
+  // Server-side error mapping
+  // -------------------------------------------------------------------------
+
+  it('propagates setactor_required AS 400 as HTTP 400', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      mockTokenResponse: {
+        status: 400,
+        body: {
+          error: 'setactor_required',
+          error_description:
+            'setActor is required when requesting a session transfer token via token exchange.',
+        },
+      },
+    });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.err.error, 'setactor_required');
+  });
+
+  it('propagates session_transfer_disabled AS 400 as HTTP 400', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      mockTokenResponse: {
+        status: 400,
+        body: {
+          error: 'session_transfer_disabled',
+          error_description:
+            'Session Transfer Tokens cannot be requested using Custom Token Exchange.',
+        },
+      },
+    });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.err.error, 'session_transfer_disabled');
+  });
+
+  it('propagates generic AS errors as HTTP 400', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      mockTokenResponse: {
+        status: 400,
+        body: {
+          error: 'access_denied',
+          error_description: 'Token exchange not allowed',
+        },
+      },
+    });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.err.error, 'access_denied');
+  });
+
+  // -------------------------------------------------------------------------
+  // grant_type wired correctly
+  // -------------------------------------------------------------------------
+
+  it('uses token-exchange grant_type', async () => {
+    const { capturedBody } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+    });
+    assert.equal(
+      capturedBody.grant_type,
+      'urn:ietf:params:oauth:grant-type:token-exchange',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSessionTransferRedirect tests
+// ---------------------------------------------------------------------------
+
+describe('buildSessionTransferRedirect', () => {
+  let server;
+
+  afterEach(() => {
+    if (server) {
+      server.close();
+    }
+  });
+
+  const setupRedirect = async (targetLoginUrl, result, opts) => {
+    const router = express.Router();
+    router.use(auth({ ...defaultConfig }));
+    router.get('/redirect', async (req, res, next) => {
+      try {
+        const url = req.oidc.buildSessionTransferRedirect(
+          targetLoginUrl,
+          result,
+          opts,
+        );
+        res.json({ url });
+      } catch (err) {
+        next(err);
+      }
+    });
+
+    server = await createServer(router);
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: defaultSession(),
+    });
+
+    return request.get('/redirect', { baseUrl, jar, json: true });
+  };
+
+  it('appends session_transfer_token as a query param', async () => {
+    const response = await setupRedirect('https://app.example.com/login', {
+      session_transfer_token: '__test_stt__',
+    });
+    assert.equal(response.statusCode, 200);
+    const redirectUrl = new URL(response.body.url);
+    assert.equal(
+      redirectUrl.searchParams.get('session_transfer_token'),
+      '__test_stt__',
+    );
+  });
+
+  it('URL-encodes the STT', async () => {
+    const sttWithSpecialChars = 'abc+def/ghi=';
+    const response = await setupRedirect('https://app.example.com/login', {
+      session_transfer_token: sttWithSpecialChars,
+    });
+    assert.equal(response.statusCode, 200);
+    const redirectUrl = new URL(response.body.url);
+    assert.equal(
+      redirectUrl.searchParams.get('session_transfer_token'),
+      sttWithSpecialChars,
+    );
+  });
+
+  it('appends organization when provided in opts', async () => {
+    const response = await setupRedirect(
+      'https://app.example.com/login',
+      { session_transfer_token: '__test_stt__' },
+      { organization: 'org_globex' },
+    );
+    assert.equal(response.statusCode, 200);
+    const redirectUrl = new URL(response.body.url);
+    assert.equal(redirectUrl.searchParams.get('organization'), 'org_globex');
+    assert.equal(
+      redirectUrl.searchParams.get('session_transfer_token'),
+      '__test_stt__',
+    );
+  });
+
+  it('does not append organization when not provided', async () => {
+    const response = await setupRedirect('https://app.example.com/login', {
+      session_transfer_token: '__test_stt__',
+    });
+    assert.equal(response.statusCode, 200);
+    const redirectUrl = new URL(response.body.url);
+    assert.isNull(redirectUrl.searchParams.get('organization'));
+  });
+
+  it('preserves existing query params on targetLoginUrl', async () => {
+    const response = await setupRedirect(
+      'https://app.example.com/login?foo=bar',
+      { session_transfer_token: '__test_stt__' },
+    );
+    assert.equal(response.statusCode, 200);
+    const redirectUrl = new URL(response.body.url);
+    assert.equal(redirectUrl.searchParams.get('foo'), 'bar');
+    assert.equal(
+      redirectUrl.searchParams.get('session_transfer_token'),
+      '__test_stt__',
+    );
+  });
+
+  it('throws 400 when targetLoginUrl is missing', async () => {
+    const response = await setupRedirect(null, {
+      session_transfer_token: '__test_stt__',
+    });
+    assert.equal(response.statusCode, 400);
+  });
+
+  it('throws 400 when result has no session_transfer_token', async () => {
+    const response = await setupRedirect('https://app.example.com/login', {});
+    assert.equal(response.statusCode, 400);
+  });
+});

--- a/test/sessionTransferToken.tests.js
+++ b/test/sessionTransferToken.tests.js
@@ -197,6 +197,25 @@ describe('requestSessionTransferToken', () => {
     assert.equal(response.body.err.error, 'actor_unavailable');
   });
 
+  it('treats id_token with non-numeric exp as expired and fails actor_unavailable when no refresh_token', async () => {
+    const tokenWithBadExp = makeIdToken({ exp: 'not-a-number' });
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      sessionData: {
+        id_token: tokenWithBadExp,
+        access_token: '__test_access_token__',
+        token_type: 'Bearer',
+        expires_at: Math.floor(Date.now() / 1000) + 86400,
+      },
+      mockTokenResponse: false,
+    });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.err.error, 'actor_unavailable');
+  });
+
   it('refreshes expired id_token and uses the fresh one as actor when refresh_token is available', async () => {
     const expiredIdToken = makeIdToken({
       exp: Math.floor(Date.now() / 1000) - 3600,

--- a/test/sessionTransferToken.tests.js
+++ b/test/sessionTransferToken.tests.js
@@ -521,6 +521,7 @@ describe('buildSessionTransferRedirect', () => {
   it('appends session_transfer_token as a query param', async () => {
     const response = await setupRedirect('https://app.example.com/login', {
       session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
     });
     assert.equal(response.statusCode, 200);
     const redirectUrl = new URL(response.body.url);
@@ -534,6 +535,7 @@ describe('buildSessionTransferRedirect', () => {
     const sttWithSpecialChars = 'abc+def/ghi=';
     const response = await setupRedirect('https://app.example.com/login', {
       session_transfer_token: sttWithSpecialChars,
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
     });
     assert.equal(response.statusCode, 200);
     const redirectUrl = new URL(response.body.url);
@@ -546,7 +548,10 @@ describe('buildSessionTransferRedirect', () => {
   it('appends organization when provided in opts', async () => {
     const response = await setupRedirect(
       'https://app.example.com/login',
-      { session_transfer_token: '__test_stt__' },
+      {
+        session_transfer_token: '__test_stt__',
+        issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+      },
       { organization: 'org_globex' },
     );
     assert.equal(response.statusCode, 200);
@@ -561,6 +566,7 @@ describe('buildSessionTransferRedirect', () => {
   it('does not append organization when not provided', async () => {
     const response = await setupRedirect('https://app.example.com/login', {
       session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
     });
     assert.equal(response.statusCode, 200);
     const redirectUrl = new URL(response.body.url);
@@ -570,7 +576,10 @@ describe('buildSessionTransferRedirect', () => {
   it('preserves existing query params on targetLoginUrl', async () => {
     const response = await setupRedirect(
       'https://app.example.com/login?foo=bar',
-      { session_transfer_token: '__test_stt__' },
+      {
+        session_transfer_token: '__test_stt__',
+        issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+      },
     );
     assert.equal(response.statusCode, 200);
     const redirectUrl = new URL(response.body.url);
@@ -581,15 +590,99 @@ describe('buildSessionTransferRedirect', () => {
     );
   });
 
-  it('throws 400 when targetLoginUrl is missing', async () => {
+  it('throws TypeError when targetLoginUrl is null', async () => {
     const response = await setupRedirect(null, {
       session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
     });
-    assert.equal(response.statusCode, 400);
+    assert.equal(response.statusCode, 500);
+    assert.match(
+      response.body.err.message,
+      /targetLoginUrl must be a valid URL/,
+    );
   });
 
-  it('throws 400 when result has no session_transfer_token', async () => {
-    const response = await setupRedirect('https://app.example.com/login', {});
-    assert.equal(response.statusCode, 400);
+  it('throws TypeError when targetLoginUrl is whitespace only', async () => {
+    const response = await setupRedirect('   ', {
+      session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    });
+    assert.equal(response.statusCode, 500);
+    assert.match(
+      response.body.err.message,
+      /targetLoginUrl must be a valid URL/,
+    );
+  });
+
+  it('throws TypeError when targetLoginUrl is not a valid URL', async () => {
+    const response = await setupRedirect('not-a-valid-url', {
+      session_transfer_token: '__test_stt__',
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    });
+    assert.equal(response.statusCode, 500);
+    assert.match(
+      response.body.err.message,
+      /targetLoginUrl must be a valid URL/,
+    );
+  });
+
+  it('throws TypeError when organization is not a string', async () => {
+    const response = await setupRedirect(
+      'https://app.example.com/login',
+      {
+        session_transfer_token: '__test_stt__',
+        issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+      },
+      { organization: 123 },
+    );
+    assert.equal(response.statusCode, 500);
+    assert.match(
+      response.body.err.message,
+      /organization must be a non-empty string/,
+    );
+  });
+
+  it('throws TypeError when organization is a blank string', async () => {
+    const response = await setupRedirect(
+      'https://app.example.com/login',
+      {
+        session_transfer_token: '__test_stt__',
+        issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+      },
+      { organization: '   ' },
+    );
+    assert.equal(response.statusCode, 500);
+    assert.match(
+      response.body.err.message,
+      /organization must be a non-empty string/,
+    );
+  });
+
+  it('throws TypeError when result has wrong issued_token_type', async () => {
+    const response = await setupRedirect('https://app.example.com/login', {
+      session_transfer_token: '__test_stt__',
+      issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+    });
+    assert.equal(response.statusCode, 500);
+    assert.match(response.body.err.message, /issued_token_type/);
+  });
+
+  it('throws TypeError when result has no issued_token_type', async () => {
+    const response = await setupRedirect('https://app.example.com/login', {
+      session_transfer_token: '__test_stt__',
+    });
+    assert.equal(response.statusCode, 500);
+    assert.match(response.body.err.message, /issued_token_type/);
+  });
+
+  it('throws TypeError when result has no session_transfer_token', async () => {
+    const response = await setupRedirect('https://app.example.com/login', {
+      issued_token_type: SESSION_TRANSFER_TOKEN_IDENTIFIER,
+    });
+    assert.equal(response.statusCode, 500);
+    assert.match(
+      response.body.err.message,
+      /result must be a SessionTransferTokenResult with a session_transfer_token/,
+    );
   });
 });

--- a/test/sessionTransferToken.tests.js
+++ b/test/sessionTransferToken.tests.js
@@ -254,6 +254,55 @@ describe('requestSessionTransferToken', () => {
     assert.equal(capturedSttBody.actor_token_type, ID_TOKEN_IDENTIFIER);
   });
 
+  it('throws 400 with actor_unavailable when refresh succeeds but returns no new id_token', async () => {
+    const expiredIdToken = makeIdToken({
+      exp: Math.floor(Date.now() / 1000) - 3600,
+    });
+
+    const router = express.Router();
+    router.use(auth({ ...defaultConfig }));
+    router.get('/stt', async (req, res, next) => {
+      try {
+        const result = await req.oidc.requestSessionTransferToken({
+          subject_token: '__test_subject__',
+          subject_token_type: 'urn:mycompany:test-token',
+        });
+        res.json(result);
+      } catch (err) {
+        next(err);
+      }
+    });
+
+    server = await createServer(router);
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: expiredIdToken,
+        access_token: '__test_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: Math.floor(Date.now() / 1000) - 3600,
+      },
+    });
+
+    // Refresh grant succeeds but returns no new id_token — old expired one is kept
+    nock('https://op.example.com').post('/oauth/token').reply(200, {
+      access_token: '__new_access_token__',
+      token_type: 'Bearer',
+      expires_in: 86400,
+    });
+
+    const response = await request.get('/stt', { baseUrl, jar, json: true });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.err.error, 'actor_unavailable');
+    assert.match(
+      response.body.err.message,
+      /refresh did not return a new id_token/,
+    );
+  });
+
   // -------------------------------------------------------------------------
   // subject_token validation (reuses validateSubjectToken)
   // -------------------------------------------------------------------------

--- a/test/sessionTransferToken.tests.js
+++ b/test/sessionTransferToken.tests.js
@@ -176,6 +176,84 @@ describe('requestSessionTransferToken', () => {
     assert.equal(response.body.err.error, 'actor_unavailable');
   });
 
+  it('throws 400 with actor_unavailable when id_token is expired and no refresh_token', async () => {
+    const expiredIdToken = makeIdToken({
+      exp: Math.floor(Date.now() / 1000) - 3600,
+    });
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      sessionData: {
+        id_token: expiredIdToken,
+        access_token: '__test_access_token__',
+        token_type: 'Bearer',
+        expires_at: Math.floor(Date.now() / 1000) - 3600,
+      },
+      mockTokenResponse: false,
+    });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.err.error, 'actor_unavailable');
+  });
+
+  it('refreshes expired id_token and uses the fresh one as actor when refresh_token is available', async () => {
+    const expiredIdToken = makeIdToken({
+      exp: Math.floor(Date.now() / 1000) - 3600,
+    });
+    const freshIdToken = makeIdToken();
+
+    const router = express.Router();
+    router.use(auth({ ...defaultConfig }));
+    router.get('/stt', async (req, res, next) => {
+      try {
+        const result = await req.oidc.requestSessionTransferToken({
+          subject_token: '__test_subject__',
+          subject_token_type: 'urn:mycompany:test-token',
+        });
+        res.json(result);
+      } catch (err) {
+        next(err);
+      }
+    });
+
+    server = await createServer(router);
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: expiredIdToken,
+        access_token: '__test_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: Math.floor(Date.now() / 1000) - 3600,
+      },
+    });
+
+    let capturedSttBody;
+    // First call: refresh grant; second call: STT exchange
+    nock('https://op.example.com')
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: '__new_access_token__',
+        id_token: freshIdToken,
+        refresh_token: '__new_refresh_token__',
+        token_type: 'Bearer',
+        expires_in: 86400,
+      })
+      .post('/oauth/token')
+      .reply(200, function (uri, body) {
+        capturedSttBody = qs.parse(body);
+        return defaultSTTResponse();
+      });
+
+    const response = await request.get('/stt', { baseUrl, jar, json: true });
+    assert.equal(response.statusCode, 200);
+    assert.equal(capturedSttBody.actor_token, freshIdToken);
+    assert.equal(capturedSttBody.actor_token_type, ID_TOKEN_IDENTIFIER);
+  });
+
   // -------------------------------------------------------------------------
   // subject_token validation (reuses validateSubjectToken)
   // -------------------------------------------------------------------------
@@ -268,18 +346,18 @@ describe('requestSessionTransferToken', () => {
     assert.equal(capturedBody.organization, 'org_abc123');
   });
 
-  it('sends reason when provided', async () => {
+  it('forwards extra params to the token endpoint', async () => {
     const { capturedBody } = await setup({
       sttOptions: {
         subject_token: '__test_subject__',
         subject_token_type: 'urn:mycompany:test-token',
-        reason: 'Investigating TCK-4821',
+        extra: { reason: 'Investigating TCK-4821' },
       },
     });
     assert.equal(capturedBody.reason, 'Investigating TCK-4821');
   });
 
-  it('omits scope, organization, and reason when not provided', async () => {
+  it('omits scope, organization, and extra when not provided', async () => {
     const { capturedBody } = await setup({
       sttOptions: {
         subject_token: '__test_subject__',
@@ -288,7 +366,6 @@ describe('requestSessionTransferToken', () => {
     });
     assert.isUndefined(capturedBody.scope);
     assert.isUndefined(capturedBody.organization);
-    assert.isUndefined(capturedBody.reason);
   });
 
   // -------------------------------------------------------------------------
@@ -319,7 +396,7 @@ describe('requestSessionTransferToken', () => {
     );
   });
 
-  it('falls back to SESSION_TRANSFER_TOKEN_IDENTIFIER when issued_token_type is absent', async () => {
+  it('returns empty string for issued_token_type when absent in AS response', async () => {
     const { response } = await setup({
       sttOptions: {
         subject_token: '__test_subject__',
@@ -336,10 +413,7 @@ describe('requestSessionTransferToken', () => {
       },
     });
     assert.equal(response.statusCode, 200);
-    assert.equal(
-      response.body.issued_token_type,
-      SESSION_TRANSFER_TOKEN_IDENTIFIER,
-    );
+    assert.equal(response.body.issued_token_type, '');
   });
 
   it('result has no access_token field — STT is in session_transfer_token', async () => {

--- a/test/sessionTransferToken.tests.js
+++ b/test/sessionTransferToken.tests.js
@@ -445,7 +445,27 @@ describe('requestSessionTransferToken', () => {
     );
   });
 
-  it('returns empty string for issued_token_type when absent in AS response', async () => {
+  it('throws 500 when AS response has unexpected issued_token_type', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      mockTokenResponse: {
+        status: 200,
+        body: {
+          access_token: '__test_stt__',
+          token_type: 'Bearer',
+          expires_in: 60,
+          issued_token_type: 'urn:ietf:params:oauth:token-type:access_token',
+        },
+      },
+    });
+    assert.equal(response.statusCode, 500);
+    assert.match(response.body.err.message, /Unexpected issued_token_type/);
+  });
+
+  it('throws 500 when AS response omits issued_token_type', async () => {
     const { response } = await setup({
       sttOptions: {
         subject_token: '__test_subject__',
@@ -461,8 +481,8 @@ describe('requestSessionTransferToken', () => {
         },
       },
     });
-    assert.equal(response.statusCode, 200);
-    assert.equal(response.body.issued_token_type, '');
+    assert.equal(response.statusCode, 500);
+    assert.match(response.body.err.message, /Unexpected issued_token_type/);
   });
 
   it('result has no access_token field — STT is in session_transfer_token', async () => {

--- a/test/sessionTransferToken.tests.js
+++ b/test/sessionTransferToken.tests.js
@@ -176,6 +176,25 @@ describe('requestSessionTransferToken', () => {
     assert.equal(response.body.err.error, 'actor_unavailable');
   });
 
+  it('throws 400 with actor_unavailable when session has no id_token', async () => {
+    const { response } = await setup({
+      sttOptions: {
+        subject_token: '__test_subject__',
+        subject_token_type: 'urn:mycompany:test-token',
+      },
+      sessionData: {
+        id_token: null,
+        access_token: '__test_access_token__',
+        token_type: 'Bearer',
+        expires_at: Math.floor(Date.now() / 1000) + 86400,
+      },
+      mockTokenResponse: false,
+    });
+    assert.equal(response.statusCode, 400);
+    assert.equal(response.body.err.error, 'actor_unavailable');
+    assert.match(response.body.err.message, /no id_token/);
+  });
+
   it('throws 400 with actor_unavailable when id_token is expired and no refresh_token', async () => {
     const expiredIdToken = makeIdToken({
       exp: Math.floor(Date.now() / 1000) - 3600,
@@ -372,19 +391,6 @@ describe('requestSessionTransferToken', () => {
         subject_token_type: 'urn:mycompany:test-token',
       },
     });
-    assert.equal(capturedBody.audience, 'urn:op.example.com:session_transfer');
-  });
-
-  it('strips protocol from issuerBaseURL when building audience', async () => {
-    // The audience must be urn:{hostname}:session_transfer — not including https://
-    const { capturedBody } = await setup({
-      sttOptions: {
-        subject_token: '__test_subject__',
-        subject_token_type: 'urn:mycompany:test-token',
-      },
-    });
-    // issuerBaseURL is 'https://op.example.com' → audience must be urn:op.example.com:session_transfer
-    assert.notMatch(capturedBody.audience, /https?:\/\//);
     assert.equal(capturedBody.audience, 'urn:op.example.com:session_transfer');
   });
 


### PR DESCRIPTION
## Summary

Adds **Custom Token Exchange (CTE) — Impersonation via Session Transfer**.

This extends the existing `req.oidc.customTokenExchange` surface with two new methods that implement the initiator role of the session transfer flow: an application requests a short-lived, single-use Session Transfer Token (STT) via CTE, then redirects the user's browser to a target app's login URL carrying that STT, which is redeemed at `/authorize` to establish an ephemeral web session as the subject user with the actor recorded in the `act` claim.

### New methods on `req.oidc`

**`requestSessionTransferToken(options)`**

Performs a token exchange against the `urn:{domain}:session_transfer` audience and returns a `SessionTransferTokenResult`. The SDK handles the protocol plumbing automatically:

- Builds the `audience` from the configured `issuerBaseURL` hostname
- Sources the `actor_token` from the current session `id_token`, checking the id_token's own `exp` claim (with a 30s skew). If expired and a refresh token is available, the session is refreshed automatically; if the refresh returns no new id_token, raises `actor_unavailable`. If expired with no refresh token, raises `actor_unavailable` before any network call. An explicit `actor_token` override is accepted to bypass session sourcing entirely.
- Raises `actor_unavailable` (HTTP 400) client-side before any network call when no actor can be resolved.
- Validates that the AS response carries `issued_token_type === "urn:auth0:params:oauth:token-type:session_transfer_token"` — an unexpected or missing value raises HTTP 500 (`invalid_token_response`).
- The returned STT is **never written to the session** — it is a one-shot handle to be forwarded immediately.

```js
app.post('/impersonate', requiresAuth(), async (req, res) => {
  const result = await req.oidc.requestSessionTransferToken({
    subject_token: req.body.customerToken,
    subject_token_type: 'urn:mycompany:customer-subject',
    extra: { reason: 'Investigating ticket TCK-1234' },
  });
  res.redirect(req.oidc.buildSessionTransferRedirect('https://app.example.com/login', result));
});
```

**`buildSessionTransferRedirect(targetLoginUrl, result, opts?)`**

Pure URL builder — appends `session_transfer_token` (and optionally `organization`) as query parameters to `targetLoginUrl`. Makes no network call and writes nothing to the session. The caller passes the returned string to `res.redirect()`.

> **Security:** `targetLoginUrl` must be a trusted, app-controlled value — never derive it from untrusted input (e.g. a query parameter), as the STT would be forwarded to an attacker-controlled host. The URL must use `https:` — `http:` is accepted only for `localhost`, `127.0.0.1`, and `[::1]` for local development; any other scheme or non-loopback `http:` host throws a `TypeError`.

**Target side (no new SDK methods needed)**

The target app forwards the STT to `/authorize` via `res.oidc.login()`. Two things are required: `authRequired: false` on the middleware (so the middleware doesn't intercept the unauthenticated `/login` request before the custom route runs), and `returnTo: '/'` on the login call (to avoid a redirect loop where the callback redirects back to `/login?session_transfer_token=...`):

```js
app.use(auth({
  // ... your other config
  authRequired: false,
  routes: { login: false },
}));

app.get('/login', async (req, res) => {
  await res.oidc.login({
    authorizationParams: {
      session_transfer_token: req.query.session_transfer_token,
    },
    returnTo: '/',
  });
});
```

### New TypeScript types

- `SessionTransferTokenResult` — result type returned by `requestSessionTransferToken`
- `SessionTransferTokenOptions` — input options for `requestSessionTransferToken`
- `SessionTransferRedirectOptions` — options for `buildSessionTransferRedirect`

### Error codes

| Code | HTTP | Where | When |
|------|------|-------|------|
| `actor_unavailable` | 400 | client-side | No actor passed and no usable session `id_token` (not logged in, expired with no refresh token, refresh returned no new id_token, or no `id_token` in session) |
| `setactor_required` | 400 | server | CTE Action did not call `setActor` |
| `session_transfer_disabled` | 400 | server | Session transfer not enabled on the tenant |
| `invalid_token_response` | 500 | client-side | AS returned an unexpected or missing `issued_token_type` |

### Implementation notes

- Fully additive — no existing types, methods, or behavior changed. All existing `customTokenExchange` tests continue to pass.
- Reuses `validateSubjectToken`, `validateTokenExchangeExtras`, `TOKEN_EXCHANGE_GRANT_TYPE`, and the `genericGrantRequest` CTE machinery.
- `isIdTokenExpired(exp)` added to `lib/utils/sessionExpiry.js`, reusing the existing `SESSION_EXPIRY_LEEWAY` (30s skew). Guards against non-numeric `exp` (fails closed — treats as expired).
- `SESSION_TRANSFER_TOKEN_IDENTIFIER` defined as an internal constant in `lib/context.js` — not exported; the URN is documented in EXAMPLES.md and the type declarations for developers who need to branch on `issued_token_type`.
- `extractOidcError()` added to `lib/utils/oidcError.js` — extracts `error_description` from RFC 6749 AS error responses and the `cause` chain from `openid-client` v6 `ClientError` objects. Used in `requestSessionTransferToken` so consumers see the actual AS error (e.g. `"setActor is required..."`) rather than the generic `openid-client` wrapper message.
- `examples/cte-session-transfer.js` — runnable two-server example demonstrating the full initiator → target flow.

## Test plan

- [x] 35 tests in `test/sessionTransferToken.tests.js` covering: actor resolution (session sourcing, explicit override, blank actor, no session, no id_token in session, expired id_token with and without refresh token, refresh returning no new id_token, non-numeric exp), `subject_token` validation, audience construction, optional params (`scope`, `organization`, `extra`), result shape (STT in `session_transfer_token`, no `access_token`, no `act`), `issued_token_type` validation at exchange (unexpected and missing both throw 500), no-persistence guarantee, server error code mapping, and `buildSessionTransferRedirect` URL construction (including https enforcement and all three loopback variants).
- [x] All existing tests pass without modification.
- [x] End-to-end smoke test passed: STT minted, forwarded to target app, redeemed at `/authorize`, impersonation session established with correct `sub` (customer) and `act.sub` (agent). Auth0 logs confirmed `triggered_by_session_transfer_token: true`.