### PR TITLE
feat: add req.oidc.getAccessToken() with multi-resource refresh token support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -18,6 +18,7 @@
 16. [JWT-Secured Authorization Requests (JAR)](#16-jwt-secured-authorization-requests-jar)
 17. [mTLS client authentication](#17-mtls-client-authentication)
 18. [Passwordless authentication](#18-passwordless-authentication)
+19. [Multi-Resource Refresh Tokens (MRRT)](#19-multi-resource-refresh-tokens-mrrt)
 
 ## 1. Basic setup
 
@@ -770,6 +771,7 @@ try {
 
 Full example at [mtls.js](./examples/mtls.js).
 
+
 ## 18. Passwordless authentication
 
 [Passwordless](https://auth0.com/docs/authenticate/passwordless) lets users sign in without a password, using a one-time code (email or SMS) or a magic link (email). It is driven through Universal Login: Auth0 hosts the page that sends and collects the code or link. Select the connection with the `connection` authorization parameter, and optionally prefill the identifier with `login_hint`. No dedicated config is needed — `authorizationParams` accepts these directly.
@@ -800,3 +802,112 @@ Whether the `email` connection sends a code or a magic link is configured on the
 **Magic-link limitation:** a magic link only completes in the **same browser** that started the login, because `/callback` validates the browser-bound transaction cookie (`state`/`nonce`/PKCE) set at `/login`. Cross-device magic links (start on laptop, click on phone) are not supported by this redirect-based SDK; the Auth0 setting `allow_magiclink_verify_without_session` lifts Auth0's own same-session check but not this SDK's cookie requirement. One-time code flows are unaffected.
 
 Full example at [passwordless.js](./examples/passwordless.js), to run it: `npm run start:example -- passwordless`
+
+## 19. Multi-Resource Refresh Tokens (MRRT)
+
+> **Auth0-specific feature.** MRRT requires refresh token policies to be configured on your Auth0 application. See [Configure and Implement Multi-Resource Refresh Token](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token/configure-and-implement-multi-resource-refresh-token) for setup instructions, and [Multi-Resource Refresh Token](https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token#multi-resource-refresh-token) to learn how the feature works.
+
+By default, the access token in the session (`req.oidc.accessToken`) is scoped to the single audience you specified at login. With MRRT, you can use the same refresh token to obtain access tokens for additional APIs — without sending the user through a new login flow.
+
+`req.oidc.getAccessToken()` handles this automatically: it returns a cached token when one exists and is valid, or exchanges the session's refresh token for a new one when the cache is empty or expired.
+
+### Setup
+
+Request `offline_access` at login so the session contains a refresh token:
+
+```js
+app.use(
+  auth({
+    authorizationParams: {
+      response_type: 'code',
+      audience: 'https://products-api.example.com/',
+      scope: 'openid profile offline_access read:products',
+    },
+  }),
+);
+```
+
+### Retrieving an access token
+
+Call `getAccessToken()` with no arguments to get a token for the audience configured at login. The SDK returns the cached token when it has not expired, or silently refreshes it when it has:
+
+```js
+app.get('/products', requiresAuth(), async (req, res, next) => {
+  try {
+    const { access_token, token_type } = await req.oidc.getAccessToken();
+
+    const { data } = await axios.get(
+      'https://products-api.example.com/v1/products',
+      { headers: { Authorization: `${token_type} ${access_token}` } },
+    );
+
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+});
+```
+
+### Retrieving a token for a different API (MRRT)
+
+Pass `audience` to exchange the session's refresh token for a token scoped to a different resource server. The first call hits the token endpoint; subsequent calls return the cached token until it expires:
+
+```js
+app.get('/orders', requiresAuth(), async (req, res, next) => {
+  try {
+    const { access_token, token_type } = await req.oidc.getAccessToken({
+      audience: 'https://orders-api.example.com/',
+      scope: 'read:orders',
+    });
+
+    const { data } = await axios.get(
+      'https://orders-api.example.com/v1/orders',
+      { headers: { Authorization: `${token_type} ${access_token}` } },
+    );
+
+    res.json(data);
+  } catch (err) {
+    next(err);
+  }
+});
+```
+
+> **Note:** Auth0 silently ignores any audience or scopes not covered by the configured policies — it will not throw an error, but the returned token will only contain the permitted scopes. Refer to your application's policy configuration to confirm what is allowed.
+
+### Downscoping
+
+You can request a narrower set of scopes than the cached token holds. The SDK treats a cached token as a hit when it covers all the requested scopes, so no new exchange is made:
+
+```js
+// Cached token has 'read:orders write:orders' — returns it without a new exchange
+const { access_token } = await req.oidc.getAccessToken({
+  audience: 'https://orders-api.example.com/',
+  scope: 'read:orders',
+});
+```
+
+### Error handling
+
+| Error | Cause |
+|-------|-------|
+| `Error: The user does not have an active session.` | No session found — user is not logged in |
+| `Error: The access token has expired and a refresh token was not found…` | Token expired but `offline_access` was not requested at login |
+| `SessionExpiredError` | The IdP session ceiling (`sessionExpiresAt`) has been reached — redirect the user to login |
+
+```js
+const { SessionExpiredError } = require('express-openid-connect');
+
+app.get('/orders', requiresAuth(), async (req, res, next) => {
+  try {
+    const { access_token } = await req.oidc.getAccessToken({
+      audience: 'https://orders-api.example.com/',
+    });
+    // use access_token ...
+  } catch (err) {
+    if (err instanceof SessionExpiredError) {
+      return res.oidc.login(); // re-authenticate the user
+    }
+    next(err);
+  }
+});
+```

--- a/examples/.env.sample
+++ b/examples/.env.sample
@@ -7,3 +7,6 @@ BASE_URL=https://YOUR_APPLICATION_ROOT_URL
 SECRET=LONG_RANDOM_VALUE
 # For response_type values that include 'code'
 CLIENT_SECRET=YOUR_CLIENT_SECRET
+# For multiple audiences and scopes, you can add additional audience and scope pairs as needed
+AUDIENCE_1=https://YOUR_FIRST_API
+AUDIENCE_2=https://YOUR_SECOND_API

--- a/examples/mrrt.js
+++ b/examples/mrrt.js
@@ -1,0 +1,94 @@
+const express = require('express');
+const { auth, requiresAuth } = require('../');
+
+const app = express();
+
+/*
+ * Multi-Resource Refresh Tokens (MRRT).
+ *
+ * MRRT is an Auth0 feature that lets a single refresh token be exchanged for
+ * access tokens targeting multiple pre-approved resource servers (audiences).
+ * Which audiences (and scopes) a refresh token may be exchanged for is governed
+ * by refresh token policies configured on the Auth0 application — see
+ * https://auth0.com/docs/secure/tokens/refresh-tokens/multi-resource-refresh-token
+ *
+ * `req.oidc.getAccessToken({ audience?, scope? })` drives it:
+ *   - no arguments  -> returns a token for the audience used at login, cached in
+ *                      the session and refreshed automatically when it expires.
+ *   - with audience -> exchanges the session's refresh token for a token scoped
+ *                      to that resource server (MRRT). Tokens are cached per
+ *                      audience+scope and reused until they expire.
+ *
+ * `offline_access` must be requested at login so the session holds a refresh
+ * token to exchange.
+ *
+ * Run with: npm run start:example -- mrrt
+ * NOTE: MRRT requires a real Auth0 tenant — the bundled mock authorization
+ * server does not implement refresh token policies. Configure a tenant and the
+ * two audiences via .env (see .env.sample): ISSUER_BASE_URL, CLIENT_ID,
+ * CLIENT_SECRET, BASE_URL, SECRET, plus AUDIENCE_1 / SCOPE_1 (used at login) and
+ * AUDIENCE_2 / SCOPE_2 (the second resource server). The Auth0 application also
+ * needs a refresh token policy authorizing AUDIENCE_2 for the requested scopes.
+ */
+
+const {
+  AUDIENCE_1,
+  SCOPE_1 = 'read:products',
+  AUDIENCE_2,
+  SCOPE_2 = 'read:orders',
+} = process.env;
+
+app.use(
+  auth({
+    authRequired: false,
+    authorizationParams: {
+      response_type: 'code',
+      audience: AUDIENCE_1,
+      scope: `openid profile email offline_access ${SCOPE_1}`,
+    },
+  }),
+);
+
+app.get('/', (req, res) => {
+  if (req.oidc.isAuthenticated()) {
+    res.send(
+      `<p>Logged in as <strong>${req.oidc.user.sub}</strong></p>` +
+        '<ul>' +
+        '<li><a href="/login-api">Login-audience API</a></li>' +
+        '<li><a href="/mrrt-api">Second API (MRRT exchange)</a></li>' +
+        '</ul>' +
+        '<a href="/logout">logout</a>',
+    );
+  } else {
+    res.send('<a href="/login">login</a>');
+  }
+});
+
+// Token for the audience configured at login. getAccessToken() returns the
+// cached token when it is still valid, or refreshes it when it has expired.
+app.get('/login-api', requiresAuth(), async (req, res, next) => {
+  try {
+    const { access_token, token_type } = await req.oidc.getAccessToken();
+    res.json({ audience: AUDIENCE_1, token_type, access_token });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Token for a different resource server. Passing `audience` exchanges the
+// session's refresh token for a token scoped to the second API (MRRT). This
+// requires a refresh token policy on the Auth0 application authorizing that
+// audience and the requested scopes.
+app.get('/mrrt-api', requiresAuth(), async (req, res, next) => {
+  try {
+    const { access_token, token_type } = await req.oidc.getAccessToken({
+      audience: AUDIENCE_2,
+      scope: SCOPE_2,
+    });
+    res.json({ audience: AUDIENCE_2, token_type, access_token });
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = app;

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,17 @@ interface Session {
    * hard expiry on every session read and before any token refresh.
    */
   sessionExpiresAt?: number;
+  /**
+   * Per-audience token cache used by {@link RequestContext.getAccessToken}.
+   * Populated automatically on the first `getAccessToken()` call. Pre-existing
+   * sessions without this field are migrated transparently — no re-login required.
+   */
+  tokenSets?: Array<{
+    audience: string;
+    access_token: string;
+    scope?: string;
+    expires_at?: number;
+  }>;
   [key: string]: any;
 }
 
@@ -413,6 +424,32 @@ interface RequestContext {
     result: SessionTransferTokenResult,
     opts?: SessionTransferRedirectOptions,
   ) => string;
+
+  /**
+   * Retrieves an access token from the session cache, or performs a refresh token
+   * grant (including Multi-Resource Refresh Token exchange) when the cached token
+   * is absent or expired.
+   *
+   * ```js
+   * // Default audience — equivalent to req.oidc.accessToken but async and cache-aware
+   * const { access_token } = await req.oidc.getAccessToken();
+   *
+   * // MRRT: exchange the session's refresh token for a different resource server
+   * const { access_token } = await req.oidc.getAccessToken({
+   *   audience: 'https://api-b.example.com',
+   *   scope: 'read:reports',
+   * });
+   * ```
+   *
+   * Tokens are cached per audience+scope in `session.tokenSets` and reused on
+   * subsequent calls until they expire.
+   *
+   * **Errors thrown:**
+   * - `Error` — user has no active session
+   * - `Error` — token is expired and no refresh token is available
+   * - `SessionExpiredError` — IdP session ceiling has been reached
+   */
+  getAccessToken(options?: GetAccessTokenOptions): Promise<AccessToken>;
 }
 
 /**
@@ -1215,6 +1252,25 @@ interface CookieConfigParams {
    * When setting to 'None' (uncommon), you should implement CSRF protection on your own routes
    */
   sameSite?: string;
+}
+
+/**
+ * Options for {@link RequestContext.getAccessToken}.
+ */
+interface GetAccessTokenOptions {
+  /**
+   * The audience (resource server identifier) to request an access token for.
+   * When different from the audience used at login, the SDK performs a
+   * Multi-Resource Refresh Token (MRRT) exchange using the session's refresh token.
+   * If omitted, falls back to `authorizationParams.audience` or the default audience.
+   */
+  audience?: string;
+
+  /**
+   * Space-separated scopes to request.
+   * If omitted, falls back to `authorizationParams.scope`.
+   */
+  scope?: string;
 }
 
 interface AccessToken {

--- a/index.d.ts
+++ b/index.d.ts
@@ -449,7 +449,9 @@ interface RequestContext {
    * - `Error` — token is expired and no refresh token is available
    * - `SessionExpiredError` — IdP session ceiling has been reached
    */
-  getAccessToken(options?: GetAccessTokenOptions): Promise<AccessToken>;
+  getAccessToken?: (
+    options?: GetAccessTokenOptions,
+  ) => Promise<GetAccessTokenResult>;
 }
 
 /**
@@ -1271,6 +1273,30 @@ interface GetAccessTokenOptions {
    * If omitted, falls back to `authorizationParams.scope`.
    */
   scope?: string;
+}
+
+/**
+ * The access token returned by {@link RequestContext.getAccessToken}.
+ *
+ * Unlike {@link AccessToken}, this has no `isExpired()` or `refresh()` methods:
+ * `getAccessToken()` is itself cache- and refresh-aware, so callers get a valid
+ * token by calling it again rather than refreshing the returned value manually.
+ */
+interface GetAccessTokenResult {
+  /**
+   * The access token itself, can be an opaque string, JWT, or non-JWT token.
+   */
+  access_token: string;
+
+  /**
+   * The type of access token, Usually "Bearer".
+   */
+  token_type: string;
+
+  /**
+   * Number of seconds until the access token expires.
+   */
+  expires_in: number;
 }
 
 interface AccessToken {

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,13 @@ interface Session {
    */
   sessionExpiresAt?: number;
   /**
+   * The audience the session's access token was minted for, recorded at login
+   * (respects a per-login `authorizationParams.audience` override). Used by
+   * {@link RequestContext.getAccessToken} to label the token correctly in its
+   * per-audience cache.
+   */
+  audience?: string;
+  /**
    * Per-audience token cache used by {@link RequestContext.getAccessToken}.
    * Populated automatically on the first `getAccessToken()` call. Pre-existing
    * sessions without this field are migrated transparently — no re-login required.

--- a/lib/context.js
+++ b/lib/context.js
@@ -41,6 +41,8 @@ const {
   isIdTokenExpired,
 } = require('./utils/sessionExpiry');
 const { extractOidcError } = require('./utils/oidcError');
+const compareScopes = require('./utils/compareScopes');
+const { getOrInitTokenSets, updateTokenSets } = require('./utils/tokenSets');
 
 // Caches one RemoteJWKSet instance per auth() configuration for backchannel logout token verification.
 const jwksClientCache = new Map();
@@ -679,6 +681,104 @@ class RequestContext {
     }
 
     return redirectUrl.toString();
+  }
+
+  async getAccessToken(options = {}) {
+    const { config, req } = weakRef(this);
+    const session = req[config.session.name];
+
+    if (!session || !('id_token' in session)) {
+      throw new Error('The user does not have an active session.');
+    }
+
+    if (isSessionExpiryReached(session.sessionExpiresAt)) {
+      throw new SessionExpiredError();
+    }
+
+    const requestedAudience =
+      options.audience ?? config.authorizationParams?.audience;
+    const audience = requestedAudience ?? 'default';
+    const scope = options.scope ?? config.authorizationParams?.scope;
+
+    // Hydrate tokenSets from flat session fields for pre-MRRT sessions.
+    if (!session.tokenSets) {
+      session.tokenSets = getOrInitTokenSets(session, audience);
+    }
+
+    // Cache hit: valid, non-expired token for this audience+scope.
+    // When ts.scope is undefined (hydrated from a pre-MRRT flat session) we
+    // treat it as a match — we don't know what scopes that token has, so we
+    // let it through and let Auth0 enforce scope constraints.
+    const cached = session.tokenSets.find(
+      (ts) =>
+        ts.audience === audience &&
+        (ts.scope === undefined || !scope || compareScopes(ts.scope, scope)),
+    );
+    if (cached && cached.expires_at > Math.floor(Date.now() / 1000)) {
+      const cachedExpiresIn = cached.expires_at - Math.floor(Date.now() / 1000);
+      return {
+        access_token: cached.access_token,
+        token_type: session.token_type || 'Bearer',
+        expires_in: cachedExpiresIn > 0 ? cachedExpiresIn : 0,
+        isExpired: isExpired.bind(this),
+        refresh: refresh.bind(this),
+      };
+    }
+
+    if (!session.refresh_token) {
+      throw new Error(
+        'The access token has expired and a refresh token was not found in the session. The user needs to re-authenticate.',
+      );
+    }
+
+    debug(
+      'getAccessToken() cache miss for audience=%s, exchanging refresh token',
+      audience,
+    );
+
+    const { configuration } = await getClient(config);
+    const parameters = {
+      ...(requestedAudience && { audience: requestedAudience }),
+      ...(scope && { scope }),
+      ...config.tokenEndpointParams,
+    };
+
+    const newTokenSet = await oidcClient.refreshTokenGrant(
+      configuration,
+      session.refresh_token,
+      Object.keys(parameters).length ? parameters : undefined,
+    );
+
+    // Update the per-audience token cache.
+    session.tokenSets = updateTokenSets(
+      session.tokenSets,
+      audience,
+      newTokenSet,
+    );
+    // Preserve rotated refresh token.
+    session.refresh_token = newTokenSet.refresh_token || session.refresh_token;
+
+    // Keep flat fields in sync when refreshing the config/default audience
+    // so req.oidc.accessToken continues to reflect the latest token.
+    const configAudience = config.authorizationParams?.audience ?? 'default';
+    if (audience === configAudience) {
+      session.access_token = newTokenSet.access_token;
+      session.token_type = normalizeTokenType(newTokenSet.token_type);
+      session.expires_at = newTokenSet.expires_in
+        ? epoch() + newTokenSet.expires_in
+        : undefined;
+      // Invalidate the internal TokenSet wrapper so accessToken re-reads from session.
+      const cachedTokenSet = weakRef(session);
+      delete cachedTokenSet.value;
+    }
+
+    return {
+      access_token: newTokenSet.access_token,
+      token_type: normalizeTokenType(newTokenSet.token_type),
+      expires_in: newTokenSet.expires_in ?? 0,
+      isExpired: isExpired.bind(this),
+      refresh: refresh.bind(this),
+    };
   }
 }
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -720,8 +720,6 @@ class RequestContext {
         access_token: cached.access_token,
         token_type: session.token_type || 'Bearer',
         expires_in: cachedExpiresIn > 0 ? cachedExpiresIn : 0,
-        isExpired: isExpired.bind(this),
-        refresh: refresh.bind(this),
       };
     }
 
@@ -776,8 +774,6 @@ class RequestContext {
       access_token: newTokenSet.access_token,
       token_type: normalizeTokenType(newTokenSet.token_type),
       expires_in: newTokenSet.expires_in ?? 0,
-      isExpired: isExpired.bind(this),
-      refresh: refresh.bind(this),
     };
   }
 }

--- a/lib/context.js
+++ b/lib/context.js
@@ -702,7 +702,10 @@ class RequestContext {
 
     // Hydrate tokenSets from flat session fields for pre-MRRT sessions.
     if (!session.tokenSets) {
-      session.tokenSets = getOrInitTokenSets(session, audience);
+      session.tokenSets = getOrInitTokenSets(
+        session,
+        config.authorizationParams?.audience ?? 'default',
+      );
     }
 
     // Cache hit: valid, non-expired token for this audience+scope.
@@ -859,6 +862,11 @@ class ResponseContext {
               max_age: options.authorizationParams.max_age,
             }
           : undefined),
+        // Carry the audience this login actually requested (override-aware) so
+        // the callback can record which audience the resulting tokens belong to.
+        ...(options.authorizationParams.audience
+          ? { audience: options.authorizationParams.audience }
+          : undefined),
       };
 
       let authParams = {
@@ -990,6 +998,7 @@ class ResponseContext {
 
       let tokenResponse;
       let claims;
+      let loginAudience;
       try {
         const authVerification = await transient.getOnce(
           config.transactionCookie.name,
@@ -1032,6 +1041,8 @@ class ResponseContext {
         }
 
         const checks = JSON.parse(authVerification);
+
+        loginAudience = checks.audience;
 
         req.openidState = decodeState(checks.state);
 
@@ -1183,6 +1194,8 @@ class ResponseContext {
         expires_at: tokenResponse.expires_in
           ? epoch() + tokenResponse.expires_in
           : undefined,
+        // Record the audience the access token was minted for (override-aware).
+        ...(loginAudience ? { audience: loginAudience } : undefined),
       };
 
       // Warn if mTLS is enabled but the access token is not certificate-bound.

--- a/lib/utils/compareScopes.js
+++ b/lib/utils/compareScopes.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Returns true if cachedScope contains every scope token in requestedScope.
  * Used to determine whether a cached token satisfies a narrower scope request.

--- a/lib/utils/compareScopes.js
+++ b/lib/utils/compareScopes.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/**
+ * Returns true if cachedScope contains every scope token in requestedScope.
+ * Used to determine whether a cached token satisfies a narrower scope request.
+ *
+ * @param {string|undefined} cachedScope - space-separated scopes on the cached token
+ * @param {string|undefined} requestedScope - space-separated scopes being requested
+ * @returns {boolean}
+ */
+function compareScopes(cachedScope, requestedScope) {
+  if (cachedScope === requestedScope) return true;
+  if (!cachedScope || !requestedScope) return false;
+
+  const cached = new Set(cachedScope.trim().split(/\s+/).filter(Boolean));
+  const requested = requestedScope.trim().split(/\s+/).filter(Boolean);
+  return requested.every((s) => cached.has(s));
+}
+
+module.exports = compareScopes;

--- a/lib/utils/tokenSets.js
+++ b/lib/utils/tokenSets.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { epoch } = require('./epoch');
+
+/**
+ * Initialises the tokenSets array from an existing flat session.
+ * Called once when an old session (pre-MRRT) is encountered so the new
+ * cache structure is bootstrapped without requiring a fresh token exchange.
+ *
+ * @param {object} session - the raw session object
+ * @param {string} audience - the synthetic audience key ('default' or real audience)
+ * @returns {Array}
+ */
+function getOrInitTokenSets(session, audience) {
+  if (session.tokenSets) return session.tokenSets;
+
+  if (session.access_token) {
+    return [
+      {
+        audience,
+        access_token: session.access_token,
+        scope: undefined,
+        expires_at: session.expires_at,
+      },
+    ];
+  }
+
+  return [];
+}
+
+/**
+ * Merges a newly-fetched token into the tokenSets array.
+ * Replaces an existing entry for the same audience+scope, or appends a new one.
+ *
+ * @param {Array} tokenSets - existing tokenSets from session
+ * @param {string} audience - audience key for the new token
+ * @param {object} tokenResponse - raw token endpoint response from openid-client
+ * @returns {Array} updated tokenSets (new array reference)
+ */
+function updateTokenSets(tokenSets, audience, tokenResponse) {
+  const scope = tokenResponse.scope;
+  const entry = {
+    audience,
+    access_token: tokenResponse.access_token,
+    scope,
+    expires_at: tokenResponse.expires_in
+      ? epoch() + tokenResponse.expires_in
+      : undefined,
+  };
+
+  const idx = tokenSets.findIndex(
+    (ts) => ts.audience === audience && ts.scope === scope,
+  );
+
+  if (idx === -1) {
+    return [...tokenSets, entry];
+  }
+
+  const updated = [...tokenSets];
+  updated[idx] = entry;
+  return updated;
+}
+
+module.exports = { getOrInitTokenSets, updateTokenSets };

--- a/lib/utils/tokenSets.js
+++ b/lib/utils/tokenSets.js
@@ -5,17 +5,22 @@ const { epoch } = require('./epoch');
  * Called once when an old session (pre-MRRT) is encountered so the new
  * cache structure is bootstrapped without requiring a fresh token exchange.
  *
+ * The hydrated token is labelled with the audience it was actually minted for:
+ * `session.audience` (recorded at login, override-aware) when present, otherwise
+ * the `fallbackAudience` (config audience, or 'default' when none is configured)
+ * for sessions created before `session.audience` was persisted.
+ *
  * @param {object} session - the raw session object
- * @param {string} audience - the synthetic audience key ('default' or real audience)
+ * @param {string} fallbackAudience - synthetic key used when session.audience is absent
  * @returns {Array}
  */
-function getOrInitTokenSets(session, audience) {
+function getOrInitTokenSets(session, fallbackAudience) {
   if (session.tokenSets) return session.tokenSets;
 
   if (session.access_token) {
     return [
       {
-        audience,
+        audience: session.audience ?? fallbackAudience,
         access_token: session.access_token,
         scope: undefined,
         expires_at: session.expires_at,

--- a/lib/utils/tokenSets.js
+++ b/lib/utils/tokenSets.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const { epoch } = require('./epoch');
 
 /**

--- a/test/getAccessToken.tests.js
+++ b/test/getAccessToken.tests.js
@@ -1,0 +1,611 @@
+'use strict';
+
+const assert = require('chai').assert;
+const sinon = require('sinon');
+const request = require('request-promise-native').defaults({
+  simple: false,
+  resolveWithFullResponse: true,
+});
+const nock = require('nock');
+
+const { auth } = require('..');
+const { create: createServer } = require('./fixture/server');
+const { makeIdToken } = require('./fixture/cert');
+const { epoch } = require('../lib/utils/epoch');
+
+const baseUrl = 'http://localhost:3000';
+
+const defaultConfig = {
+  secret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  baseURL: 'http://example.org',
+  issuerBaseURL: 'https://op.example.com',
+  authRequired: false,
+  clientSecret: '__test_client_secret__',
+  authorizationParams: {
+    response_type: 'code',
+    audience: 'https://api.example.com/',
+    scope: 'openid profile offline_access',
+  },
+};
+
+/**
+ * Boots a server with the given router and an optional route handler.
+ * Returns the server. Each test seeds its own session via POST /session.
+ */
+const setup = async ({
+  authConfig = {},
+  routeHandler,
+  routePath = '/get-token',
+} = {}) => {
+  const authOpts = { ...defaultConfig, ...authConfig };
+  const router = auth(authOpts);
+
+  if (routeHandler) {
+    router.get(routePath, routeHandler);
+  }
+
+  return createServer(router);
+};
+
+describe('req.oidc.getAccessToken()', () => {
+  let server;
+
+  afterEach(() => {
+    if (server) {
+      server.close();
+      server = null;
+    }
+    nock.cleanAll();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 1. Cache hit — default audience, valid token
+  // ---------------------------------------------------------------------------
+  it('returns cached token when not expired (no audience option)', async () => {
+    const futureExp = epoch() + 3600;
+    const idToken = makeIdToken();
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        const result = await req.oidc.getAccessToken();
+        res.json({
+          access_token: result.access_token,
+          token_type: result.token_type,
+          expires_in: result.expires_in,
+        });
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__cached_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: futureExp,
+        tokenSets: [
+          {
+            audience: 'https://api.example.com/',
+            access_token: '__cached_access_token__',
+            scope: 'openid profile offline_access',
+            expires_at: futureExp,
+          },
+        ],
+      },
+    });
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+
+    assert.equal(result.access_token, '__cached_access_token__');
+    assert.equal(result.token_type, 'Bearer');
+    assert.isNumber(result.expires_in);
+    assert.isTrue(result.expires_in > 0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 2. Expired default token → refresh
+  // ---------------------------------------------------------------------------
+  it('refreshes an expired default-audience token and updates the session', async () => {
+    const idToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+    const pastExp = epoch() - 60;
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        const result = await req.oidc.getAccessToken();
+        res.json({ access_token: result.access_token });
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__old_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: pastExp,
+      },
+    });
+
+    const spy = sinon.spy(() => ({
+      access_token: '__refreshed_access_token__',
+      refresh_token: '__new_refresh_token__',
+      token_type: 'Bearer',
+      expires_in: 86400,
+      scope: 'openid profile offline_access',
+    }));
+    const {
+      interceptors: [interceptor],
+    } = nock('https://op.example.com', {
+      allowUnmocked: true,
+    })
+      .post('/oauth/token')
+      .reply(200, spy);
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+
+    nock.removeInterceptor(interceptor);
+
+    sinon.assert.calledOnce(spy);
+    assert.equal(result.access_token, '__refreshed_access_token__');
+
+    const [, reqBody] = spy.firstCall.args;
+    assert.match(reqBody, /grant_type=refresh_token/);
+    assert.match(reqBody, /refresh_token=__test_refresh_token__/);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 3. Cache hit for explicit audience
+  // ---------------------------------------------------------------------------
+  it('returns cached token for an explicit audience without a token endpoint call', async () => {
+    const futureExp = epoch() + 3600;
+    const idToken = makeIdToken();
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        const result = await req.oidc.getAccessToken({
+          audience: 'https://api-b.example.com/',
+          scope: 'read:reports',
+        });
+        res.json({ access_token: result.access_token });
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__default_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: futureExp,
+        tokenSets: [
+          {
+            audience: 'https://api.example.com/',
+            access_token: '__default_access_token__',
+            scope: 'openid profile offline_access',
+            expires_at: futureExp,
+          },
+          {
+            audience: 'https://api-b.example.com/',
+            access_token: '__api_b_access_token__',
+            scope: 'read:reports',
+            expires_at: futureExp,
+          },
+        ],
+      },
+    });
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+
+    // Correct token returned — proves cache was used, no exchange needed
+    assert.equal(result.access_token, '__api_b_access_token__');
+  });
+
+  // ---------------------------------------------------------------------------
+  // 4. MRRT exchange — new audience not yet in tokenSets
+  // ---------------------------------------------------------------------------
+  it('exchanges the refresh token for a new audience (MRRT) and stores it in tokenSets', async () => {
+    const idToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+    const futureExp = epoch() + 3600;
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        const result = await req.oidc.getAccessToken({
+          audience: 'https://api-b.example.com/',
+          scope: 'read:reports',
+        });
+        res.json({ access_token: result.access_token });
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__default_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: futureExp,
+        tokenSets: [
+          {
+            audience: 'https://api.example.com/',
+            access_token: '__default_access_token__',
+            scope: 'openid profile offline_access',
+            expires_at: futureExp,
+          },
+        ],
+      },
+    });
+
+    const spy = sinon.spy(() => ({
+      access_token: '__api_b_access_token__',
+      refresh_token: '__new_refresh_token__',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: 'read:reports',
+    }));
+    const {
+      interceptors: [interceptor],
+    } = nock('https://op.example.com', {
+      allowUnmocked: true,
+    })
+      .post('/oauth/token')
+      .reply(200, spy);
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+    nock.removeInterceptor(interceptor);
+
+    sinon.assert.calledOnce(spy);
+    assert.equal(result.access_token, '__api_b_access_token__');
+
+    const [, reqBody] = spy.firstCall.args;
+    assert.match(reqBody, /audience=https%3A%2F%2Fapi-b\.example\.com%2F/);
+    assert.match(reqBody, /scope=read%3Areports/);
+
+    // New token must be cached in tokenSets
+    const session = await request
+      .get('/session', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+    const apiBEntry = session.tokenSets.find(
+      (ts) => ts.audience === 'https://api-b.example.com/',
+    );
+    assert.ok(apiBEntry, 'tokenSets should have an entry for api-b');
+    assert.equal(apiBEntry.access_token, '__api_b_access_token__');
+
+    // Flat fields for the config audience must be unchanged
+    assert.equal(session.access_token, '__default_access_token__');
+  });
+
+  // ---------------------------------------------------------------------------
+  // 5. Backward compat — old session with no tokenSets
+  // ---------------------------------------------------------------------------
+  it('silently hydrates tokenSets from flat session fields on first call (pre-MRRT session)', async () => {
+    const futureExp = epoch() + 3600;
+    const idToken = makeIdToken();
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        const result = await req.oidc.getAccessToken();
+        res.json({
+          access_token: result.access_token,
+          tokenSetsLength: req.appSession.tokenSets?.length,
+        });
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__legacy_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: futureExp,
+        // no tokenSets — simulates a pre-MRRT session
+      },
+    });
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+
+    assert.equal(result.access_token, '__legacy_access_token__');
+    assert.equal(result.tokenSetsLength, 1, 'tokenSets should be initialised');
+  });
+
+  // ---------------------------------------------------------------------------
+  // 6. Scope superset cache hit
+  // ---------------------------------------------------------------------------
+  it('returns cached token when requested scopes are a subset of cached scopes', async () => {
+    const futureExp = epoch() + 3600;
+    const idToken = makeIdToken();
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        // Request only 'read:reports' but cache has 'read:reports write:reports'
+        const result = await req.oidc.getAccessToken({
+          audience: 'https://api.example.com/',
+          scope: 'read:reports',
+        });
+        res.json({ access_token: result.access_token });
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__broad_scope_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: futureExp,
+        tokenSets: [
+          {
+            audience: 'https://api.example.com/',
+            access_token: '__broad_scope_token__',
+            scope: 'read:reports write:reports',
+            expires_at: futureExp,
+          },
+        ],
+      },
+    });
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+
+    // Correct token returned — proves cache was hit without a new exchange
+    assert.equal(result.access_token, '__broad_scope_token__');
+  });
+
+  // ---------------------------------------------------------------------------
+  // 7. No session → error
+  // ---------------------------------------------------------------------------
+  it('throws when the user has no active session', async () => {
+    server = await setup({
+      routeHandler: async (req, res) => {
+        try {
+          await req.oidc.getAccessToken();
+          res.json({ ok: true });
+        } catch (e) {
+          res.status(401).json({ message: e.message });
+        }
+      },
+    });
+
+    const jar = request.jar(); // fresh jar — no session seeded
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+
+    assert.match(result.message, /active session/i);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 8. Expired token + no refresh token → error
+  // ---------------------------------------------------------------------------
+  it('throws when the token is expired and no refresh token exists', async () => {
+    const idToken = makeIdToken();
+    const pastExp = epoch() - 60;
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        try {
+          await req.oidc.getAccessToken();
+          res.json({ ok: true });
+        } catch (e) {
+          res.status(400).json({ message: e.message });
+        }
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__expired_token__',
+        // no refresh_token
+        token_type: 'Bearer',
+        expires_at: pastExp,
+      },
+    });
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+
+    assert.match(result.message, /refresh token/i);
+  });
+
+  // ---------------------------------------------------------------------------
+  // 9. SessionExpiredError when sessionExpiresAt ceiling has passed
+  // ---------------------------------------------------------------------------
+  it('throws SessionExpiredError when the IdP session ceiling has been reached', async () => {
+    const idToken = makeIdToken();
+
+    // Seed the session ceiling directly in the route handler to avoid the
+    // appSession middleware rejecting the session before we can test it.
+    server = await setup({
+      routeHandler: async (req, res) => {
+        // Manually inject a past ceiling into the already-loaded session
+        req.appSession.sessionExpiresAt = epoch() - 60;
+        try {
+          await req.oidc.getAccessToken();
+          res.json({ ok: true });
+        } catch (e) {
+          res.status(401).json({ message: e.message, name: e.name });
+        }
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__test_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: epoch() + 3600,
+      },
+    });
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+
+    assert.equal(result.name, 'SessionExpiredError');
+  });
+
+  // ---------------------------------------------------------------------------
+  // 10. sessionExpiresAt is preserved after MRRT exchange
+  // ---------------------------------------------------------------------------
+  it('preserves sessionExpiresAt after an MRRT token exchange', async () => {
+    const idToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+    const futureExp = epoch() + 3600;
+    const sessionCeiling = epoch() + 7200;
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        await req.oidc.getAccessToken({
+          audience: 'https://api-b.example.com/',
+          scope: 'read:reports',
+        });
+        res.json({ sessionExpiresAt: req.appSession.sessionExpiresAt });
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__default_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: futureExp,
+        sessionExpiresAt: sessionCeiling,
+        tokenSets: [
+          {
+            audience: 'https://api.example.com/',
+            access_token: '__default_token__',
+            scope: 'openid profile offline_access',
+            expires_at: futureExp,
+          },
+        ],
+      },
+    });
+
+    const {
+      interceptors: [interceptor],
+    } = nock('https://op.example.com', {
+      allowUnmocked: true,
+    })
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: '__api_b_token__',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'read:reports',
+      });
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+    nock.removeInterceptor(interceptor);
+
+    assert.equal(
+      result.sessionExpiresAt,
+      sessionCeiling,
+      'sessionExpiresAt must be preserved across MRRT exchange',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // 11. Flat access_token kept in sync after refreshing the config audience
+  // ---------------------------------------------------------------------------
+  it('keeps flat access_token in sync when refreshing the config audience', async () => {
+    const idToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+    const pastExp = epoch() - 60;
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        await req.oidc.getAccessToken();
+        res.json({
+          flatAccessToken: req.appSession.access_token,
+          legacyAccessToken: req.oidc.accessToken?.access_token,
+        });
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__old_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: pastExp,
+      },
+    });
+
+    const {
+      interceptors: [interceptor],
+    } = nock('https://op.example.com', {
+      allowUnmocked: true,
+    })
+      .post('/oauth/token')
+      .reply(200, {
+        access_token: '__refreshed_access_token__',
+        refresh_token: '__new_refresh_token__',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'openid profile offline_access',
+      });
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+    nock.removeInterceptor(interceptor);
+
+    assert.equal(
+      result.flatAccessToken,
+      '__refreshed_access_token__',
+      'flat access_token should be updated in session',
+    );
+    assert.equal(
+      result.legacyAccessToken,
+      '__refreshed_access_token__',
+      'req.oidc.accessToken should reflect the new token',
+    );
+  });
+});

--- a/test/getAccessToken.tests.js
+++ b/test/getAccessToken.tests.js
@@ -335,6 +335,79 @@ describe('req.oidc.getAccessToken()', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // 5b. Pre-MRRT session, first call requests a NON-config audience. The
+  // hydrated login token must be labelled with the login audience, not the
+  // requested one, so a real MRRT exchange happens instead of a false cache hit.
+  // ---------------------------------------------------------------------------
+  it('does not mislabel the hydrated login token when the first call requests a different audience', async () => {
+    const idToken = makeIdToken({ c_hash: '77QmUPtjPfzWtF2AnpK9RQ' });
+    const futureExp = epoch() + 3600;
+
+    server = await setup({
+      routeHandler: async (req, res) => {
+        const result = await req.oidc.getAccessToken({
+          audience: 'https://api-b.example.com/',
+          scope: 'read:reports',
+        });
+        res.json({ access_token: result.access_token });
+      },
+    });
+
+    const jar = request.jar();
+    await request.post('/session', {
+      baseUrl,
+      jar,
+      json: {
+        id_token: idToken,
+        access_token: '__login_access_token__',
+        refresh_token: '__test_refresh_token__',
+        token_type: 'Bearer',
+        expires_at: futureExp,
+        // no tokenSets — pre-MRRT session; login audience is the config
+        // audience https://api.example.com/
+      },
+    });
+
+    const spy = sinon.spy(() => ({
+      access_token: '__api_b_access_token__',
+      refresh_token: '__new_refresh_token__',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: 'read:reports',
+    }));
+    const {
+      interceptors: [interceptor],
+    } = nock('https://op.example.com', {
+      allowUnmocked: true,
+    })
+      .post('/oauth/token')
+      .reply(200, spy);
+
+    const result = await request
+      .get('/get-token', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+    nock.removeInterceptor(interceptor);
+
+    // An exchange MUST happen — the login token belongs to api.example.com,
+    // not api-b. Returning the login token would be the mislabelling bug.
+    sinon.assert.calledOnce(spy);
+    assert.equal(result.access_token, '__api_b_access_token__');
+
+    // The hydrated login token must be cached under the config audience.
+    const session = await request
+      .get('/session', { baseUrl, jar, json: true })
+      .then((r) => r.body);
+    const loginEntry = session.tokenSets.find(
+      (ts) => ts.audience === 'https://api.example.com/',
+    );
+    assert.ok(
+      loginEntry,
+      'hydrated token should be cached under the login audience',
+    );
+    assert.equal(loginEntry.access_token, '__login_access_token__');
+  });
+
+  // ---------------------------------------------------------------------------
   // 6. Scope superset cache hit
   // ---------------------------------------------------------------------------
   it('returns cached token when requested scopes are a subset of cached scopes', async () => {


### PR DESCRIPTION
## Summary

- Adds `req.oidc.getAccessToken(options?)` to `RequestContext` for async, audience-aware access token retrieval.
- Tokens are cached per audience+scope in `session.tokenSets` and reused until they expire; a refresh token grant is performed automatically on a cache miss.
- Passing a different `audience` than the one used at login triggers a refresh token exchange for that resource server, enabling multi-resource refresh token (MRRT) flows.
- Existing sessions without `tokenSets` are transparently migrated on the first call — no re-login required.
- Returns a dedicated `GetAccessTokenResult` (`{ access_token, token_type, expires_in }`) rather than the `AccessToken` shape used by the synchronous `req.oidc.accessToken` getter (see [TypeScript](#typescript)).
- Records the audience the session's tokens were minted for in a new optional `session.audience` field, so the per-audience cache labels the login token correctly (see [Recording the login audience](#recording-the-login-audience)).

## New files

| File | Purpose |
|------|---------|
| `lib/utils/tokenSets.js` | `getOrInitTokenSets` / `updateTokenSets` — manage the per-audience token cache |
| `lib/utils/compareScopes.js` | Returns `true` when cached scopes are a superset of requested scopes |
| `test/getAccessToken.tests.js` | Tests covering all major paths |
| `examples/mrrt.js` | Runnable example — login-audience token and a cross-audience MRRT exchange |

## TypeScript

- `GetAccessTokenOptions` interface added to `index.d.ts`.
- `GetAccessTokenResult` interface added — the return type of `getAccessToken()`, with just `access_token`, `token_type`, and `expires_in`.
- `getAccessToken?()` is optional on `RequestContext`, matching the other recently-added methods (`customTokenExchange?`, `requestSessionTransferToken?`, `buildSessionTransferRedirect?`).
- `Session.tokenSets` and `Session.audience` fields typed in `index.d.ts`.

### Why not reuse the existing `AccessToken` interface?

`req.oidc.accessToken` returns an `AccessToken` (`{ access_token, token_type, expires_in, isExpired(), refresh() }`). Those two methods exist because the synchronous getter is a static snapshot — it hands you whatever token is currently in the session and lets you check/renew it yourself.

`getAccessToken()` does that work for you: it is cache- and refresh-aware, returning a cached token when valid or transparently exchanging the refresh token otherwise. So `isExpired()`/`refresh()` are redundant — a fresh token is obtained by calling `getAccessToken()` again.

They would also be **misleading for MRRT**: both are implemented against the session's flat fields (the default/config audience) via the internal `tokenSet()` helper and do not read `session.tokenSets[]`. On a result returned for a non-default audience the data fields are correct, but `isExpired()`/`refresh()` would report/refresh the *default* audience's token. Returning a dedicated `GetAccessTokenResult` avoids shipping methods that silently operate on the wrong audience. The `AccessToken` interface and the synchronous getter are unchanged.

### Recording the login audience

The per-audience cache keys tokens by audience, but the original login token — stored in the flat session fields — carries no audience of its own. Labelling the hydrated login token by the audience the *first* `getAccessToken()` call happens to request causes a false cache hit (the login token is returned under the wrong audience instead of triggering an exchange).

To fix this, the audience actually sent to `/authorize` at login is now persisted in a new optional `session.audience` field (override-aware — correct whether the audience came from config or a per-login `authorizationParams.audience` override). Hydration labels the flat token with `session.audience`, falling back to `config.authorizationParams.audience` (or `'default'`) for sessions created before the field existed. The field is optional and additive — no breaking change and no forced re-login.

## Docs

- Added a "Multi-Resource Refresh Tokens (MRRT)" section to `EXAMPLES.md` covering setup, default token retrieval, MRRT exchange, downscoping, and error handling.
- Added a runnable example at `examples/mrrt.js` (`npm run start:example -- mrrt`).

## Test plan

- [ ] `npm test` passes (448 tests, 0 failures)
- [ ] Cache hit — valid non-expired token returned without a token endpoint call
- [ ] Expired default-audience token — refresh grant called, session updated
- [ ] Explicit audience cache hit — correct token returned, no exchange
- [ ] MRRT exchange — new audience not yet cached triggers refresh grant with `audience` param; result stored in `tokenSets`
- [ ] Scope superset match — cached token with broader scopes satisfies a narrower request
- [ ] Legacy session — pre-MRRT flat session hydrated transparently on first call
- [ ] Legacy session — first call for a non-login audience performs a real exchange (login token is not mislabelled)
- [ ] No session — throws `Error` with "active session"
- [ ] Expired token, no refresh token — throws `Error` with "refresh token"
- [ ] IdP session ceiling reached — throws `SessionExpiredError`
- [ ] `sessionExpiresAt` preserved after MRRT exchange
- [ ] Flat `access_token` kept in sync when refreshing the config audience

### Manual testing

Verified end-to-end against a real Auth0 tenant with two APIs and a refresh token policy authorizing the second audience:

- [ ] Logged in via the Authorization Code flow requesting the first API's audience with `offline_access`.
- [ ] Called `getAccessToken()` (no arguments) — returned an access token whose `aud` is the first API and whose scopes match those requested at login.
- [ ] Called `getAccessToken({ audience, scope })` for the second API — a refresh token exchange returned an access token whose `aud` is the second API and whose scopes match the policy-authorized scopes, for the same logged-in user, with no re-login.
- [ ] Confirmed the two access tokens carry different `aud` claims, proving a single session's refresh token was exchanged across resource servers.
