### PR TITLE
chore: group codeql-action and actions/cache dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,17 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      codeql:
+        patterns:
+          - 'github/codeql-action*'
+      actions-cache:
+        patterns:
+          - 'actions/cache*'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'
     ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
## Summary

- Groups all `github/codeql-action/*` Dependabot updates (`init`, `autobuild`, `analyze`) so they are always bumped together in a single PR
- Groups `actions/cache/restore` and `actions/cache/save` Dependabot updates so they are always bumped together in a single PR

## Why

These actions are sub-actions of the same repository and share the same version — bumping them independently can cause version mismatches in workflows. Grouping ensures they stay in sync.

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid YAML
- [ ] Confirm next Dependabot run for `github-actions` produces grouped PRs for `codeql-action` and `actions/cache`