### PR TITLE
feat(mTLS): add Mutual TLS (RFC 8705) client authentication support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -834,7 +834,8 @@ interface ConfigParams {
    * A custom fetch function to use for all OIDC HTTP requests (discovery, token, userinfo, etc.).
    * The SDK wraps this function to inject required headers (User-Agent, Auth0-Client telemetry) before making requests.
    *
-   * This is useful for configuring proxies or custom HTTP behavior.
+   * Required when `useMtls` is `true` — provide a TLS-aware implementation that attaches your
+   * client certificate to every outbound request (e.g. `undici` with `connect: { key, cert }`).
    *
    * @example
    * ```js
@@ -853,6 +854,47 @@ interface ConfigParams {
    * Optional User-Agent header value for oidc client requests.  Default is `express-openid-connect/{version}`.
    */
   httpUserAgent?: string;
+
+  /**
+   * Enable mTLS (Mutual TLS, RFC 8705) client authentication.
+   *
+   * When `true`, the SDK authenticates with Auth0 using a TLS client certificate instead of a
+   * `clientSecret` or `clientAssertionSigningKey`. Access tokens will carry a `cnf.x5t#S256`
+   * claim binding them to the certificate fingerprint (certificate-bound tokens).
+   *
+   * Requires:
+   * 1. A TLS-aware `customFetch` implementation that attaches your client certificate
+   *    (e.g. Node.js `undici` configured with `connect: { key, cert }`).
+   * 2. The mTLS feature to be enabled on your Auth0 tenant.
+   *
+   * You do **not** need to provide `clientSecret` when `useMtls` is `true`.
+   *
+   * Can also be enabled by setting the `AUTH0_MTLS=true` environment variable.
+   *
+   * @default false
+   *
+   * @example
+   * ```js
+   * const { Agent, fetch: undiciFetch } = require('undici');
+   * const { readFileSync } = require('fs');
+   *
+   * const tlsAgent = new Agent({
+   *   connect: {
+   *     key: readFileSync('client.key'),
+   *     cert: readFileSync('client.crt'),
+   *   },
+   * });
+   *
+   * app.use(auth({
+   *   useMtls: true,
+   *   customFetch: (url, options) =>
+   *     undiciFetch(url, { ...options, dispatcher: tlsAgent }),
+   * }));
+   * ```
+   *
+   * @see {@link https://datatracker.ietf.org/doc/html/rfc8705 | RFC 8705: OAuth 2.0 Mutual-TLS Client Authentication}
+   */
+  useMtls?: boolean;
 }
 
 interface SessionStorePayload<Data = Session> {
@@ -1249,4 +1291,35 @@ export class SessionExpiredError extends Error {
   readonly status: 401;
   readonly statusCode: 401;
   constructor(message?: string);
+}
+
+/**
+ * Error codes for mTLS (Mutual TLS, RFC 8705) configuration failures.
+ */
+export const MtlsErrorCode: {
+  readonly MTLS_REQUIRES_CUSTOM_FETCH: 'mtls_requires_custom_fetch';
+};
+
+/**
+ * Thrown during `auth()` initialization when the mTLS configuration is invalid.
+ *
+ * Currently thrown when `useMtls: true` is set without a `customFetch` implementation.
+ * Catch by `error.code` string rather than `instanceof` to be bundler-safe.
+ *
+ * ```js
+ * const { MtlsError, MtlsErrorCode } = require('express-openid-connect');
+ *
+ * try {
+ *   app.use(auth({ useMtls: true })); // missing customFetch — throws
+ * } catch (err) {
+ *   if (err.code === MtlsErrorCode.MTLS_REQUIRES_CUSTOM_FETCH) {
+ *     console.error('Provide a TLS-aware customFetch when useMtls is true.');
+ *   }
+ * }
+ * ```
+ */
+export class MtlsError extends Error {
+  readonly name: 'MtlsError';
+  readonly code: string;
+  constructor(code: string, message: string);
 }

--- a/index.js
+++ b/index.js
@@ -1,11 +1,17 @@
 const auth = require('./middleware/auth');
 const requiresAuth = require('./middleware/requiresAuth');
 const attemptSilentLogin = require('./middleware/attemptSilentLogin');
-const { SessionExpiredError } = require('./lib/errors');
+const {
+  SessionExpiredError,
+  MtlsError,
+  MtlsErrorCode,
+} = require('./lib/errors');
 
 module.exports = {
   auth,
   ...requiresAuth,
   attemptSilentLogin,
   SessionExpiredError,
+  MtlsError,
+  MtlsErrorCode,
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -83,6 +83,8 @@ function createCustomFetch(config) {
  */
 async function getClientAuth(config) {
   switch (config.clientAuthMethod) {
+    case 'tls_client_auth':
+      return client.TlsClientAuth();
     case 'client_secret_basic':
       return client.ClientSecretBasic(config.clientSecret);
     case 'client_secret_post':
@@ -141,6 +143,7 @@ async function get(config) {
   const clientMetadata = {
     [client.clockTolerance]: config.clockTolerance,
     id_token_signed_response_alg: config.idTokenSigningAlg,
+    ...(config.useMtls && { use_mtls_endpoint_aliases: true }),
   };
 
   // Discover and create configuration

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,7 @@
 const Joi = require('joi');
 const crypto = require('crypto');
 const { defaultState: getLoginState } = require('./hooks/getLoginState');
+const { MtlsError, MtlsErrorCode } = require('./errors');
 const isHttps = /^https:/i;
 
 const defaultSessionIdGenerator = () => crypto.randomBytes(16).toString('hex');
@@ -194,8 +195,11 @@ const paramsSchema = Joi.object({
       }),
       {
         is: true,
-        then: Joi.string().required().messages({
-          'any.required': `"clientSecret" is required for the "clientAuthMethod" "{{clientAuthMethod}}"`,
+        then: Joi.when(Joi.ref('useMtls'), {
+          is: true,
+          otherwise: Joi.string().required().messages({
+            'any.required': `"clientSecret" is required for the "clientAuthMethod" "{{clientAuthMethod}}"`,
+          }),
         }),
       },
     )
@@ -272,10 +276,14 @@ const paramsSchema = Joi.object({
       'client_secret_post',
       'client_secret_jwt',
       'private_key_jwt',
+      'tls_client_auth',
       'none',
     )
     .optional()
     .default((parent) => {
+      if (parent.useMtls) {
+        return 'tls_client_auth';
+      }
       if (
         parent.authorizationParams.response_type === 'id_token' &&
         !parent.pushedAuthorizationRequests
@@ -364,6 +372,7 @@ const paramsSchema = Joi.object({
   httpTimeout: Joi.number().optional().min(500).default(5000),
   httpUserAgent: Joi.string().optional(),
   customFetch: Joi.function().optional(),
+  useMtls: Joi.boolean().optional().default(false),
 });
 
 module.exports.get = function (config = {}) {
@@ -373,6 +382,7 @@ module.exports.get = function (config = {}) {
     baseURL: process.env.BASE_URL,
     clientID: process.env.CLIENT_ID,
     clientSecret: process.env.CLIENT_SECRET,
+    useMtls: process.env.AUTH0_MTLS === 'true' ? true : undefined,
     ...config,
   };
 
@@ -383,5 +393,15 @@ module.exports.get = function (config = {}) {
   if (warning) {
     console.warn(warning.message);
   }
+
+  if (value.useMtls && !value.customFetch) {
+    throw new MtlsError(
+      MtlsErrorCode.MTLS_REQUIRES_CUSTOM_FETCH,
+      'useMtls requires a customFetch option with a TLS client certificate implementation. ' +
+        'The standard fetch global has no client certificate API. ' +
+        'See https://github.com/auth0/express-openid-connect/blob/master/EXAMPLES.md for setup instructions.',
+    );
+  }
+
   return value;
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -8,4 +8,29 @@ class SessionExpiredError extends Error {
   }
 }
 
-module.exports = { SessionExpiredError };
+/**
+ * Error codes for mTLS (Mutual TLS, RFC 8705) configuration failures.
+ */
+const MtlsErrorCode = Object.freeze({
+  MTLS_REQUIRES_CUSTOM_FETCH: 'mtls_requires_custom_fetch',
+});
+
+/**
+ * Thrown during `auth()` initialization when the mTLS configuration is invalid.
+ *
+ * The only current case: `useMtls: true` was set but no `customFetch` was provided.
+ * The standard `fetch` global has no API for attaching client certificates, so mTLS
+ * is non-functional without a TLS-aware transport.
+ *
+ * Catch by `error.code` (a string) rather than `instanceof` to stay compatible with
+ * bundlers that may produce multiple class instances across module copies.
+ */
+class MtlsError extends Error {
+  constructor(code, message) {
+    super(message);
+    this.name = 'MtlsError';
+    this.code = code;
+  }
+}
+
+module.exports = { SessionExpiredError, MtlsError, MtlsErrorCode };

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -8,6 +8,15 @@ const nock = require('nock');
 const pkg = require('../package.json');
 const sinon = require('sinon');
 
+const MTLS_WELL_KNOWN = {
+  ...wellKnown,
+  mtls_endpoint_aliases: {
+    token_endpoint: 'https://mtls.op.example.com/oauth/token',
+    userinfo_endpoint: 'https://mtls.op.example.com/userinfo',
+    revocation_endpoint: 'https://mtls.op.example.com/oauth/revoke',
+  },
+};
+
 describe('client initialization', function () {
   beforeEach(async function () {
     nock('https://op.example.com')
@@ -682,6 +691,101 @@ describe('client initialization', function () {
         '__test_cache_max_age_client_id__',
       );
       expect(spy.callCount).to.eq(1);
+    });
+  });
+
+  describe('mTLS client configuration', function () {
+    const mtlsFetch = sinon
+      .stub()
+      .callsFake((url, options) => fetch(url, options));
+
+    const baseConfig = {
+      secret: '__test_session_secret__',
+      clientID: '__test_client_id__',
+      issuerBaseURL: 'https://mtls-test.auth0.com',
+      baseURL: 'https://example.org',
+      authorizationParams: { response_type: 'code' },
+    };
+
+    beforeEach(() => {
+      mtlsFetch.resetHistory();
+      nock('https://mtls-test.auth0.com')
+        .persist()
+        .get('/.well-known/openid-configuration')
+        .reply(200, {
+          ...MTLS_WELL_KNOWN,
+          issuer: 'https://mtls-test.auth0.com/',
+        });
+    });
+
+    afterEach(() => nock.cleanAll());
+
+    it('should set use_mtls_endpoint_aliases=true on clientMetadata when useMtls=true', async function () {
+      const config = getConfig({
+        ...baseConfig,
+        useMtls: true,
+        customFetch: mtlsFetch,
+      });
+      const { configuration } = await getClient(config);
+      const metadata = configuration.clientMetadata();
+      assert.equal(metadata.use_mtls_endpoint_aliases, true);
+    });
+
+    it('should NOT set use_mtls_endpoint_aliases when useMtls=false', async function () {
+      const config = getConfig({
+        ...baseConfig,
+        clientSecret: '__test_client_secret__',
+      });
+      const { configuration } = await getClient(config);
+      const metadata = configuration.clientMetadata();
+      assert.notEqual(metadata.use_mtls_endpoint_aliases, true);
+    });
+
+    it('should resolve clientAuthMethod to tls_client_auth when useMtls=true', function () {
+      const config = getConfig({
+        ...baseConfig,
+        useMtls: true,
+        customFetch: mtlsFetch,
+      });
+      assert.equal(config.clientAuthMethod, 'tls_client_auth');
+    });
+
+    it('should invoke customFetch during discovery when useMtls=true', async function () {
+      const config = getConfig({
+        ...baseConfig,
+        useMtls: true,
+        customFetch: mtlsFetch,
+      });
+      await getClient(config);
+      assert.isTrue(mtlsFetch.called);
+    });
+
+    it('should expose mtls_endpoint_aliases in server metadata when present', async function () {
+      const config = getConfig({
+        ...baseConfig,
+        useMtls: true,
+        customFetch: mtlsFetch,
+      });
+      const { serverMetadata } = await getClient(config);
+      assert.deepEqual(serverMetadata.mtls_endpoint_aliases, {
+        token_endpoint: 'https://mtls.op.example.com/oauth/token',
+        userinfo_endpoint: 'https://mtls.op.example.com/userinfo',
+        revocation_endpoint: 'https://mtls.op.example.com/oauth/revoke',
+      });
+    });
+
+    it('should work without mtls_endpoint_aliases in discovery (graceful fallback)', async function () {
+      nock.cleanAll();
+      nock('https://mtls-test.auth0.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, { ...wellKnown, issuer: 'https://mtls-test.auth0.com/' });
+
+      const config = getConfig({
+        ...baseConfig,
+        useMtls: true,
+        customFetch: mtlsFetch,
+      });
+      await assert.isFulfilled(getClient(config));
     });
   });
 });

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -1,6 +1,7 @@
-const { assert } = require('chai');
+const { assert, expect } = require('chai');
 const sinon = require('sinon');
 const { get: getConfig } = require('../lib/config');
+const { MtlsError, MtlsErrorCode } = require('../lib/errors');
 
 const defaultConfig = {
   secret: '__test_session_secret__',
@@ -905,5 +906,81 @@ describe('get config', () => {
         },
       }),
     );
+  });
+
+  describe('mTLS configuration', () => {
+    const mtlsFetch = () => Promise.resolve(new Response());
+
+    it('should default useMtls to false', () => {
+      const config = getConfig({ ...defaultConfig, clientSecret: 'secret' });
+      assert.equal(config.useMtls, false);
+    });
+
+    it('should accept useMtls=true with customFetch and no clientSecret', () => {
+      assert.doesNotThrow(() =>
+        getConfig({ ...defaultConfig, useMtls: true, customFetch: mtlsFetch }),
+      );
+    });
+
+    it('should throw MtlsError when useMtls=true and customFetch is missing', () => {
+      let caught;
+      try {
+        getConfig({ ...defaultConfig, useMtls: true });
+      } catch (e) {
+        caught = e;
+      }
+      assert.instanceOf(caught, MtlsError);
+      assert.equal(caught.code, MtlsErrorCode.MTLS_REQUIRES_CUSTOM_FETCH);
+    });
+
+    it('should set clientAuthMethod to tls_client_auth when useMtls=true', () => {
+      const config = getConfig({
+        ...defaultConfig,
+        useMtls: true,
+        customFetch: mtlsFetch,
+      });
+      assert.equal(config.clientAuthMethod, 'tls_client_auth');
+    });
+
+    it('should accept an explicit clientAuthMethod=tls_client_auth', () => {
+      assert.doesNotThrow(() =>
+        getConfig({
+          ...defaultConfig,
+          useMtls: true,
+          customFetch: mtlsFetch,
+          clientAuthMethod: 'tls_client_auth',
+        }),
+      );
+    });
+
+    it('should read useMtls from AUTH0_MTLS env var', () => {
+      sinon.stub(process, 'env').value({ ...process.env, AUTH0_MTLS: 'true' });
+      let caught;
+      try {
+        getConfig({ ...defaultConfig });
+      } catch (e) {
+        caught = e;
+      }
+      assert.instanceOf(caught, MtlsError);
+      assert.equal(caught.code, MtlsErrorCode.MTLS_REQUIRES_CUSTOM_FETCH);
+    });
+
+    it('should not throw when AUTH0_MTLS=true and customFetch is provided', () => {
+      sinon.stub(process, 'env').value({ ...process.env, AUTH0_MTLS: 'true' });
+      assert.doesNotThrow(() =>
+        getConfig({ ...defaultConfig, customFetch: mtlsFetch }),
+      );
+    });
+
+    it('should not require clientSecret when useMtls=true', () => {
+      const config = getConfig({
+        ...defaultConfig,
+        useMtls: true,
+        customFetch: mtlsFetch,
+        authorizationParams: { response_type: 'code' },
+      });
+      assert.equal(config.useMtls, true);
+      assert.equal(config.clientAuthMethod, 'tls_client_auth');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Implements [RFC 8705](https://datatracker.ietf.org/doc/html/rfc8705) Mutual TLS client authentication, allowing applications to authenticate with Auth0 using a TLS client certificate instead of a `clientSecret`. When the IdP supports it, issued access tokens will carry a `cnf.x5t#S256` claim binding them to the client certificate fingerprint (certificate-bound tokens).

- **`useMtls: boolean`** — new opt-in config flag (default `false`); also settable via `AUTH0_MTLS=true` env var
- When `useMtls: true`, the SDK switches client authentication from `ClientSecretPost` to `TlsClientAuth()` (openid-client v6 / `oauth4webapi`) and sets `use_mtls_endpoint_aliases: true` on client metadata so all token/userinfo requests are routed to the `mtls_endpoint_aliases` advertised in the OIDC discovery document
- **`customFetch` is required** when `useMtls: true` — the standard `fetch` global has no API for attaching client certificates; a TLS-aware implementation (e.g. `undici` `Agent` with `connect: { key, cert }`) must be provided. A `MtlsError` with code `mtls_requires_custom_fetch` is thrown at `auth()` initialization time if it is missing (fail-fast)
- `clientSecret` is no longer required when `useMtls: true` — the certificate is the sole client credential
- New `MtlsError` class and `MtlsErrorCode` enum exported from the package for structured error handling
- Graceful fallback: if the discovery document has no `mtls_endpoint_aliases`, the SDK falls back to the standard endpoints without throwing

## Usage

```js
const { Agent, fetch: undiciFetch } = require('undici');
const { readFileSync } = require('fs');
const { auth } = require('express-openid-connect');

const tlsAgent = new Agent({
  connect: {
    key: readFileSync(process.env.MTLS_CLIENT_KEY_PATH),
    cert: readFileSync(process.env.MTLS_CLIENT_CERT_PATH),
  },
});

app.use(auth({
  useMtls: true,
  customFetch: (url, options) =>
    undiciFetch(url, { ...options, dispatcher: tlsAgent }),
  // clientSecret is not needed
}));
```

## Files changed

| File | Change |
|------|--------|
| `lib/errors.js` | New `MtlsError` class and `MtlsErrorCode` |
| `lib/config.js` | `useMtls` Joi option, `AUTH0_MTLS` env var, fail-fast validation, `tls_client_auth` added to valid `clientAuthMethod` values, relaxed `clientSecret` requirement |
| `lib/client.js` | `tls_client_auth` case in `getClientAuth()` calling `TlsClientAuth()`, `use_mtls_endpoint_aliases` on client metadata |
| `index.js` | Export `MtlsError` / `MtlsErrorCode` |
| `index.d.ts` | `useMtls` in `ConfigParams`, export `MtlsError` class and `MtlsErrorCode` const with full JSDoc |
| `test/config.tests.js` | 8 config validation tests |
| `test/client.tests.js` | 6 client-level tests |

## Test plan

- [x] All 334 existing tests still pass
- [x] `useMtls` defaults to `false`
- [x] `useMtls: true` + `customFetch` → no throw, `clientAuthMethod` resolves to `tls_client_auth`
- [x] `useMtls: true` without `customFetch` → throws `MtlsError` with `mtls_requires_custom_fetch`
- [x] `AUTH0_MTLS=true` env var respected
- [x] `clientSecret` not required when `useMtls: true`
- [x] `use_mtls_endpoint_aliases: true` set on `clientMetadata`
- [x] `mtls_endpoint_aliases` from discovery document surfaced in `serverMetadata`
- [x] Graceful fallback when discovery has no `mtls_endpoint_aliases`
- [x] `customFetch` is invoked during discovery when `useMtls: true`

## References

- [RFC 8705 — OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens](https://datatracker.ietf.org/doc/html/rfc8705)
- [Auth0 docs — Configure mTLS](https://auth0.com/docs/get-started/applications/configure-mtls)
- Modelled after the equivalent implementation in [nextjs-auth0 PRs #2645–#2648](https://github.com/auth0/nextjs-auth0/pull/2646)