### PR TITLE
feat(jar): JWT-Secured Authorization Requests (JAR) support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -15,6 +15,7 @@
 13. [Impersonation via Session Transfer Token](#13-impersonation-via-session-transfer-token)
 14. [Use a proxy for OIDC requests](#14-use-a-proxy-for-oidc-requests)
 15. [Session expiry from upstream IdP (IPSIE `session_expiry`)](#15-session-expiry-from-upstream-idp-ipsie-session_expiry)
+16. [JWT-Secured Authorization Requests (JAR)](#16-jwt-secured-authorization-requests-jar)
 
 ## 1. Basic setup
 
@@ -667,3 +668,30 @@ app.get('/status', (req, res) => {
 ### Upgrading existing apps
 
 Once your IdP starts emitting `session_expiry`, `req.appSession` can be `null` for a previously logged-in user once the ceiling is reached. If your code assumed the session always exists after login, add a null check. Sessions created before the upgrade (or through connections without the claim) have no `sessionExpiresAt` and behave exactly as before.
+
+## 16. JWT-Secured Authorization Requests (JAR)
+
+[JAR](https://www.rfc-editor.org/rfc/rfc9101.html) (part of Auth0's Highly Regulated Identity feature set) signs all authorization parameters into a JWT and sends them as the `request` parameter, so the `/authorize` redirect carries only `client_id` and `request`. Set `requestObjectSigningKey` to enable it. `requestObjectSigningAlg` is always required, since Web Crypto algorithm names are not valid JWA `alg` values.
+
+```js
+app.use(
+  auth({
+    authorizationParams: {
+      response_type: 'code',
+    },
+    // Sign the authorization request object.
+    requestObjectSigningKey: fs.readFileSync('./request-object-key.pem'),
+    requestObjectSigningAlg: 'RS256',
+    // Optional: set a `kid` in the request object's JWT header.
+    // requestObjectSigningKeyId: 'my-key-id',
+
+    // Recommended for FAPI: combine with PAR so the signed request object is
+    // POSTed to /oauth/par and only an opaque request_uri is exposed in the URL.
+    pushedAuthorizationRequests: true,
+  }),
+);
+```
+
+The request object's `aud` is set to the issuer identifier advertised in the discovery document (which may differ from `issuerBaseURL`, e.g. a trailing slash), as JAR requires. `requestObjectSigningKey` accepts the same key formats as `clientAssertionSigningKey` (PEM string, Buffer, KeyObject, JWK, CryptoKey).
+
+Full example at [jar.js](./examples/jar.js), to run it: `npm run start:example -- jar`

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -694,4 +694,22 @@ app.use(
 
 The request object's `aud` is set to the issuer identifier advertised in the discovery document (which may differ from `issuerBaseURL`, e.g. a trailing slash), as JAR requires. `requestObjectSigningKey` accepts the same key formats as `clientAssertionSigningKey` (PEM string, Buffer, KeyObject, JWK, CryptoKey).
 
+`requestObjectSigningAlg` must be a JWA algorithm name from the following set: `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `ES256`, `ES384`, `ES512`, `Ed25519`. Register the corresponding public key with your authorization server so it can verify the signed request object.
+
+Generate a signing key pair that matches your chosen algorithm, for example an RSA key for `RS256`/`PS256`:
+
+```bash
+# Private key (used by the app as requestObjectSigningKey)
+openssl genrsa -out request-object-key.pem 2048
+# Public key (registered with the authorization server)
+openssl rsa -in request-object-key.pem -pubout -out request-object-key.pub.pem
+```
+
+For an EC algorithm such as `ES256`, generate a P-256 key instead:
+
+```bash
+openssl ecparam -name prime256v1 -genkey -noout -out request-object-key.pem
+openssl ec -in request-object-key.pem -pubout -out request-object-key.pub.pem
+```
+
 Full example at [jar.js](./examples/jar.js), to run it: `npm run start:example -- jar`

--- a/end-to-end/fixture/oidc-provider.js
+++ b/end-to-end/fixture/oidc-provider.js
@@ -33,9 +33,9 @@ const config = {
       client_id: 'client-secret-jwt-client',
       token_endpoint_auth_method: 'client_secret_jwt',
     }),
-    // HRI demo client: supports private_key_jwt auth, JAR (request objects), and PAR
+    // JAR demo client: supports private_key_jwt auth, JAR (request objects), and PAR
     Object.assign({}, client, {
-      client_id: 'hri-client',
+      client_id: 'jar-client',
       token_endpoint_auth_method: 'private_key_jwt',
       jwks: { keys: [publicJWK] },
       request_object_signing_alg: 'RS256',

--- a/end-to-end/fixture/oidc-provider.js
+++ b/end-to-end/fixture/oidc-provider.js
@@ -33,6 +33,13 @@ const config = {
       client_id: 'client-secret-jwt-client',
       token_endpoint_auth_method: 'client_secret_jwt',
     }),
+    // HRI demo client: supports private_key_jwt auth, JAR (request objects), and PAR
+    Object.assign({}, client, {
+      client_id: 'hri-client',
+      token_endpoint_auth_method: 'private_key_jwt',
+      jwks: { keys: [publicJWK] },
+      request_object_signing_alg: 'RS256',
+    }),
   ],
   jwks: {
     keys: [privateJWK],
@@ -53,6 +60,12 @@ const config = {
   features: {
     backchannelLogout: {
       enabled: true,
+    },
+    pushedAuthorizationRequests: {
+      enabled: true,
+    },
+    requestObjects: {
+      request: true,
     },
   },
 };

--- a/end-to-end/jar.test.js
+++ b/end-to-end/jar.test.js
@@ -1,0 +1,83 @@
+const { assert } = require('chai');
+const { once } = require('events');
+const puppeteer = require('puppeteer');
+const provider = require('./fixture/oidc-provider');
+const {
+  baseUrl,
+  start,
+  runExample,
+  stubEnv,
+  goto,
+  login,
+} = require('./fixture/helpers');
+
+describe('JAR + PAR', async () => {
+  let authServer;
+  let appServer;
+
+  beforeEach(async () => {
+    stubEnv({
+      ISSUER_BASE_URL: 'http://localhost:3001',
+      CLIENT_ID: 'hri-client',
+      BASE_URL: 'http://localhost:3000',
+      SECRET: 'LONG_RANDOM_VALUE',
+      CLIENT_SECRET: 'test-express-openid-connect-client-secret',
+    });
+    authServer = await start(provider, 3001);
+    appServer = await runExample('jar');
+  });
+
+  afterEach(async () => {
+    authServer.close();
+    appServer.close();
+  });
+
+  it('should login with JAR and PAR', async () => {
+    const browser = await puppeteer.launch({
+      args: puppeteer
+        .defaultArgs()
+        .concat(['--no-sandbox', '--disable-setuid-sandbox']),
+    });
+
+    // pushed_authorization_request.success fires when the PAR endpoint accepts the request.
+    // It receives the ctx at that moment, before the PushedAuthorizationRequest entity is
+    // consumed during the subsequent authorization code flow.
+    const parPromise = once(provider, 'pushed_authorization_request.success');
+    const grantPromise = once(provider, 'grant.success');
+
+    const page = await browser.newPage();
+    await goto(baseUrl, page);
+    assert.match(page.url(), /http:\/\/localhost:3000/);
+    await page.click('a[href="/login"]');
+    assert.match(
+      page.url(),
+      /http:\/\/localhost:3001\/interaction/,
+      'User should have been redirected to the auth server to login',
+    );
+
+    await login('username', 'password', page);
+
+    // PAR must have completed before the authorization redirect was issued
+    const [parCtx] = await parPromise;
+    assert.ok(
+      parCtx.oidc.body.request,
+      'PAR request should contain a signed request object (JAR)',
+    );
+
+    // The final token exchange must also succeed
+    await grantPromise;
+
+    // Verify we're back on the app
+    assert.equal(
+      page.url(),
+      `${baseUrl}/`,
+      'User is returned to the original page',
+    );
+
+    const content = await page.content();
+    assert.include(content, 'Logged in as');
+    assert.include(content, 'username');
+
+    await browser.close();
+  });
+});

--- a/end-to-end/jar.test.js
+++ b/end-to-end/jar.test.js
@@ -18,7 +18,7 @@ describe('JAR + PAR', async () => {
   beforeEach(async () => {
     stubEnv({
       ISSUER_BASE_URL: 'http://localhost:3001',
-      CLIENT_ID: 'hri-client',
+      CLIENT_ID: 'jar-client',
       BASE_URL: 'http://localhost:3000',
       SECRET: 'LONG_RANDOM_VALUE',
       CLIENT_SECRET: 'test-express-openid-connect-client-secret',

--- a/examples/jar.js
+++ b/examples/jar.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const { auth } = require('../');
+const { privateJWK, privatePEM } = require('../end-to-end/fixture/jwk');
+
+const app = express();
+
+// JAR (JWT-Secured Authorization Requests) demo.
+//
+// When `requestObjectSigningKey` is set, the SDK signs all authorization
+// parameters into a JWT and sends it as the `request` parameter, so the
+// /authorize redirect carries only `client_id` and `request`. Combined with PAR
+// (recommended for FAPI), the signed request object is POSTed to /oauth/par and
+// only an opaque `request_uri` appears in the browser redirect.
+//
+// `requestObjectSigningAlg` is always required - Web Crypto algorithm names are
+// not valid JWA `alg` values.
+//
+// Run with: node examples/run_example.js jar.js
+// The mock OIDC provider is auto-started. Login with any username/password.
+
+app.use(
+  auth({
+    authRequired: false,
+    authorizationParams: {
+      response_type: 'code',
+    },
+
+    // The mock provider's 'hri-client' is registered for private_key_jwt + JAR.
+    // clientAssertionSigningKey authenticates the token exchange; the same key
+    // pair signs the JAR request object here. In production they can differ.
+    clientAuthMethod: 'private_key_jwt',
+    clientAssertionSigningKey: privateJWK,
+
+    pushedAuthorizationRequests: true,
+    requestObjectSigningKey: privatePEM,
+    requestObjectSigningAlg: 'RS256',
+    // Optional: set a `kid` in the signed request object's JWT header.
+    // requestObjectSigningKeyId: 'my-key-id',
+  }),
+);
+
+app.get('/', (req, res) => {
+  if (req.oidc.isAuthenticated()) {
+    res.send(
+      `<p>Logged in as <strong>${req.oidc.user.sub}</strong></p>` +
+        `<a href="/logout">logout</a>`,
+    );
+  } else {
+    res.send('<a href="/login">login</a>');
+  }
+});
+
+module.exports = app;

--- a/examples/jar.js
+++ b/examples/jar.js
@@ -25,7 +25,7 @@ app.use(
       response_type: 'code',
     },
 
-    // The mock provider's 'hri-client' is registered for private_key_jwt + JAR.
+    // The mock provider's 'jar-client' is registered for private_key_jwt + JAR.
     // clientAssertionSigningKey authenticates the token exchange; the same key
     // pair signs the JAR request object here. In production they can differ.
     clientAuthMethod: 'private_key_jwt',

--- a/examples/run_example.js
+++ b/examples/run_example.js
@@ -4,7 +4,9 @@ require('dotenv').config();
 
 const { PORT = 3000, PROVIDER_PORT = 3001, API_PORT = 3002 } = process.env;
 
-const example = process.argv.pop();
+// Accept the example either with or without the `.js` extension
+// (e.g. `jar` or `jar.js`); require() resolves both.
+const example = process.argv.pop().replace(/\.js$/, '');
 
 // Configure and start a mock authorization server if no .env config is found
 if (!process.env.CLIENT_ID) {
@@ -15,9 +17,7 @@ if (!process.env.CLIENT_ID) {
   // The jar example uses a registered client that supports
   // private_key_jwt + JAR + PAR. All other examples use the default client.
   const clientId =
-    example === 'jar.js'
-      ? 'jar-client'
-      : 'test-express-openid-connect-client-id';
+    example === 'jar' ? 'jar-client' : 'test-express-openid-connect-client-id';
   process.env = {
     ...process.env,
     ISSUER_BASE_URL: `http://localhost:${PROVIDER_PORT}`,

--- a/examples/run_example.js
+++ b/examples/run_example.js
@@ -12,10 +12,15 @@ if (!process.env.CLIENT_ID) {
   console.log(
     'Starting a mock authorization server. You can login with any credentials.',
   );
+  // The hri and jar examples use a registered client that supports
+  // private_key_jwt + JAR + PAR. All other examples use the default client.
+  const clientId = ['hri.js', 'jar.js'].includes(example)
+    ? 'hri-client'
+    : 'test-express-openid-connect-client-id';
   process.env = {
     ...process.env,
     ISSUER_BASE_URL: `http://localhost:${PROVIDER_PORT}`,
-    CLIENT_ID: 'test-express-openid-connect-client-id',
+    CLIENT_ID: clientId,
     BASE_URL: `http://localhost:${PORT}`,
     SECRET: 'LONG_RANDOM_VALUE',
     CLIENT_SECRET: 'test-express-openid-connect-client-secret',

--- a/examples/run_example.js
+++ b/examples/run_example.js
@@ -12,11 +12,12 @@ if (!process.env.CLIENT_ID) {
   console.log(
     'Starting a mock authorization server. You can login with any credentials.',
   );
-  // The hri and jar examples use a registered client that supports
+  // The jar example uses a registered client that supports
   // private_key_jwt + JAR + PAR. All other examples use the default client.
-  const clientId = ['hri.js', 'jar.js'].includes(example)
-    ? 'hri-client'
-    : 'test-express-openid-connect-client-id';
+  const clientId =
+    example === 'jar.js'
+      ? 'jar-client'
+      : 'test-express-openid-connect-client-id';
   process.env = {
     ...process.env,
     ISSUER_BASE_URL: `http://localhost:${PROVIDER_PORT}`,

--- a/index.d.ts
+++ b/index.d.ts
@@ -584,8 +584,7 @@ interface BackchannelLogoutOptions {
    * (See {@link https://github.com/auth0/express-openid-connect/tree/master/examples/examples/backchannel-logout-custom-genid.js} or {@link https://github.com/auth0/express-openid-connect/tree/master/examples/examples/backchannel-logout-custom-query-store.js})
    */
   onLogin?:
-    | false
-    | ((req: Request, config: ConfigParams) => Promise<void> | void);
+    false | ((req: Request, config: ConfigParams) => Promise<void> | void);
 }
 
 /**
@@ -871,7 +870,12 @@ interface ConfigParams {
   /**
    * String value for the client's authentication method. Default is `none` when using response_type='id_token', `private_key_jwt` when using a `clientAssertionSigningKey`, otherwise `client_secret_basic`.
    */
-  clientAuthMethod?: string;
+  clientAuthMethod?:
+    | 'client_secret_basic'
+    | 'client_secret_post'
+    | 'client_secret_jwt'
+    | 'private_key_jwt'
+    | 'none';
 
   /**
    * Private key for use with 'private_key_jwt' clients.
@@ -932,6 +936,34 @@ interface ConfigParams {
     | 'ES384'
     | 'ES512'
     | 'Ed25519';
+
+  /**
+   * Private key used to sign JWT-Secured Authorization Requests (JAR).
+   * When set, all authorization parameters are signed as a `request` JWT before being sent to the authorization endpoint.
+   * Accepts the same formats as `clientAssertionSigningKey`: PEM string, Buffer, KeyObject, JWK, or CryptoKey.
+   */
+  requestObjectSigningKey?: KeyObject | JoseCryptoKey | JWK | string | Buffer;
+
+  /**
+   * Algorithm used to sign the JAR request object JWT. Always required when `requestObjectSigningKey` is set.
+   * Web Crypto algorithm names (e.g. `RSASSA-PKCS1-v1_5`) are not valid here — use JWA names (e.g. `RS256`).
+   */
+  requestObjectSigningAlg?:
+    | 'RS256'
+    | 'RS384'
+    | 'RS512'
+    | 'PS256'
+    | 'PS384'
+    | 'PS512'
+    | 'ES256'
+    | 'ES384'
+    | 'ES512'
+    | 'Ed25519';
+
+  /**
+   * Optional key ID to include as the `kid` header in the JAR request object JWT.
+   */
+  requestObjectSigningKeyId?: string;
 
   /**
    * Additional request body properties to be sent to the `token_endpoint` during authorization code exchange or token refresh.

--- a/index.d.ts
+++ b/index.d.ts
@@ -870,12 +870,7 @@ interface ConfigParams {
   /**
    * String value for the client's authentication method. Default is `none` when using response_type='id_token', `private_key_jwt` when using a `clientAssertionSigningKey`, otherwise `client_secret_basic`.
    */
-  clientAuthMethod?:
-    | 'client_secret_basic'
-    | 'client_secret_post'
-    | 'client_secret_jwt'
-    | 'private_key_jwt'
-    | 'none';
+  clientAuthMethod?: string;
 
   /**
    * Private key for use with 'private_key_jwt' clients.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -6,3 +6,12 @@ expectType<RequestHandler>(auth());
 expectType<RequestHandler>(auth({ session: { name: 'foo' } }));
 expectType<RequestHandler>(auth({ session: { cookie: { secure: true } } }));
 expectType<RequestHandler>(auth({ routes: { login: '' } }));
+
+// JAR (JWT-Secured Authorization Requests)
+expectType<RequestHandler>(
+  auth({
+    requestObjectSigningKey: '-----BEGIN PRIVATE KEY-----',
+    requestObjectSigningAlg: 'RS256',
+    requestObjectSigningKeyId: 'kid-1',
+  }),
+);

--- a/lib/client.js
+++ b/lib/client.js
@@ -281,6 +281,15 @@ const cache = new Map();
  * All authorization parameters are embedded in the JWT payload along with iss and aud claims.
  */
 async function buildRequestObject(authParams, config, audience) {
+  // `aud` must equal the issuer identifier as advertised in discovery metadata
+  // (which may carry a trailing slash), not the configured issuerBaseURL. It is
+  // required: falling back to issuerBaseURL is the exact mismatch JAR rejects with
+  // invalid_request_object, so callers must pass the discovered issuer.
+  if (!audience) {
+    throw new TypeError(
+      'buildRequestObject requires the discovered issuer as audience',
+    );
+  }
   const key = await importPrivateKey(
     config.requestObjectSigningKey,
     config.requestObjectSigningAlg,
@@ -290,9 +299,7 @@ async function buildRequestObject(authParams, config, audience) {
     ...authParams,
     client_id: config.clientID,
     iss: config.clientID,
-    // `aud` must equal the issuer identifier as advertised in discovery metadata
-    // (which may carry a trailing slash). Fall back to issuerBaseURL if not provided.
-    aud: audience || config.issuerBaseURL,
+    aud: audience,
     jti: crypto.randomBytes(16).toString('hex'),
     iat: now,
     nbf: now,

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,6 @@
+const crypto = require('crypto');
 const client = require('openid-client');
-const { importPKCS8, importJWK, exportPKCS8 } = require('jose');
+const { importPKCS8, importJWK, exportPKCS8, SignJWT } = require('jose');
 const pkg = require('../package.json');
 const debug = require('./debug')('client');
 
@@ -274,6 +275,40 @@ function buildEndSessionUrl(
 }
 
 const cache = new Map();
+
+/**
+ * Builds a signed JWT request object for JAR (JWT-Secured Authorization Requests).
+ * All authorization parameters are embedded in the JWT payload along with iss and aud claims.
+ */
+async function buildRequestObject(authParams, config, audience) {
+  const key = await importPrivateKey(
+    config.requestObjectSigningKey,
+    config.requestObjectSigningAlg,
+  );
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    ...authParams,
+    client_id: config.clientID,
+    iss: config.clientID,
+    // `aud` must equal the issuer identifier as advertised in discovery metadata
+    // (which may carry a trailing slash). Fall back to issuerBaseURL if not provided.
+    aud: audience || config.issuerBaseURL,
+    jti: crypto.randomBytes(16).toString('hex'),
+    iat: now,
+    nbf: now,
+    exp: now + 60,
+  };
+  return new SignJWT(payload)
+    .setProtectedHeader({
+      alg: config.requestObjectSigningAlg,
+      ...(config.requestObjectSigningKeyId && {
+        kid: config.requestObjectSigningKeyId,
+      }),
+    })
+    .sign(key);
+}
+
+exports.buildRequestObject = buildRequestObject;
 
 exports.get = (config) => {
   const { discoveryCacheMaxAge: cacheMaxAge } = config;

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,6 +37,19 @@ const binaryMin8 = (() => {
     });
 })();
 
+const ASYMMETRIC_SIGNING_ALGS = [
+  'RS256',
+  'RS384',
+  'RS512',
+  'PS256',
+  'PS384',
+  'PS512',
+  'ES256',
+  'ES384',
+  'ES512',
+  'Ed25519',
+];
+
 const paramsSchema = Joi.object({
   secret: Joi.alternatives([
     Joi.string().min(8),
@@ -314,18 +327,7 @@ const paramsSchema = Joi.object({
       }),
     }), // <Object> | <string> | <Buffer> | <KeyObject>,
   clientAssertionSigningAlg: Joi.string()
-    .valid(
-      'RS256',
-      'RS384',
-      'RS512',
-      'PS256',
-      'PS384',
-      'PS512',
-      'ES256',
-      'ES384',
-      'ES512',
-      'Ed25519',
-    )
+    .valid(...ASYMMETRIC_SIGNING_ALGS)
     .when('clientAssertionSigningKey', {
       // Required when the key cannot carry its own algorithm:
       // PEM string, Buffer, Node.js KeyObject, or JWK without an "alg" property.
@@ -357,6 +359,18 @@ const paramsSchema = Joi.object({
       }),
       otherwise: Joi.string().optional(),
     }),
+  requestObjectSigningKey: Joi.any().optional(),
+  requestObjectSigningAlg: Joi.string()
+    .valid(...ASYMMETRIC_SIGNING_ALGS)
+    .when('requestObjectSigningKey', {
+      is: Joi.exist(),
+      then: Joi.string().required().messages({
+        'any.required':
+          '"requestObjectSigningAlg" is required when "requestObjectSigningKey" is set',
+      }),
+      otherwise: Joi.string().optional(),
+    }),
+  requestObjectSigningKeyId: Joi.string().optional(),
   discoveryCacheMaxAge: Joi.number()
     .optional()
     .min(0)
@@ -383,5 +397,13 @@ module.exports.get = function (config = {}) {
   if (warning) {
     console.warn(warning.message);
   }
+
+  if (value.requestObjectSigningKey && !value.pushedAuthorizationRequests) {
+    console.warn(
+      'Using JAR without PAR is permitted but not recommended for FAPI compliance. ' +
+        'Consider enabling pushedAuthorizationRequests.',
+    );
+  }
+
   return value;
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -359,7 +359,10 @@ const paramsSchema = Joi.object({
       }),
       otherwise: Joi.string().optional(),
     }),
-  requestObjectSigningKey: Joi.any().optional(),
+  // Reject an empty string so the "is set" test is consistent everywhere: Joi
+  // treats '' as existing (forcing alg required) but the login-side truthiness
+  // check would skip JAR, silently disabling it. Disallow it up front.
+  requestObjectSigningKey: Joi.any().invalid('').optional(),
   requestObjectSigningAlg: Joi.string()
     .valid(...ASYMMETRIC_SIGNING_ALGS)
     .when('requestObjectSigningKey', {

--- a/lib/context.js
+++ b/lib/context.js
@@ -17,6 +17,7 @@ const { once } = require('./once');
 const {
   get: getClient,
   buildEndSessionUrl,
+  buildRequestObject,
   client: oidcClient,
 } = require('./client');
 const { encodeState, decodeState } = require('../lib/hooks/getLoginState');
@@ -671,7 +672,7 @@ class ResponseContext {
     let { config, req, res, next, transient } = weakRef(this);
     next = once(next);
     try {
-      const { configuration } = await getClient(config);
+      const { configuration, serverMetadata } = await getClient(config);
 
       // Set default returnTo value, allow passed-in options to override or use originalUrl on GET
       let returnTo = config.baseURL;
@@ -752,6 +753,21 @@ class ResponseContext {
             : config.transactionCookie.sameSite,
         value: JSON.stringify(authVerification),
       });
+
+      if (config.requestObjectSigningKey) {
+        // The request object's `aud` must exactly match the issuer identifier as
+        // advertised in discovery (which may include a trailing slash), not the
+        // configured issuerBaseURL.
+        const requestJwt = await buildRequestObject(
+          authParams,
+          config,
+          serverMetadata.issuer,
+        );
+        authParams = {
+          client_id: config.clientID,
+          request: requestJwt,
+        };
+      }
 
       let authorizationUrl;
       if (config.pushedAuthorizationRequests) {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -684,4 +684,177 @@ describe('client initialization', function () {
       expect(spy.callCount).to.eq(1);
     });
   });
+
+  describe('buildRequestObject', function () {
+    const { buildRequestObject } = require('../lib/client');
+    const { privatePEM } = require('../end-to-end/fixture/jwk');
+
+    it('should return a compact JWT with 3 parts', async function () {
+      const config = getConfig({
+        secret: '__test_session_secret__',
+        clientID: '__test_client_id__',
+        clientSecret: '__test_client_secret__',
+        issuerBaseURL: 'https://op.example.com',
+        baseURL: 'https://example.org',
+        requestObjectSigningKey: privatePEM,
+        requestObjectSigningAlg: 'RS256',
+        authorizationParams: { response_type: 'code' },
+      });
+
+      const authParams = {
+        scope: 'openid profile email',
+        response_type: 'code',
+        redirect_uri: 'https://example.org/callback',
+      };
+
+      const jwt = await buildRequestObject(authParams, config);
+      const parts = jwt.split('.');
+      assert.equal(parts.length, 3, 'JWT should have 3 parts');
+    });
+
+    it('should decode header with correct algorithm', async function () {
+      const config = getConfig({
+        secret: '__test_session_secret__',
+        clientID: '__test_client_id__',
+        clientSecret: '__test_client_secret__',
+        issuerBaseURL: 'https://op.example.com',
+        baseURL: 'https://example.org',
+        requestObjectSigningKey: privatePEM,
+        requestObjectSigningAlg: 'RS256',
+        authorizationParams: { response_type: 'code' },
+      });
+
+      const authParams = {
+        scope: 'openid profile email',
+        response_type: 'code',
+      };
+
+      const jwt = await buildRequestObject(authParams, config);
+      const header = JSON.parse(
+        Buffer.from(jwt.split('.')[0], 'base64url').toString(),
+      );
+
+      assert.equal(header.alg, 'RS256');
+    });
+
+    it('should include kid in header when requestObjectSigningKeyId is provided', async function () {
+      const config = getConfig({
+        secret: '__test_session_secret__',
+        clientID: '__test_client_id__',
+        clientSecret: '__test_client_secret__',
+        issuerBaseURL: 'https://op.example.com',
+        baseURL: 'https://example.org',
+        requestObjectSigningKey: privatePEM,
+        requestObjectSigningAlg: 'RS256',
+        requestObjectSigningKeyId: 'my-key-id',
+        authorizationParams: { response_type: 'code' },
+      });
+
+      const authParams = {
+        scope: 'openid profile email',
+        response_type: 'code',
+      };
+
+      const jwt = await buildRequestObject(authParams, config);
+      const header = JSON.parse(
+        Buffer.from(jwt.split('.')[0], 'base64url').toString(),
+      );
+
+      assert.equal(header.kid, 'my-key-id');
+    });
+
+    it('should exclude kid from header when requestObjectSigningKeyId is not set', async function () {
+      const config = getConfig({
+        secret: '__test_session_secret__',
+        clientID: '__test_client_id__',
+        clientSecret: '__test_client_secret__',
+        issuerBaseURL: 'https://op.example.com',
+        baseURL: 'https://example.org',
+        requestObjectSigningKey: privatePEM,
+        requestObjectSigningAlg: 'RS256',
+        authorizationParams: { response_type: 'code' },
+      });
+
+      const authParams = {
+        scope: 'openid profile email',
+        response_type: 'code',
+      };
+
+      const jwt = await buildRequestObject(authParams, config);
+      const header = JSON.parse(
+        Buffer.from(jwt.split('.')[0], 'base64url').toString(),
+      );
+
+      assert.notProperty(header, 'kid');
+    });
+
+    it('should include all required claims in payload', async function () {
+      const config = getConfig({
+        secret: '__test_session_secret__',
+        clientID: '__test_client_id__',
+        clientSecret: '__test_client_secret__',
+        issuerBaseURL: 'https://op.example.com',
+        baseURL: 'https://example.org',
+        requestObjectSigningKey: privatePEM,
+        requestObjectSigningAlg: 'RS256',
+        authorizationParams: { response_type: 'code' },
+      });
+
+      const authParams = {
+        scope: 'openid profile email',
+        response_type: 'code',
+        redirect_uri: 'https://example.org/callback',
+      };
+
+      const jwt = await buildRequestObject(authParams, config);
+      const payload = JSON.parse(
+        Buffer.from(jwt.split('.')[1], 'base64url').toString(),
+      );
+
+      assert.equal(payload.iss, '__test_client_id__');
+      assert.equal(payload.aud, 'https://op.example.com');
+      assert.equal(payload.client_id, '__test_client_id__');
+      assert.isNumber(payload.exp);
+      assert.isString(payload.jti);
+      assert.isNotEmpty(payload.jti);
+      assert.equal(payload.scope, 'openid profile email');
+      assert.equal(payload.response_type, 'code');
+      assert.equal(payload.redirect_uri, 'https://example.org/callback');
+    });
+
+    it('should set exp to approximately 60 seconds in future', async function () {
+      const clock = sinon.useFakeTimers({
+        now: Date.now(),
+        toFake: ['Date'],
+      });
+
+      try {
+        const config = getConfig({
+          secret: '__test_session_secret__',
+          clientID: '__test_client_id__',
+          clientSecret: '__test_client_secret__',
+          issuerBaseURL: 'https://op.example.com',
+          baseURL: 'https://example.org',
+          requestObjectSigningKey: privatePEM,
+          requestObjectSigningAlg: 'RS256',
+          authorizationParams: { response_type: 'code' },
+        });
+
+        const authParams = {
+          scope: 'openid profile email',
+          response_type: 'code',
+        };
+
+        const jwt = await buildRequestObject(authParams, config);
+        const payload = JSON.parse(
+          Buffer.from(jwt.split('.')[1], 'base64url').toString(),
+        );
+
+        const now = Math.floor(Date.now() / 1000);
+        assert.approximately(payload.exp, now + 60, 2);
+      } finally {
+        clock.restore();
+      }
+    });
+  });
 });

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -688,6 +688,25 @@ describe('client initialization', function () {
   describe('buildRequestObject', function () {
     const { buildRequestObject } = require('../lib/client');
     const { privatePEM } = require('../end-to-end/fixture/jwk');
+    // The discovered issuer (with trailing slash), passed as the required audience.
+    const ISSUER = 'https://op.example.com/';
+
+    it('should throw when no audience (discovered issuer) is passed', async function () {
+      const config = getConfig({
+        secret: '__test_session_secret__',
+        clientID: '__test_client_id__',
+        clientSecret: '__test_client_secret__',
+        issuerBaseURL: 'https://op.example.com',
+        baseURL: 'https://example.org',
+        requestObjectSigningKey: privatePEM,
+        requestObjectSigningAlg: 'RS256',
+        authorizationParams: { response_type: 'code' },
+      });
+      await assert.isRejected(
+        buildRequestObject({ response_type: 'code' }, config),
+        /audience/,
+      );
+    });
 
     it('should return a compact JWT with 3 parts', async function () {
       const config = getConfig({
@@ -707,7 +726,7 @@ describe('client initialization', function () {
         redirect_uri: 'https://example.org/callback',
       };
 
-      const jwt = await buildRequestObject(authParams, config);
+      const jwt = await buildRequestObject(authParams, config, ISSUER);
       const parts = jwt.split('.');
       assert.equal(parts.length, 3, 'JWT should have 3 parts');
     });
@@ -729,7 +748,7 @@ describe('client initialization', function () {
         response_type: 'code',
       };
 
-      const jwt = await buildRequestObject(authParams, config);
+      const jwt = await buildRequestObject(authParams, config, ISSUER);
       const header = JSON.parse(
         Buffer.from(jwt.split('.')[0], 'base64url').toString(),
       );
@@ -755,7 +774,7 @@ describe('client initialization', function () {
         response_type: 'code',
       };
 
-      const jwt = await buildRequestObject(authParams, config);
+      const jwt = await buildRequestObject(authParams, config, ISSUER);
       const header = JSON.parse(
         Buffer.from(jwt.split('.')[0], 'base64url').toString(),
       );
@@ -780,7 +799,7 @@ describe('client initialization', function () {
         response_type: 'code',
       };
 
-      const jwt = await buildRequestObject(authParams, config);
+      const jwt = await buildRequestObject(authParams, config, ISSUER);
       const header = JSON.parse(
         Buffer.from(jwt.split('.')[0], 'base64url').toString(),
       );
@@ -806,13 +825,13 @@ describe('client initialization', function () {
         redirect_uri: 'https://example.org/callback',
       };
 
-      const jwt = await buildRequestObject(authParams, config);
+      const jwt = await buildRequestObject(authParams, config, ISSUER);
       const payload = JSON.parse(
         Buffer.from(jwt.split('.')[1], 'base64url').toString(),
       );
 
       assert.equal(payload.iss, '__test_client_id__');
-      assert.equal(payload.aud, 'https://op.example.com');
+      assert.equal(payload.aud, ISSUER);
       assert.equal(payload.client_id, '__test_client_id__');
       assert.isNumber(payload.exp);
       assert.isString(payload.jti);
@@ -845,7 +864,7 @@ describe('client initialization', function () {
           response_type: 'code',
         };
 
-        const jwt = await buildRequestObject(authParams, config);
+        const jwt = await buildRequestObject(authParams, config, ISSUER);
         const payload = JSON.parse(
           Buffer.from(jwt.split('.')[1], 'base64url').toString(),
         );

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -906,4 +906,110 @@ describe('get config', () => {
       }),
     );
   });
+
+  describe('JAR config validation', () => {
+    it('should throw when requestObjectSigningKey is set without requestObjectSigningAlg', () => {
+      assert.throws(
+        () =>
+          getConfig({
+            ...defaultConfig,
+            clientSecret: '__test_client_secret__',
+            requestObjectSigningKey: 'some-key',
+            authorizationParams: { response_type: 'code' },
+          }),
+        TypeError,
+        '"requestObjectSigningAlg" is required when "requestObjectSigningKey" is set',
+      );
+    });
+
+    it('should accept requestObjectSigningKey with requestObjectSigningAlg', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const key = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+      const config = getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        requestObjectSigningKey: key,
+        requestObjectSigningAlg: 'RS256',
+        authorizationParams: { response_type: 'code' },
+      });
+      assert.ok(config.requestObjectSigningKey);
+      assert.equal(config.requestObjectSigningAlg, 'RS256');
+    });
+
+    it('should accept requestObjectSigningKeyId as optional', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const key = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+      const config = getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        requestObjectSigningKey: key,
+        requestObjectSigningAlg: 'RS256',
+        requestObjectSigningKeyId: 'key-1',
+        authorizationParams: { response_type: 'code' },
+      });
+      assert.equal(config.requestObjectSigningKeyId, 'key-1');
+    });
+
+    it('should accept requestObjectSigningKey without requestObjectSigningKeyId', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const key = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+      const config = getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        requestObjectSigningKey: key,
+        requestObjectSigningAlg: 'RS256',
+        authorizationParams: { response_type: 'code' },
+      });
+      assert.isUndefined(config.requestObjectSigningKeyId);
+    });
+
+    it('should emit console.warn when JAR is set without PAR', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const key = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+      const warnCallsBefore = console.warn.callCount;
+      getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        requestObjectSigningKey: key,
+        requestObjectSigningAlg: 'RS256',
+        pushedAuthorizationRequests: false,
+        authorizationParams: { response_type: 'code' },
+      });
+      const warnCalls = console.warn.getCalls().slice(warnCallsBefore);
+      const parWarn = warnCalls.some((call) => /PAR/i.test(call.args[0]));
+      assert.ok(parWarn);
+    });
+
+    it('should NOT emit console.warn when JAR is set WITH PAR', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const key = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+      const warnCallsBefore = console.warn.callCount;
+      getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        requestObjectSigningKey: key,
+        requestObjectSigningAlg: 'RS256',
+        pushedAuthorizationRequests: true,
+        authorizationParams: { response_type: 'code' },
+      });
+      const warnCalls = console.warn.getCalls().slice(warnCallsBefore);
+      const parWarn = warnCalls.some((call) => /PAR/i.test(call.args[0]));
+      assert.notOk(parWarn);
+    });
+  });
 });

--- a/test/login.tests.js
+++ b/test/login.tests.js
@@ -631,6 +631,31 @@ describe('auth', () => {
       assert.isNotEmpty(parsed.query.request);
     });
 
+    it('should reduce the non-PAR authorize redirect to only client_id and request', async () => {
+      server = await createServer(
+        auth({
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          requestObjectSigningKey: key,
+          requestObjectSigningAlg: 'RS256',
+          authorizationParams: { response_type: 'code' },
+        }),
+      );
+      const res = await request.get('/login', {
+        baseUrl,
+        followRedirect: false,
+      });
+      assert.equal(res.statusCode, 302);
+
+      const parsed = url.parse(res.headers.location, true);
+      // The signed request object carries every parameter; the redirect itself
+      // must expose only client_id and request.
+      assert.deepEqual(Object.keys(parsed.query).sort(), [
+        'client_id',
+        'request',
+      ]);
+    });
+
     it('should return a valid JWT in request param', async () => {
       server = await createServer(
         auth({

--- a/test/login.tests.js
+++ b/test/login.tests.js
@@ -602,4 +602,173 @@ describe('auth', () => {
       'Should get error json from server error middleware',
     );
   });
+
+  describe('JAR (JWT-Secured Authorization Requests)', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const key = fs.readFileSync(
+      path.join(__dirname, '../examples', 'private-key.pem'),
+    );
+
+    it('should include request param when requestObjectSigningKey is set', async () => {
+      server = await createServer(
+        auth({
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          requestObjectSigningKey: key,
+          requestObjectSigningAlg: 'RS256',
+          authorizationParams: { response_type: 'code' },
+        }),
+      );
+      const res = await request.get('/login', {
+        baseUrl,
+        followRedirect: false,
+      });
+      assert.equal(res.statusCode, 302);
+
+      const parsed = url.parse(res.headers.location, true);
+      assert.property(parsed.query, 'request');
+      assert.isNotEmpty(parsed.query.request);
+    });
+
+    it('should return a valid JWT in request param', async () => {
+      server = await createServer(
+        auth({
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          requestObjectSigningKey: key,
+          requestObjectSigningAlg: 'RS256',
+          authorizationParams: { response_type: 'code' },
+        }),
+      );
+      const res = await request.get('/login', {
+        baseUrl,
+        followRedirect: false,
+      });
+      const parsed = url.parse(res.headers.location, true);
+      const requestJwt = parsed.query.request;
+
+      const parts = requestJwt.split('.');
+      assert.equal(parts.length, 3, 'request param should be a JWT');
+
+      const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+      assert.isObject(payload);
+    });
+
+    it('should include standard claims in request JWT payload', async () => {
+      server = await createServer(
+        auth({
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          requestObjectSigningKey: key,
+          requestObjectSigningAlg: 'RS256',
+          authorizationParams: {
+            response_type: 'code',
+            scope: 'openid profile email',
+          },
+        }),
+      );
+      const res = await request.get('/login', {
+        baseUrl,
+        followRedirect: false,
+      });
+      const parsed = url.parse(res.headers.location, true);
+      const requestJwt = parsed.query.request;
+
+      const payload = JSON.parse(
+        Buffer.from(requestJwt.split('.')[1], 'base64url').toString(),
+      );
+
+      assert.equal(payload.iss, '__test_client_id__');
+      // aud must be the issuer identifier as advertised in discovery, which
+      // includes the trailing slash — not the configured issuerBaseURL.
+      assert.equal(payload.aud, 'https://op.example.com/');
+      assert.equal(payload.client_id, '__test_client_id__');
+      assert.equal(payload.response_type, 'code');
+      assert.equal(payload.scope, 'openid profile email');
+      assert.isNumber(payload.exp);
+      assert.isString(payload.jti);
+    });
+
+    it('should set aud to the discovered issuer, not issuerBaseURL (trailing slash)', async () => {
+      server = await createServer(
+        auth({
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          requestObjectSigningKey: key,
+          requestObjectSigningAlg: 'RS256',
+          authorizationParams: { response_type: 'code' },
+        }),
+      );
+      const res = await request.get('/login', {
+        baseUrl,
+        followRedirect: false,
+      });
+      const parsed = url.parse(res.headers.location, true);
+      const payload = JSON.parse(
+        Buffer.from(parsed.query.request.split('.')[1], 'base64url').toString(),
+      );
+      // The discovery fixture advertises issuer "https://op.example.com/".
+      assert.equal(payload.aud, 'https://op.example.com/');
+      assert.notEqual(payload.aud, 'https://op.example.com');
+    });
+
+    it('should use PAR endpoint when pushedAuthorizationRequests is enabled', async () => {
+      nock('https://op.example.com').post('/oauth/par').reply(201, {
+        request_uri: 'urn:ietf:params:oauth:request-uri:test',
+        expires_in: 60,
+      });
+
+      server = await createServer(
+        auth({
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          requestObjectSigningKey: key,
+          requestObjectSigningAlg: 'RS256',
+          pushedAuthorizationRequests: true,
+          authorizationParams: { response_type: 'code' },
+        }),
+      );
+      const res = await request.get('/login', {
+        baseUrl,
+        followRedirect: false,
+      });
+      assert.equal(res.statusCode, 302);
+
+      const parsed = url.parse(res.headers.location, true);
+      // When using PAR, the request param is replaced with request_uri
+      assert.property(parsed.query, 'request_uri');
+      assert.isUndefined(parsed.query.request);
+    });
+
+    it('should not include request param in final URL when PAR is used', async () => {
+      nock('https://op.example.com').post('/oauth/par').reply(201, {
+        request_uri: 'urn:ietf:params:oauth:request-uri:test',
+        expires_in: 60,
+      });
+
+      server = await createServer(
+        auth({
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          requestObjectSigningKey: key,
+          requestObjectSigningAlg: 'RS256',
+          pushedAuthorizationRequests: true,
+          authorizationParams: { response_type: 'code' },
+        }),
+      );
+      const res = await request.get('/login', {
+        baseUrl,
+        followRedirect: false,
+      });
+      const parsed = url.parse(res.headers.location, true);
+
+      // The request object is consumed by PAR, so it should not appear in the final redirect
+      assert.isUndefined(parsed.query.request);
+      assert.equal(
+        parsed.query.request_uri,
+        'urn:ietf:params:oauth:request-uri:test',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds support for [JWT-Secured Authorization Requests (JAR, RFC 9101)](https://www.rfc-editor.org/rfc/rfc9101.html). When `requestObjectSigningKey` is configured, the SDK signs all authorization parameters into a JWT and sends it as the `request` parameter, so the `/authorize` redirect carries only `client_id` and `request`.

## What's included

- **`requestObjectSigningKey`** — private key used to sign the request object. Accepts the same formats as `clientAssertionSigningKey` (PEM string, Buffer, KeyObject, JWK, CryptoKey).
- **`requestObjectSigningAlg`** — required whenever `requestObjectSigningKey` is set. Web Crypto algorithm names are not valid JWA `alg` values, so an explicit JWA algorithm is required (a shared `ASYMMETRIC_SIGNING_ALGS` list is used, matching `clientAssertionSigningAlg`).
- **`requestObjectSigningKeyId`** — optional `kid` header on the request object JWT.
- Works transparently on top of the existing PAR support. When PAR is enabled, the signed request object is POSTed to `/oauth/par`, which is the recommended FAPI pattern.
- The request object's `aud` is set to the issuer identifier advertised in the discovery document (which may differ from `issuerBaseURL`, e.g. a trailing slash), as JAR requires.

## Usage

```js
app.use(
  auth({
    authorizationParams: { response_type: 'code' },
    requestObjectSigningKey: fs.readFileSync('./request-object-key.pem'),
    requestObjectSigningAlg: 'RS256',
    pushedAuthorizationRequests: true, // recommended
  }),
);
```

## Tests

- Unit tests for `buildRequestObject` (header, `kid`, standard claims, `aud`), config validation (alg required with key), and the login redirect (`request` param present, PAR combination).
- An end-to-end test covering the combined PAR + JAR flow.
- Type tests in `index.test-d.ts`.
- Documentation in `EXAMPLES.md` and a runnable example at `examples/jar.js`.
