### PR TITLE
fix: replace $(pwd) with github.workspace in rl-scanner artifact path

### DIFF
--- a/.github/workflows/rl-secure.yml
+++ b/.github/workflows/rl-secure.yml
@@ -55,7 +55,7 @@ jobs:
         id: rl-scan-conclusion
         uses: ./.github/actions/rl-scanner
         with:
-          artifact-path: '$(pwd)/${{ inputs.artifact-name }}'
+          artifact-path: '${{ github.workspace }}/${{ inputs.artifact-name }}'
           version: '${{ steps.get_version.outputs.version }}'
         env:
           RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}


### PR DESCRIPTION
## Summary

Fixes the RL Scanner workflow failure introduced by PR #849.

## Problem

PR #849 correctly moved interpolated values into `env:` blocks to prevent script injection. However, the `artifact-path` input was set to:

```yaml
artifact-path: '$(pwd)/${{ inputs.artifact-name }}'
```

`$(pwd)` is shell command substitution — it only expands inside a `run:` shell step. When passed as a `with:` input or `env:` value in GitHub Actions, it is treated as a literal string, so `ARTIFACT_PATH` becomes `$(pwd)/express-openid-connect.tgz` and the file is never found.

## Fix

Replace `$(pwd)` with `${{ github.workspace }}`, which is a GitHub Actions context variable that resolves to the correct working directory path in all contexts.

```yaml
artifact-path: '${{ github.workspace }}/${{ inputs.artifact-name }}'
```