### PR TITLE
feat(jwe): decrypt JWE-encrypted access tokens

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -15,6 +15,7 @@
 13. [Use a proxy for OIDC requests](#13-use-a-proxy-for-oidc-requests)
 14. [Session expiry from upstream IdP (IPSIE `session_expiry`)](#14-session-expiry-from-upstream-idp-ipsie-session_expiry)
 15. [JWT-Secured Authorization Requests (JAR)](#15-jwt-secured-authorization-requests-jar)
+16. [Decrypt JWE-encrypted access tokens](#16-decrypt-jwe-encrypted-access-tokens)
 
 ## 1. Basic setup
 
@@ -567,3 +568,28 @@ app.use(
 The request object's `aud` is set to the issuer identifier advertised in the discovery document (which may differ from `issuerBaseURL`, e.g. a trailing slash), as JAR requires. `requestObjectSigningKey` accepts the same key formats as `clientAssertionSigningKey` (PEM string, Buffer, KeyObject, JWK, CryptoKey).
 
 Full example at [jar.js](./examples/jar.js), to run it: `npm run start:example -- jar`
+
+## 16. Decrypt JWE-encrypted access tokens
+
+When an Auth0 API is configured with [Token Encryption](https://auth0.com/docs/secure/tokens/access-tokens/json-web-encryption), the access token returned at the callback is a JWE. Set `accessTokenDecryptionKey` and the SDK decrypts it before writing it to the session, at both the callback and on token refresh, so `req.oidc.accessToken` and `afterCallback` always receive a plaintext JWT. No change is needed in consuming code.
+
+```js
+app.use(
+  auth({
+    authorizationParams: {
+      response_type: 'code', // requires a client secret; JWE requires a code flow
+      audience: 'https://your-api/',
+      scope: 'openid profile email offline_access',
+    },
+    // Private key matching the public key uploaded to the API's Token Encryption
+    // settings. Accepts PEM string, Buffer, KeyObject, JWK, or CryptoKey.
+    accessTokenDecryptionKey: fs.readFileSync('./api-decryption-key.pem'),
+    // Optional pin. Omit to auto-detect the algorithm from the JWE header.
+    // accessTokenDecryptionAlg: 'RSA-OAEP-512',
+  }),
+);
+```
+
+The key-management algorithm is read from the JWE protected header (validated against a strong-algorithm allowlist), so decryption works whether the tenant uses `RSA-OAEP-256`, `RSA-OAEP-512`, and so on. Set `accessTokenDecryptionAlg` only if you want to pin one. Decryption requires a code flow, since implicit flow does not return access tokens from the token endpoint.
+
+Full example at [jwe.js](./examples/jwe.js).

--- a/examples/jwe.js
+++ b/examples/jwe.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const { auth } = require('../');
+
+const app = express();
+
+// JWE access token decryption demo.
+//
+// When Auth0 is configured to encrypt access tokens for an API (Dashboard > APIs >
+// your API > Token Encryption), the token returned at the callback is a JWE (five
+// dot-separated parts). With `accessTokenDecryptionKey` set, the SDK decrypts it
+// before writing it to the session - at both the callback and on token refresh -
+// so `req.oidc.accessToken` and `afterCallback` always see a plaintext JWT.
+//
+// The key-management algorithm is read from the JWE protected header (validated
+// against a strong-alg allowlist), so decryption works whether the tenant uses
+// RSA-OAEP-256, RSA-OAEP-512, etc. Set `accessTokenDecryptionAlg` only to pin one.
+//
+// Requires a code flow and an API that encrypts tokens, so this example is not
+// runnable against the mock provider (it does not encrypt). It shows the config.
+
+app.use(
+  auth({
+    authRequired: false,
+    clientSecret: '__your_client_secret__',
+    authorizationParams: {
+      response_type: 'code',
+      // Request the API whose access tokens are encrypted.
+      audience: 'https://your-api/',
+      scope: 'openid profile email offline_access',
+    },
+
+    // Private key matching the public key uploaded to the API's Token Encryption
+    // settings. Accepts PEM string, Buffer, KeyObject, JWK, or CryptoKey.
+    accessTokenDecryptionKey: require('fs').readFileSync(
+      './api-decryption-key.pem',
+    ),
+    // Optional pin. Omit to auto-detect the alg from the JWE header.
+    // accessTokenDecryptionAlg: 'RSA-OAEP-512',
+  }),
+);
+
+app.get('/', (req, res) => {
+  if (req.oidc.isAuthenticated()) {
+    const token = req.oidc.accessToken?.access_token;
+    // A decrypted token is a normal 3-part JWT; a 5-part value means it is still
+    // encrypted (decryption key not active).
+    const parts = token ? token.split('.').length : 0;
+    res.send(
+      `<p>Logged in as <strong>${req.oidc.user.sub}</strong></p>` +
+        `<p>Access token parts: ${parts} (3 = decrypted JWT)</p>` +
+        `<a href="/logout">logout</a>`,
+    );
+  } else {
+    res.send('<a href="/login">login</a>');
+  }
+});
+
+module.exports = app;

--- a/index.d.ts
+++ b/index.d.ts
@@ -848,6 +848,22 @@ interface ConfigParams {
   requestObjectSigningKeyId?: string;
 
   /**
+   * Private key used to decrypt JWE-encrypted access tokens.
+   * When set, the SDK decrypts the access token at the callback and on refresh
+   * before writing it to the session, so `req.oidc.accessToken` and `afterCallback`
+   * always receive a plaintext JWT. Requires a code flow (`response_type: 'code'`
+   * or `'code id_token'`). Accepts PEM string, Buffer, KeyObject, JWK, or CryptoKey.
+   */
+  accessTokenDecryptionKey?: KeyObject | JoseCryptoKey | JWK | string | Buffer;
+
+  /**
+   * Optional pin for the JWE key-management algorithm. When omitted, the algorithm
+   * is read from the JWE protected header (validated against a strong-algorithm
+   * allowlist), so decryption works with whatever alg the tenant uses.
+   */
+  accessTokenDecryptionAlg?: string;
+
+  /**
    * Additional request body properties to be sent to the `token_endpoint` during authorization code exchange or token refresh.
    */
   tokenEndpointParams?: TokenParameters;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -15,3 +15,11 @@ expectType<RequestHandler>(
     requestObjectSigningKeyId: 'kid-1',
   }),
 );
+
+// JWE access token decryption
+expectType<RequestHandler>(
+  auth({
+    accessTokenDecryptionKey: '-----BEGIN PRIVATE KEY-----',
+    accessTokenDecryptionAlg: 'RSA-OAEP-512',
+  }),
+);

--- a/lib/client.js
+++ b/lib/client.js
@@ -341,14 +341,23 @@ const ALLOWED_ACCESS_TOKEN_JWE_ALGS = [
  * Decrypts a JWE-encrypted access token.
  * Co-located here so it can call the internal importPrivateKey helper directly.
  *
- * The key-management algorithm is taken from the JWE protected header (so the tenant
- * can encrypt with e.g. RSA-OAEP-256 or RSA-OAEP-512 without the client pre-declaring
- * it) but ONLY after jose validates it against an allowlist of strong algorithms.
- * This prevents algorithm-confusion / downgrade attacks (notably RSA1_5). When the
- * developer sets `accessTokenDecryptionAlg`, the allowlist is narrowed to that one
- * value, turning it into a hard pin.
+ * A JWE in compact serialization has exactly five dot-separated parts. Anything
+ * else (a plaintext 3-part JWT, an opaque token, etc.) is returned unchanged, so
+ * that toggling Token Encryption off, a mid-rollout mismatch, or an audience that
+ * yields an opaque token does not turn every login and refresh into a hard error.
+ *
+ * For genuine JWEs the key-management algorithm is taken from the protected header
+ * (so the tenant can encrypt with e.g. RSA-OAEP-256 or RSA-OAEP-512 without the
+ * client pre-declaring it) but ONLY after jose validates it against an allowlist of
+ * strong algorithms. This prevents algorithm-confusion / downgrade attacks (notably
+ * RSA1_5). When the developer sets `accessTokenDecryptionAlg`, the allowlist is
+ * narrowed to that one value, turning it into a hard pin.
  */
 async function decryptAccessToken(token, keyData, alg) {
+  // Not a compact JWE (five parts) — pass through untouched.
+  if (typeof token !== 'string' || token.split('.').length !== 5) {
+    return token;
+  }
   const keyManagementAlgorithms = alg ? [alg] : ALLOWED_ACCESS_TOKEN_JWE_ALGS;
   const { plaintext } = await compactDecrypt(
     token,

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,12 @@
 const crypto = require('crypto');
 const client = require('openid-client');
-const { importPKCS8, importJWK, exportPKCS8, SignJWT } = require('jose');
+const {
+  importPKCS8,
+  importJWK,
+  exportPKCS8,
+  SignJWT,
+  compactDecrypt,
+} = require('jose');
 const pkg = require('../package.json');
 const debug = require('./debug')('client');
 
@@ -315,7 +321,45 @@ async function buildRequestObject(authParams, config, audience) {
     .sign(key);
 }
 
+// Key-management ("alg") algorithms accepted for access-token decryption when the
+// developer has not pinned one. Deliberately excludes RSA1_5 (PKCS#1 v1.5), which
+// is vulnerable to Bleichenbacher padding-oracle attacks. jose enforces this list
+// against the JWE header before the key is imported, so a token cannot downgrade
+// us to a weak or unexpected algorithm.
+const ALLOWED_ACCESS_TOKEN_JWE_ALGS = [
+  'RSA-OAEP',
+  'RSA-OAEP-256',
+  'RSA-OAEP-384',
+  'RSA-OAEP-512',
+  'ECDH-ES',
+  'ECDH-ES+A128KW',
+  'ECDH-ES+A192KW',
+  'ECDH-ES+A256KW',
+];
+
+/**
+ * Decrypts a JWE-encrypted access token.
+ * Co-located here so it can call the internal importPrivateKey helper directly.
+ *
+ * The key-management algorithm is taken from the JWE protected header (so the tenant
+ * can encrypt with e.g. RSA-OAEP-256 or RSA-OAEP-512 without the client pre-declaring
+ * it) but ONLY after jose validates it against an allowlist of strong algorithms.
+ * This prevents algorithm-confusion / downgrade attacks (notably RSA1_5). When the
+ * developer sets `accessTokenDecryptionAlg`, the allowlist is narrowed to that one
+ * value, turning it into a hard pin.
+ */
+async function decryptAccessToken(token, keyData, alg) {
+  const keyManagementAlgorithms = alg ? [alg] : ALLOWED_ACCESS_TOKEN_JWE_ALGS;
+  const { plaintext } = await compactDecrypt(
+    token,
+    (header) => importPrivateKey(keyData, header.alg),
+    { keyManagementAlgorithms },
+  );
+  return Buffer.from(plaintext).toString('utf8');
+}
+
 exports.buildRequestObject = buildRequestObject;
+exports.decryptAccessToken = decryptAccessToken;
 
 exports.get = (config) => {
   const { discoveryCacheMaxAge: cacheMaxAge } = config;

--- a/lib/config.js
+++ b/lib/config.js
@@ -50,6 +50,20 @@ const ASYMMETRIC_SIGNING_ALGS = [
   'Ed25519',
 ];
 
+// Strong JWE key-management algorithms accepted for access-token decryption.
+// Mirrors ALLOWED_ACCESS_TOKEN_JWE_ALGS in lib/client.js; kept here so an explicit
+// accessTokenDecryptionAlg pin is validated at config time (defense in depth).
+const ACCESS_TOKEN_JWE_ALGS = [
+  'RSA-OAEP',
+  'RSA-OAEP-256',
+  'RSA-OAEP-384',
+  'RSA-OAEP-512',
+  'ECDH-ES',
+  'ECDH-ES+A128KW',
+  'ECDH-ES+A192KW',
+  'ECDH-ES+A256KW',
+];
+
 const paramsSchema = Joi.object({
   secret: Joi.alternatives([
     Joi.string().min(8),
@@ -390,8 +404,11 @@ const paramsSchema = Joi.object({
     ),
   // Optional pin. When omitted, the key-management alg is read from the JWE
   // protected header, so decryption works with whatever alg the tenant uses
-  // (e.g. RSA-OAEP-256 or RSA-OAEP-512). When set, the token's alg must match.
-  accessTokenDecryptionAlg: Joi.string().optional(),
+  // (e.g. RSA-OAEP-256 or RSA-OAEP-512). When set, the token's alg must match,
+  // and the pin itself is constrained to the strong-algorithm allowlist.
+  accessTokenDecryptionAlg: Joi.string()
+    .valid(...ACCESS_TOKEN_JWE_ALGS)
+    .optional(),
   discoveryCacheMaxAge: Joi.number()
     .optional()
     .min(0)

--- a/lib/config.js
+++ b/lib/config.js
@@ -374,6 +374,24 @@ const paramsSchema = Joi.object({
       otherwise: Joi.string().optional(),
     }),
   requestObjectSigningKeyId: Joi.string().optional(),
+  accessTokenDecryptionKey: Joi.any()
+    .optional()
+    .when(
+      Joi.ref('authorizationParams.response_type', {
+        adjust: (v) => v && !v.includes('code'),
+      }),
+      {
+        is: true,
+        then: Joi.any().forbidden().messages({
+          'any.unknown':
+            '"accessTokenDecryptionKey" requires a code flow. Set authorizationParams.response_type to "code" or "code id_token".',
+        }),
+      },
+    ),
+  // Optional pin. When omitted, the key-management alg is read from the JWE
+  // protected header, so decryption works with whatever alg the tenant uses
+  // (e.g. RSA-OAEP-256 or RSA-OAEP-512). When set, the token's alg must match.
+  accessTokenDecryptionAlg: Joi.string().optional(),
   discoveryCacheMaxAge: Joi.number()
     .optional()
     .min(0)

--- a/lib/context.js
+++ b/lib/context.js
@@ -18,6 +18,7 @@ const {
   get: getClient,
   buildEndSessionUrl,
   buildRequestObject,
+  decryptAccessToken,
   client: oidcClient,
 } = require('./client');
 const { encodeState, decodeState } = require('../lib/hooks/getLoginState');
@@ -224,11 +225,34 @@ async function refresh({ tokenEndpointParams } = {}) {
     parameters,
   );
 
+  // Decrypt the refreshed access token when JWE decryption is configured, so the
+  // stored token and req.oidc.accessToken remain plaintext JWTs after a refresh —
+  // consistent with the callback. Without this, encrypted tokens would revert to
+  // ciphertext on the first refresh.
+  let refreshedAccessToken = newTokenSet.access_token;
+  if (config.accessTokenDecryptionKey && refreshedAccessToken) {
+    try {
+      refreshedAccessToken = await decryptAccessToken(
+        refreshedAccessToken,
+        config.accessTokenDecryptionKey,
+        config.accessTokenDecryptionAlg,
+      );
+    } catch (error) {
+      throw createError(
+        500,
+        `Failed to decrypt the refreshed access token: ${error.message}. ` +
+          'Check that accessTokenDecryptionKey matches the key configured on the ' +
+          'authorization server, and that accessTokenDecryptionAlg (if set) matches ' +
+          'the JWE "alg".',
+      );
+    }
+  }
+
   // Update the session, preserving sessionExpiresAt — the refresh-token grant
   // does not return a session_expiry claim, so we must not overwrite the ceiling
   // that was set at login.
   Object.assign(session, {
-    access_token: newTokenSet.access_token,
+    access_token: refreshedAccessToken,
     // If no new ID token assume the current ID token is valid.
     id_token: newTokenSet.id_token || oldTokenSet.id_token,
     // If no new refresh token assume the current refresh token is valid.
@@ -851,6 +875,28 @@ class ResponseContext {
           ? epoch() + tokenResponse.expires_in
           : undefined,
       };
+
+      if (config.accessTokenDecryptionKey && session.access_token) {
+        try {
+          session.access_token = await decryptAccessToken(
+            session.access_token,
+            config.accessTokenDecryptionKey,
+            config.accessTokenDecryptionAlg,
+          );
+        } catch (error) {
+          // Surface a clear, actionable error instead of a raw crypto stack trace.
+          // The most common causes are a key that does not match the tenant's
+          // encryption key, or an accessTokenDecryptionAlg that does not match the
+          // alg the token was encrypted with.
+          throw createError(
+            500,
+            `Failed to decrypt the access token: ${error.message}. ` +
+              'Check that accessTokenDecryptionKey matches the key configured on the ' +
+              'authorization server, and that accessTokenDecryptionAlg (if set) matches ' +
+              'the JWE "alg".',
+          );
+        }
+      }
 
       // Must store the `sid` separately as the ID Token gets overridden by
       // ID Token from the Refresh Grant which may not contain a sid (In Auth0 currently).

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -1751,7 +1751,7 @@ describe('callback response_mode: form_post', () => {
         c_hash: '77QmUPtjPfzWtF2AnpK9RQ',
       });
 
-      const { jar, tokens } = await setup({
+      const { tokens } = await setup({
         authOpts: {
           ...defaultConfig,
           clientSecret: '__test_client_secret__',

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -76,7 +76,8 @@ const setup = async (params) => {
       tokenReqBodyJson = qs.parse(requestBody);
       require('querystring').parse(requestBody);
       return {
-        access_token: '__test_access_token__',
+        // Allow tests to inject a specific access token (e.g. a JWE) via params.
+        access_token: params.accessToken || '__test_access_token__',
         refresh_token: '__test_refresh_token__',
         // Use tokenIdToken param for pure code flow, fallback to body.id_token for hybrid
         id_token: params.tokenIdToken || params.body.id_token,
@@ -1742,6 +1743,215 @@ describe('callback response_mode: form_post', () => {
         storedCeiling,
         'sessionExpiresAt must be preserved across refreshes',
       );
+    });
+  });
+  describe('JWE access token decryption', () => {
+    it('should pass through a plain access token when no decryption key is configured', async () => {
+      const validToken = makeIdToken({
+        c_hash: '77QmUPtjPfzWtF2AnpK9RQ',
+      });
+
+      const { jar, tokens } = await setup({
+        authOpts: {
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          authorizationParams: { response_type: 'code id_token' },
+        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+        body: {
+          state: expectedDefaultState,
+          id_token: validToken,
+          code: 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y',
+        },
+      });
+
+      // Plain token should pass through unchanged
+      assert.equal(tokens.accessToken.access_token, '__test_access_token__');
+    });
+
+    it('should accept accessTokenDecryptionKey configuration without throwing errors', async () => {
+      const fs = require('fs');
+      const path = require('path');
+      const privateKeyPem = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+
+      // This test verifies the config is accepted without throwing
+      // The actual JWE decryption is tested in client.tests.js
+      assert.doesNotThrow(() => {
+        const { get: getConfig } = require('../lib/config');
+        getConfig({
+          secret: '__test_session_secret__',
+          clientID: '__test_client_id__',
+          baseURL: 'https://example.org',
+          issuerBaseURL: 'https://op.example.com',
+          clientSecret: '__test_client_secret__',
+          accessTokenDecryptionKey: privateKeyPem,
+          accessTokenDecryptionAlg: 'RSA-OAEP-256',
+          authorizationParams: { response_type: 'code' },
+        });
+      });
+    });
+
+    const { CompactEncrypt, importJWK } = require('jose');
+    const { publicJWK, privatePEM } = require('../end-to-end/fixture/jwk');
+
+    const encryptToken = async (plaintext, alg) => {
+      const publicKey = await importJWK(publicJWK, alg);
+      return new CompactEncrypt(new TextEncoder().encode(plaintext))
+        .setProtectedHeader({ alg, enc: 'A128CBC-HS256' })
+        .encrypt(publicKey);
+    };
+
+    it('should decrypt a JWE access token before storing it in the session', async () => {
+      const plainAccessToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.body.sig';
+      const jwe = await encryptToken(plainAccessToken, 'RSA-OAEP-256');
+      const validToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+
+      const { tokens } = await setup({
+        accessToken: jwe,
+        authOpts: {
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          accessTokenDecryptionKey: privatePEM,
+          authorizationParams: { response_type: 'code id_token' },
+        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+        body: {
+          state: expectedDefaultState,
+          id_token: validToken,
+          code: 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y',
+        },
+      });
+
+      // req.oidc.accessToken must be the decrypted, plaintext JWT.
+      assert.equal(tokens.accessToken.access_token, plainAccessToken);
+    });
+
+    it('should auto-detect the JWE alg (RSA-OAEP-512) when no alg is pinned', async () => {
+      const plainAccessToken =
+        'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.body512.sig';
+      const jwe = await encryptToken(plainAccessToken, 'RSA-OAEP-512');
+      const validToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+
+      const { tokens } = await setup({
+        accessToken: jwe,
+        authOpts: {
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          accessTokenDecryptionKey: privatePEM,
+          authorizationParams: { response_type: 'code id_token' },
+        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+        body: {
+          state: expectedDefaultState,
+          id_token: validToken,
+          code: 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y',
+        },
+      });
+
+      assert.equal(tokens.accessToken.access_token, plainAccessToken);
+    });
+
+    it('should surface a clear error when decryption fails (wrong key/token)', async () => {
+      const notAJwe = '__test_access_token__';
+      const validToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+
+      const { response } = await setup({
+        accessToken: notAJwe,
+        authOpts: {
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          accessTokenDecryptionKey: privatePEM,
+          authorizationParams: { response_type: 'code id_token' },
+        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+        body: {
+          state: expectedDefaultState,
+          id_token: validToken,
+          code: 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y',
+        },
+      });
+
+      assert.equal(response.statusCode, 500);
+      assert.match(
+        response.body.err.message,
+        /Failed to decrypt the access token/,
+      );
+    });
+
+    it('should decrypt the refreshed access token (refresh grant, not just callback)', async () => {
+      const loginPlain = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.login.sig';
+      const refreshedPlain =
+        'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.refreshed.sig';
+      const loginJwe = await encryptToken(loginPlain, 'RSA-OAEP-256');
+      const refreshedJwe = await encryptToken(refreshedPlain, 'RSA-OAEP-256');
+      const idToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+
+      const authOpts = {
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        accessTokenDecryptionKey: privatePEM,
+        authorizationParams: {
+          response_type: 'code id_token',
+          scope: 'openid profile email offline_access',
+        },
+      };
+      const router = auth(authOpts);
+      router.get('/refresh', async (req, res) => {
+        const accessToken = await req.oidc.accessToken.refresh();
+        res.json({ accessToken });
+      });
+
+      const { tokens, jar } = await setup({
+        router,
+        accessToken: loginJwe,
+        authOpts,
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+        body: {
+          state: expectedDefaultState,
+          id_token: idToken,
+          code: 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y',
+        },
+      });
+
+      // Login token was decrypted at the callback.
+      assert.equal(tokens.accessToken.access_token, loginPlain);
+
+      // Refresh grant returns a fresh JWE — it must be decrypted too.
+      const {
+        interceptors: [interceptor],
+      } = nock('https://op.example.com', { allowUnmocked: true })
+        .post('/oauth/token')
+        .reply(200, () => ({
+          access_token: refreshedJwe,
+          refresh_token: '__new_refresh_token__',
+          id_token: idToken,
+          token_type: 'Bearer',
+          expires_in: 86400,
+        }));
+
+      const refreshed = await request
+        .get('/refresh', { baseUrl, jar, json: true })
+        .then((r) => r.body);
+      nock.removeInterceptor(interceptor);
+
+      assert.equal(refreshed.accessToken.access_token, refreshedPlain);
     });
   });
 });

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -1862,16 +1862,25 @@ describe('callback response_mode: form_post', () => {
       assert.equal(tokens.accessToken.access_token, plainAccessToken);
     });
 
-    it('should surface a clear error when decryption fails (wrong key/token)', async () => {
-      const notAJwe = '__test_access_token__';
+    it('should surface a clear error when decryption fails (wrong key)', async () => {
+      // A genuine JWE (5 parts) encrypted to the fixture public key, but the SDK is
+      // configured with a different, non-matching private key -> decryption fails.
+      const jwe = await encryptToken(
+        'eyJhbGciOiJSUzI1NiJ9.body.sig',
+        'RSA-OAEP-256',
+      );
+      const { generateKeyPairSync } = require('crypto');
+      const wrongKey = generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+      }).privateKey.export({ type: 'pkcs8', format: 'pem' });
       const validToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
 
       const { response } = await setup({
-        accessToken: notAJwe,
+        accessToken: jwe,
         authOpts: {
           ...defaultConfig,
           clientSecret: '__test_client_secret__',
-          accessTokenDecryptionKey: privatePEM,
+          accessTokenDecryptionKey: wrongKey,
           authorizationParams: { response_type: 'code id_token' },
         },
         cookies: generateCookies({
@@ -1890,6 +1899,32 @@ describe('callback response_mode: form_post', () => {
         response.body.err.message,
         /Failed to decrypt the access token/,
       );
+    });
+
+    it('should pass a plaintext (non-JWE) access token through unchanged', async () => {
+      const validToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+
+      const { tokens } = await setup({
+        accessToken: '__test_access_token__', // opaque, not a JWE
+        authOpts: {
+          ...defaultConfig,
+          clientSecret: '__test_client_secret__',
+          accessTokenDecryptionKey: privatePEM,
+          authorizationParams: { response_type: 'code id_token' },
+        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+        body: {
+          state: expectedDefaultState,
+          id_token: validToken,
+          code: 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y',
+        },
+      });
+
+      // No hard 500; the opaque token is stored unchanged.
+      assert.equal(tokens.accessToken.access_token, '__test_access_token__');
     });
 
     it('should decrypt the refreshed access token (refresh grant, not just callback)', async () => {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -879,16 +879,10 @@ describe('client initialization', function () {
 
   describe('decryptAccessToken', function () {
     const { decryptAccessToken } = require('../lib/client');
-    const { CompactEncrypt, importJWK, exportSPKI } = require('jose');
-    const fs = require('fs');
-    const path = require('path');
-    const { privateJWK, publicJWK } = require('../end-to-end/fixture/jwk');
+    const { CompactEncrypt, importJWK } = require('jose');
+    const { publicJWK } = require('../end-to-end/fixture/jwk');
 
     it('should decrypt a JWE-encrypted access token', async function () {
-      const privateKeyPem = fs.readFileSync(
-        path.join(__dirname, '../examples', 'private-key.pem'),
-      );
-
       // Use the test fixture JWK keys which are explicitly created for testing
       const publicKey = await importJWK(publicJWK, 'RSA-OAEP-256');
       const plaintext = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature';

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -876,4 +876,98 @@ describe('client initialization', function () {
       }
     });
   });
+
+  describe('decryptAccessToken', function () {
+    const { decryptAccessToken } = require('../lib/client');
+    const { CompactEncrypt, importJWK, exportSPKI } = require('jose');
+    const fs = require('fs');
+    const path = require('path');
+    const { privateJWK, publicJWK } = require('../end-to-end/fixture/jwk');
+
+    it('should decrypt a JWE-encrypted access token', async function () {
+      const privateKeyPem = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+
+      // Use the test fixture JWK keys which are explicitly created for testing
+      const publicKey = await importJWK(publicJWK, 'RSA-OAEP-256');
+      const plaintext = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature';
+
+      const jwe = await new CompactEncrypt(new TextEncoder().encode(plaintext))
+        .setProtectedHeader({ alg: 'RSA-OAEP-256', enc: 'A128CBC-HS256' })
+        .encrypt(publicKey);
+
+      // Decrypt using the private key PEM
+      const decrypted = await decryptAccessToken(
+        jwe,
+        require('../end-to-end/fixture/jwk').privatePEM,
+        'RSA-OAEP-256',
+      );
+
+      assert.equal(decrypted, plaintext);
+    });
+
+    it('should throw when given a non-JWE string', async function () {
+      const plainJwt = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature';
+
+      await assert.isRejected(
+        decryptAccessToken(
+          plainJwt,
+          require('../end-to-end/fixture/jwk').privatePEM,
+          'RSA-OAEP-256',
+        ),
+      );
+    });
+
+    it('should throw when decryption fails with invalid JWE', async function () {
+      const plainJwt = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9';
+
+      // Try to decrypt something that's not a valid JWE
+      await assert.isRejected(
+        decryptAccessToken(
+          plainJwt,
+          require('../end-to-end/fixture/jwk').privatePEM,
+          'RSA-OAEP-256',
+        ),
+      );
+    });
+
+    // The alg is read from the JWE header (within a strong-alg allowlist) when no
+    // explicit accessTokenDecryptionAlg is pinned, so decryption works regardless
+    // of whether the tenant uses RSA-OAEP-256 or RSA-OAEP-512.
+    const { privatePEM } = require('../end-to-end/fixture/jwk');
+    const plaintext = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature';
+
+    const encryptWith = async (alg) => {
+      const publicKey = await importJWK(publicJWK, alg);
+      return new CompactEncrypt(new TextEncoder().encode(plaintext))
+        .setProtectedHeader({ alg, enc: 'A128CBC-HS256' })
+        .encrypt(publicKey);
+    };
+
+    ['RSA-OAEP-256', 'RSA-OAEP-512'].forEach((alg) => {
+      it(`should auto-detect ${alg} from the JWE header when no alg is pinned`, async function () {
+        const jwe = await encryptWith(alg);
+        const decrypted = await decryptAccessToken(jwe, privatePEM, undefined);
+        assert.equal(decrypted, plaintext);
+      });
+    });
+
+    it('should decrypt when the pinned alg matches the token', async function () {
+      const jwe = await encryptWith('RSA-OAEP-512');
+      const decrypted = await decryptAccessToken(
+        jwe,
+        privatePEM,
+        'RSA-OAEP-512',
+      );
+      assert.equal(decrypted, plaintext);
+    });
+
+    it('should reject when the pinned alg does not match the token', async function () {
+      const jwe = await encryptWith('RSA-OAEP-512');
+      await assert.isRejected(
+        decryptAccessToken(jwe, privatePEM, 'RSA-OAEP-256'),
+      );
+    });
+  });
 });

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -907,29 +907,26 @@ describe('client initialization', function () {
       assert.equal(decrypted, plaintext);
     });
 
-    it('should throw when given a non-JWE string', async function () {
+    it('should pass a 3-part JWT (non-JWE) through unchanged', async function () {
       const plainJwt = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test.signature';
 
-      await assert.isRejected(
-        decryptAccessToken(
-          plainJwt,
-          require('../end-to-end/fixture/jwk').privatePEM,
-          'RSA-OAEP-256',
-        ),
+      const result = await decryptAccessToken(
+        plainJwt,
+        require('../end-to-end/fixture/jwk').privatePEM,
+        'RSA-OAEP-256',
       );
+      assert.equal(result, plainJwt);
     });
 
-    it('should throw when decryption fails with invalid JWE', async function () {
-      const plainJwt = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9';
+    it('should pass a non-JWE opaque string through unchanged', async function () {
+      const opaque = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9';
 
-      // Try to decrypt something that's not a valid JWE
-      await assert.isRejected(
-        decryptAccessToken(
-          plainJwt,
-          require('../end-to-end/fixture/jwk').privatePEM,
-          'RSA-OAEP-256',
-        ),
+      const result = await decryptAccessToken(
+        opaque,
+        require('../end-to-end/fixture/jwk').privatePEM,
+        'RSA-OAEP-256',
       );
+      assert.equal(result, opaque);
     });
 
     // The alg is read from the JWE header (within a strong-alg allowlist) when no
@@ -968,6 +965,28 @@ describe('client initialization', function () {
       await assert.isRejected(
         decryptAccessToken(jwe, privatePEM, 'RSA-OAEP-256'),
       );
+    });
+
+    it('should reject a JWE whose alg is not on the allowlist', async function () {
+      // A128KW is a valid JWE alg but deliberately excluded from the allowlist.
+      // The key resolver (importPrivateKey) must never run for a rejected alg.
+      const symKey = new Uint8Array(16); // 128-bit key for A128KW
+      const jwe = await new CompactEncrypt(new TextEncoder().encode(plaintext))
+        .setProtectedHeader({ alg: 'A128KW', enc: 'A128CBC-HS256' })
+        .encrypt(symKey);
+      await assert.isRejected(decryptAccessToken(jwe, privatePEM, undefined));
+    });
+
+    it('should pass a non-JWE (plaintext JWT) token through unchanged', async function () {
+      const jwt = 'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ4In0.sig'; // 3 parts, not a JWE
+      const result = await decryptAccessToken(jwt, privatePEM, undefined);
+      assert.equal(result, jwt);
+    });
+
+    it('should pass an opaque access token through unchanged', async function () {
+      const opaque = 'opaque-access-token-value';
+      const result = await decryptAccessToken(opaque, privatePEM, undefined);
+      assert.equal(result, opaque);
     });
   });
 });

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -1012,4 +1012,70 @@ describe('get config', () => {
       assert.notOk(parWarn);
     });
   });
+
+  describe('JWE config validation', () => {
+    it('should accept accessTokenDecryptionKey when response_type is code', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const key = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+      const config = getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        accessTokenDecryptionKey: key,
+        authorizationParams: { response_type: 'code' },
+      });
+      assert.ok(config.accessTokenDecryptionKey);
+    });
+
+    it('should throw when accessTokenDecryptionKey is set with response_type id_token', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const key = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+      assert.throws(
+        () =>
+          getConfig({
+            ...defaultConfig,
+            accessTokenDecryptionKey: key,
+            authorizationParams: { response_type: 'id_token' },
+          }),
+        TypeError,
+        '"accessTokenDecryptionKey" requires a code flow',
+      );
+    });
+
+    it('should leave accessTokenDecryptionAlg undefined by default (alg is read from the JWE header)', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const key = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+      const config = getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        accessTokenDecryptionKey: key,
+        authorizationParams: { response_type: 'code' },
+      });
+      assert.isUndefined(config.accessTokenDecryptionAlg);
+    });
+
+    it('should accept custom accessTokenDecryptionAlg', () => {
+      const fs = require('fs');
+      const path = require('path');
+      const key = fs.readFileSync(
+        path.join(__dirname, '../examples', 'private-key.pem'),
+      );
+      const config = getConfig({
+        ...defaultConfig,
+        clientSecret: '__test_client_secret__',
+        accessTokenDecryptionKey: key,
+        accessTokenDecryptionAlg: 'RSA-OAEP-512',
+        authorizationParams: { response_type: 'code' },
+      });
+      assert.equal(config.accessTokenDecryptionAlg, 'RSA-OAEP-512');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds decryption of JWE-encrypted access tokens. When an API is configured to encrypt access tokens, the token returned at the callback is a JWE. With `accessTokenDecryptionKey` set, the SDK decrypts it before writing it to the session, so `req.oidc.accessToken` and `afterCallback` always receive a plaintext JWT with no change to consuming code.

> Stacked on #863 (JAR). Review after that merges; the base will retarget to `master`.

## What's included

- **`accessTokenDecryptionKey`** — private key for decryption. Accepts PEM string, Buffer, KeyObject, JWK, or CryptoKey. Requires a code flow (implicit flow returns no access token from the token endpoint).
- **`accessTokenDecryptionAlg`** — optional pin for the key-management algorithm.
- Decryption runs at **both the callback and on token refresh**, so tokens stay plaintext across refreshes for apps using `offline_access`.
- Decryption happens before `afterCallback` fires, so hooks receive a usable token.
- The key-management algorithm is read from the JWE protected header (so RSA-OAEP-256, RSA-OAEP-512, etc. all work without pre-declaring), but only after jose validates it against an allowlist of strong algorithms. This avoids a hardcoded default that breaks other algorithms while preventing algorithm-confusion/downgrade (notably RSA1_5). `accessTokenDecryptionAlg`, when set, narrows the allowlist to that one value.
- Decryption failures surface a clear, actionable error instead of a raw crypto stack trace.

## Usage

```js
app.use(
  auth({
    authorizationParams: {
      response_type: 'code',
      audience: 'https://your-api/',
      scope: 'openid profile email offline_access',
    },
    accessTokenDecryptionKey: fs.readFileSync('./api-decryption-key.pem'),
    // accessTokenDecryptionAlg: 'RSA-OAEP-512', // optional pin
  }),
);
```

## Tests

- Unit tests for `decryptAccessToken` (header auto-detect for RSA-OAEP-256/512, pin match/mismatch, non-JWE input), config validation (code-flow requirement), and end-to-end callback + refresh decryption with a clear-error case.
- Type tests in `index.test-d.ts`.
- Documentation in `EXAMPLES.md` and an example at `examples/jwe.js`.
