### PR TITLE
feat: Anonymous Sessions support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -16,6 +16,7 @@
 14. [Use a proxy for OIDC requests](#14-use-a-proxy-for-oidc-requests)
 15. [Session expiry from upstream IdP (IPSIE `session_expiry`)](#15-session-expiry-from-upstream-idp-ipsie-session_expiry)
 16. [JWT-Secured Authorization Requests (JAR)](#16-jwt-secured-authorization-requests-jar)
+17. [Anonymous Sessions](#17-anonymous-sessions)
 
 ## 1. Basic setup
 
@@ -713,3 +714,96 @@ openssl ec -in request-object-key.pem -pubout -out request-object-key.pub.pem
 ```
 
 Full example at [jar.js](./examples/jar.js), to run it: `npm run start:example -- jar`
+
+## 17. Anonymous Sessions
+
+[Anonymous Sessions](https://auth0.com/docs) give a visitor an Auth0 identity (`anon@<uuid>`) **before they log in**, so pre-login activity — a guest cart, consent, analytics context — can be carried into their account when they authenticate. The feature is opt-in and off by default; enable it with `anonymousSession.enabled`.
+
+```js
+app.use(
+  auth({
+    authRequired: false,
+    anonymousSession: {
+      enabled: true,
+      // All cookie options are optional and mirror the session cookie defaults.
+      // cookie: {
+      //   name: 'auth0_anon', // default
+      //   sameSite: 'Lax',    // inherits session.cookie.sameSite
+      //   secure: true,       // inferred from an https baseURL
+      //   httpOnly: true,
+      //   path: '/',
+      //   domain: undefined,
+      // },
+    },
+  }),
+);
+```
+
+Once enabled, every request gets a `req.anonymousSession` context:
+
+```js
+req.anonymousSession.isAnonymous; // true when a valid anonymous session cookie is present
+req.anonymousSession.token; // the opaque anonymous session token, or null
+
+// Create a new anonymous session. The audience and scope are fixed for the
+// lifetime of the session; up to 1KB of metadata may be set once, at creation.
+const { access_token } = await req.anonymousSession.start({
+  audience: 'https://api.example.com/cart',
+  scope: 'read:cart write:cart',
+  metadata: { cart_id: 'cart_123' },
+});
+
+// Get a valid access token for the session's audience. Returns the cached token
+// while it is valid and silently renews it (or transparently creates a new
+// session if the anonymous session itself has expired) when it is not.
+const { access_token } = await req.anonymousSession.getAccessToken();
+
+// End the anonymous session and clear its cookie.
+await req.anonymousSession.end();
+```
+
+Use the access token to call your API — `getAccessToken()` handles caching and renewal for you:
+
+```js
+app.get('/cart', async (req, res) => {
+  const { access_token } = await req.anonymousSession.getAccessToken();
+  const cart = await fetch('https://api.example.com/cart', {
+    headers: { Authorization: `Bearer ${access_token}` },
+  });
+  res.json(await cart.json());
+});
+```
+
+When the visitor logs in, the anonymous session token is automatically added to the `/authorize` request — you call `res.oidc.login()` exactly as usual, and Auth0 delivers the anonymous session data to your Post Login and Pre User Registration [Actions](https://auth0.com/docs/customize/actions) via `event.anonymous_session`. Nothing is migrated automatically; your Action code decides what to persist.
+
+The anonymous session is **not** cleared automatically on login — call `req.anonymousSession.end()` explicitly when you want to end it.
+
+A few things to note:
+
+- `getAccessToken()` throws an `AnonymousSessionError` if there is no active anonymous session; call `start()` first.
+- The `session_expired` and `invalid_session_token` cases are handled internally (a new session is created transparently, so any metadata is lost); every other failure is thrown as an `AnonymousSessionError` with a `.code` you can branch on.
+
+```js
+const { AnonymousSessionError } = require('express-openid-connect');
+
+app.get('/cart', async (req, res, next) => {
+  try {
+    const { access_token } = await req.anonymousSession.getAccessToken();
+    // ...
+  } catch (err) {
+    if (
+      err instanceof AnonymousSessionError &&
+      err.code === 'metadata_too_large'
+    ) {
+      // handle the specific error
+    }
+    return next(err);
+  }
+});
+```
+
+Anonymous state is completely independent of the authenticated session — it never affects `req.oidc.isAuthenticated()` or `req.oidc.user`.
+
+> Anonymous Sessions must be enabled for your tenant (a paid add-on) and for the client, and the target API must allow anonymous access. See the Auth0 documentation for the required Dashboard/Management API configuration.
+
+Full example at [anonymous-session.js](./examples/anonymous-session.js), to run it: `npm run start:example -- anonymous-session`

--- a/examples/anonymous-session.js
+++ b/examples/anonymous-session.js
@@ -1,0 +1,62 @@
+const express = require('express');
+const { auth } = require('../');
+
+const app = express();
+
+// Anonymous Sessions give a visitor an Auth0 identity before they log in.
+// Enable the feature and keep authRequired off so anonymous visitors can browse.
+app.use(
+  auth({
+    authRequired: false,
+    anonymousSession: {
+      enabled: true,
+    },
+  }),
+);
+
+// Landing page. Start an anonymous session on first visit (storing some
+// metadata, e.g. a cart id), then reuse it on subsequent visits.
+app.get('/', async (req, res, next) => {
+  try {
+    if (!req.anonymousSession.isAnonymous) {
+      await req.anonymousSession.start({
+        audience: 'https://api.example.com/cart',
+        scope: 'read:cart write:cart',
+        metadata: { cart_id: 'cart_123' },
+      });
+    }
+    res.send(
+      req.oidc.isAuthenticated()
+        ? `Logged in as ${req.oidc.user.sub}`
+        : 'Browsing anonymously — <a href="/login">log in</a> to keep your cart.',
+    );
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Call your API with the anonymous access token. getAccessToken() returns the
+// cached token while valid and silently renews it when it expires.
+app.get('/cart', async (req, res, next) => {
+  try {
+    const { access_token } = await req.anonymousSession.getAccessToken();
+    // await fetch('https://api.example.com/cart', {
+    //   headers: { Authorization: `Bearer ${access_token}` },
+    // });
+    res.json({ access_token });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// End the anonymous session explicitly (it is not cleared automatically on login).
+app.get('/end-anonymous', async (req, res, next) => {
+  try {
+    await req.anonymousSession.end();
+    res.redirect('/');
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = app;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1502,3 +1502,36 @@ export class SessionExpiredError extends Error {
   readonly statusCode: 401;
   constructor(message?: string);
 }
+
+/**
+ * Error thrown when an anonymous session operation
+ * ({@link AnonymousSession.start}, {@link AnonymousSession.getAccessToken})
+ * fails. The `code` field carries the Auth0 error code, e.g. `metadata_too_large`,
+ * `unauthorized_client`, `feature_not_enabled`, `invalid_client`, `invalid_target`,
+ * `invalid_scope`, or `server_error`.
+ *
+ * The `session_expired` and `invalid_session_token` codes are handled internally
+ * (a new session is created transparently) and never surface as this error.
+ *
+ * ```js
+ * const { AnonymousSessionError } = require('express-openid-connect');
+ *
+ * app.get('/cart', async (req, res, next) => {
+ *   try {
+ *     const { access_token } = await req.anonymousSession.getAccessToken();
+ *   } catch (err) {
+ *     if (err instanceof AnonymousSessionError) {
+ *       // inspect err.code
+ *     }
+ *     return next(err);
+ *   }
+ * });
+ * ```
+ */
+export class AnonymousSessionError extends Error {
+  readonly name: 'AnonymousSessionError';
+  readonly code: string;
+  readonly status?: number;
+  readonly statusCode?: number;
+  constructor(message: string, code: string, statusCode?: number);
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -91,6 +91,12 @@ interface OpenidRequest extends Request {
    * Library namespace for authentication methods and data.
    */
   oidc: RequestContext;
+
+  /**
+   * Anonymous session context, present when
+   * {@link AnonymousSessionConfigParams.enabled} is `true`.
+   */
+  anonymousSession?: AnonymousSession;
 }
 
 /**
@@ -416,6 +422,74 @@ interface RequestContext {
 }
 
 /**
+ * Options for {@link AnonymousSession.start}.
+ */
+interface AnonymousSessionStartOptions {
+  /**
+   * The audience (Resource Server identifier) to request an access token for.
+   * If omitted, the tenant's default audience is used. This audience is fixed
+   * for the lifetime of the anonymous session.
+   */
+  audience?: string;
+
+  /**
+   * A space-separated list of scopes to request for the access token.
+   */
+  scope?: string;
+
+  /**
+   * Up to 1KB of key-value metadata to store on the anonymous session at
+   * creation time. Set once — metadata cannot be changed after the session
+   * is created. Exceeding the size limit throws an error with code
+   * `metadata_too_large`.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * The anonymous session context attached to the Express request as
+ * `req.anonymousSession` when {@link AnonymousSessionConfigParams.enabled} is `true`.
+ *
+ * Anonymous state is completely independent of the authenticated session — it
+ * never affects {@link RequestContext.isAuthenticated} or {@link RequestContext.user}.
+ */
+interface AnonymousSession {
+  /**
+   * `true` when a valid `auth0_anon` cookie is present on the request.
+   */
+  isAnonymous: boolean;
+
+  /**
+   * The raw, opaque anonymous session token, or `null` when no anonymous
+   * session is active. This value is never sent to APIs — use
+   * {@link AnonymousSession.getAccessToken} to obtain a token for calling APIs.
+   */
+  token: string | null;
+
+  /**
+   * Returns a valid anonymous access token for the session's audience, minting
+   * or silently renewing one as needed. Returns the cached token when it is
+   * still valid; otherwise re-mints it using the stored session token. If the
+   * session token has expired, a brand-new anonymous session is created
+   * transparently (any previously-set metadata is lost).
+   */
+  getAccessToken: () => Promise<AccessToken>;
+
+  /**
+   * Creates a new anonymous session, setting the `auth0_anon` cookie on the
+   * response, and returns the resulting access token.
+   */
+  start: (options?: AnonymousSessionStartOptions) => Promise<AccessToken>;
+
+  /**
+   * Ends the anonymous session by calling `POST /anonymous/logout` and clearing
+   * the `auth0_anon` cookie. The anonymous session is not cleared automatically
+   * on login — call this explicitly to end it.
+   */
+  end: () => Promise<void>;
+}
+
+/**
  * The response authentication context found on the Express response when
  * OpenID Connect auth middleware is added to your application.
  *
@@ -477,6 +551,7 @@ declare global {
   namespace Express {
     interface Request {
       oidc: RequestContext;
+      anonymousSession?: AnonymousSession;
     }
 
     interface Response {
@@ -868,6 +943,14 @@ interface ConfigParams {
   transactionCookie?: Pick<CookieConfigParams, 'sameSite'> & { name?: string };
 
   /**
+   * Configuration for Anonymous Sessions, which give a visitor an Auth0 identity
+   * before they log in. Disabled by default; set `enabled: true` to opt in.
+   *
+   * When enabled, `req.anonymousSession` is attached to every request.
+   */
+  anonymousSession?: AnonymousSessionConfigParams;
+
+  /**
    * String value for the client's authentication method. Default is `none` when using response_type='id_token', `private_key_jwt` when using a `clientAssertionSigningKey`, otherwise `client_secret_basic`.
    */
   clientAuthMethod?: string;
@@ -1190,6 +1273,30 @@ interface CookieConfigParams {
    * When setting to 'None' (uncommon), you should implement CSRF protection on your own routes
    */
   sameSite?: string;
+}
+
+interface AnonymousSessionConfigParams {
+  /**
+   * Whether Anonymous Sessions are enabled. When `false` (the default),
+   * `req.anonymousSession` is not attached and no anonymous cookies are set.
+   */
+  enabled?: boolean;
+
+  /**
+   * Configuration for the `auth0_anon` cookie that stores the anonymous session token.
+   * Uses the same cookie attributes as the session cookie (except `transient`),
+   * plus a configurable `name` (default `auth0_anon`, letters/numbers/underscores only).
+   */
+  cookie?: Pick<
+    CookieConfigParams,
+    'domain' | 'path' | 'httpOnly' | 'secure' | 'sameSite'
+  > & { name?: string };
+
+  /**
+   * Optional session store, using the same interface as {@link SessionConfigParams.store}.
+   * Reserved for a future release; not used yet.
+   */
+  store?: SessionStore;
 }
 
 interface AccessToken {

--- a/index.js
+++ b/index.js
@@ -2,10 +2,12 @@ const auth = require('./middleware/auth');
 const requiresAuth = require('./middleware/requiresAuth');
 const attemptSilentLogin = require('./middleware/attemptSilentLogin');
 const { SessionExpiredError } = require('./lib/errors');
+const { AnonymousSessionError } = require('./lib/anonymousSession/errors');
 
 module.exports = {
   auth,
   ...requiresAuth,
   attemptSilentLogin,
   SessionExpiredError,
+  AnonymousSessionError,
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,3 +1,4 @@
+import { Request } from 'express';
 import { RequestHandler } from 'express';
 import { expectType } from 'tsd';
 import { auth } from '.';
@@ -15,3 +16,39 @@ expectType<RequestHandler>(
     requestObjectSigningKeyId: 'kid-1',
   }),
 );
+
+// Anonymous Sessions config
+expectType<RequestHandler>(auth({ anonymousSession: { enabled: true } }));
+expectType<RequestHandler>(
+  auth({
+    anonymousSession: {
+      enabled: true,
+      cookie: {
+        name: 'auth0_anon',
+        sameSite: 'Lax',
+        secure: true,
+        httpOnly: true,
+        path: '/',
+        domain: 'example.org',
+      },
+    },
+  }),
+);
+
+// Anonymous Sessions request context
+const req = {} as Request;
+expectType<boolean | undefined>(req.anonymousSession?.isAnonymous);
+expectType<string | null | undefined>(req.anonymousSession?.token);
+expectType<string | undefined>(
+  (await req.anonymousSession?.getAccessToken())?.access_token,
+);
+expectType<string | undefined>(
+  (
+    await req.anonymousSession?.start({
+      audience: 'https://api.example.com',
+      scope: 'read:cart',
+      metadata: { cart_id: 'cart_123' },
+    })
+  )?.access_token,
+);
+expectType<void | undefined>(await req.anonymousSession?.end());

--- a/lib/anonymousSession/client.js
+++ b/lib/anonymousSession/client.js
@@ -1,0 +1,105 @@
+const { get: getClient, createCustomFetch } = require('../client');
+const { AnonymousSessionError } = require('./errors');
+const debug = require('../debug')('anonymousSession');
+
+/**
+ * Builds the client-authentication additions for an anonymous session request.
+ *
+ * Returns the headers to merge and the body fields to merge. Confidential
+ * clients using `client_secret_basic` send an `Authorization: Basic` header;
+ * other clients send `client_id` (and `client_secret` when present) in the body.
+ *
+ * `private_key_jwt` and mTLS are not supported yet.
+ */
+function getClientAuth(config) {
+  const { clientID, clientSecret, clientAuthMethod } = config;
+
+  if (clientAuthMethod === 'client_secret_basic' && clientSecret) {
+    const credentials = Buffer.from(`${clientID}:${clientSecret}`).toString(
+      'base64',
+    );
+    return { headers: { Authorization: `Basic ${credentials}` }, body: {} };
+  }
+
+  const body = { client_id: clientID };
+  if (clientSecret) {
+    body.client_secret = clientSecret;
+  }
+  return { headers: {}, body };
+}
+
+async function postJson(config, path, payload) {
+  const { serverMetadata } = await getClient(config);
+  const url = new URL(path, serverMetadata.issuer);
+
+  const { headers: authHeaders, body: authBody } = getClientAuth(config);
+  const doFetch = createCustomFetch(config);
+
+  const response = await doFetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders,
+    },
+    body: JSON.stringify({ ...authBody, ...payload }),
+    signal: AbortSignal.timeout(config.httpTimeout),
+  });
+
+  let data;
+  try {
+    data = await response.json();
+  } catch {
+    data = {};
+  }
+
+  if (!response.ok) {
+    const code = data.error || 'server_error';
+    const message =
+      data.error_description || data.message || `Anonymous session ${code}`;
+    debug('%s failed: %d %s', path, response.status, code);
+    throw new AnonymousSessionError(message, code, response.status);
+  }
+
+  return data;
+}
+
+/**
+ * Calls `POST /anonymous/token` to create a new anonymous session or, when a
+ * `session_token` is supplied, to re-mint an access token for the existing one.
+ *
+ * @param {Object} config
+ * @param {Object} options
+ * @param {string} [options.session_token] Existing session token to renew from.
+ * @param {string} [options.audience] Resource Server identifier.
+ * @param {string} [options.scope] Space-separated scopes.
+ * @param {Object} [options.metadata] Session metadata (creation only).
+ * @returns {Promise<Object>} The parsed token response.
+ */
+async function requestToken(
+  config,
+  { session_token, audience, scope, metadata } = {},
+) {
+  const payload = {};
+  if (session_token !== undefined) payload.session_token = session_token;
+  if (audience !== undefined) payload.audience = audience;
+  if (scope !== undefined) payload.scope = scope;
+  // Metadata is only accepted on creation, never on renewal.
+  if (metadata !== undefined && session_token === undefined) {
+    payload.metadata = metadata;
+  }
+
+  return postJson(config, '/anonymous/token', payload);
+}
+
+/**
+ * Calls `POST /anonymous/logout` to end an anonymous session.
+ *
+ * @param {Object} config
+ * @param {string} session_token The session token to end.
+ * @returns {Promise<Object>}
+ */
+async function logout(config, session_token) {
+  return postJson(config, '/anonymous/logout', { session_token });
+}
+
+module.exports = { requestToken, logout };

--- a/lib/anonymousSession/context.js
+++ b/lib/anonymousSession/context.js
@@ -1,0 +1,172 @@
+const weakRef = require('../weakCache');
+const { requestToken, logout } = require('./client');
+const { AnonymousSessionError } = require('./errors');
+const { epoch } = require('../utils/epoch');
+const debug = require('../debug')('anonymousSession');
+
+const WRITE = 'write';
+const CLEAR = 'clear';
+
+// Session-token errors that must never surface to the developer; a fresh
+// anonymous session is created transparently instead (metadata is lost).
+const SILENT_CODES = ['session_expired', 'invalid_session_token'];
+
+/**
+ * Shapes the internal cookie state into the public access-token object.
+ * A plain token object — unlike `req.oidc.accessToken`, there is no `refresh()`
+ * (anonymous sessions have no refresh token; `getAccessToken()` renews itself).
+ */
+function toAccessToken(state) {
+  return {
+    access_token: state.access_token,
+    token_type: state.token_type,
+    expires_in: Math.max(0, state.expires_at - epoch()),
+    isExpired: () => state.expires_at <= epoch(),
+  };
+}
+
+/**
+ * Builds the cookie state from an `/anonymous/token` response.
+ *
+ * On renewal the response omits `session_token` (keep the previous one) and the
+ * anonymous session lifetime is not extended, so `session_expires_at` is
+ * preserved from the previous state (NFR1). A brand-new session (no `prev`)
+ * takes a fresh `session_expires_at` from the response.
+ */
+function stateFromResponse(response, { audience, scope }, prev) {
+  const now = epoch();
+  return {
+    session_token: response.session_token || prev?.session_token,
+    access_token: response.access_token,
+    token_type: response.token_type,
+    expires_at: now + response.expires_in,
+    session_expires_at:
+      prev?.session_expires_at ??
+      (response.session_expires_in
+        ? now + response.session_expires_in
+        : undefined),
+    audience,
+    scope,
+  };
+}
+
+/**
+ * The anonymous session context attached to the request as
+ * `req.anonymousSession` when `anonymousSession.enabled` is `true`.
+ *
+ * Reads are served from the decrypted cookie state loaded by the middleware.
+ * `start`, `getAccessToken`, and `end` mutate that state and mark the cookie
+ * dirty; the middleware persists it in an `onHeaders` hook (see `flush`), so no
+ * method here writes to the response directly.
+ */
+class RequestAnonymousContext {
+  constructor(config, state) {
+    Object.assign(weakRef(this), { config, state, pending: null });
+  }
+
+  get isAnonymous() {
+    const { state } = weakRef(this);
+    return !!(state && state.session_token);
+  }
+
+  get token() {
+    const { state } = weakRef(this);
+    return state?.session_token ?? null;
+  }
+
+  /**
+   * Creates a new anonymous session and returns its access token. The audience
+   * and scope are fixed for the lifetime of the session.
+   */
+  async start({ audience, scope, metadata } = {}) {
+    const ctx = weakRef(this);
+    const response = await requestToken(ctx.config, {
+      audience,
+      scope,
+      metadata,
+    });
+    ctx.state = stateFromResponse(response, { audience, scope });
+    ctx.pending = WRITE;
+    return toAccessToken(ctx.state);
+  }
+
+  /**
+   * Returns a valid access token for the session's audience. Returns the cached
+   * token when still valid, otherwise renews it. If the session token has
+   * expired, a new session is created transparently.
+   */
+  async getAccessToken() {
+    const ctx = weakRef(this);
+    if (!this.isAnonymous) {
+      throw new AnonymousSessionError(
+        'no active anonymous session',
+        'no_active_session',
+      );
+    }
+    if (ctx.state.expires_at > epoch()) {
+      return toAccessToken(ctx.state);
+    }
+    return renew.call(this);
+  }
+
+  /**
+   * Ends the anonymous session (`POST /anonymous/logout`) and clears the cookie.
+   */
+  async end() {
+    const ctx = weakRef(this);
+    if (ctx.state?.session_token) {
+      try {
+        await logout(ctx.config, ctx.state.session_token);
+      } catch (err) {
+        // Best-effort: the cookie is cleared regardless.
+        debug('logout failed: %s', err);
+      }
+    }
+    ctx.state = null;
+    ctx.pending = CLEAR;
+  }
+}
+
+/**
+ * Re-mints the access token from the stored session token. If the session token
+ * has expired or is invalid, silently creates a brand-new session instead.
+ */
+async function renew() {
+  const ctx = weakRef(this);
+  const { session_token, audience, scope } = ctx.state;
+
+  let response;
+  try {
+    response = await requestToken(ctx.config, {
+      session_token,
+      audience,
+      scope,
+    });
+    ctx.state = stateFromResponse(response, { audience, scope }, ctx.state);
+  } catch (err) {
+    if (!SILENT_CODES.includes(err.code)) {
+      throw err;
+    }
+    debug('session token %s, creating a new session', err.code);
+    response = await requestToken(ctx.config, { audience, scope });
+    ctx.state = stateFromResponse(response, { audience, scope });
+  }
+
+  ctx.pending = WRITE;
+  return toAccessToken(ctx.state);
+}
+
+/**
+ * Persists any pending cookie change to the response. Called by the middleware
+ * from an `onHeaders` hook, so `req`-side methods never touch `res` directly.
+ */
+function flush(anonymousSession, res, cookieHandler) {
+  const ctx = weakRef(anonymousSession);
+  if (ctx.pending === WRITE) {
+    cookieHandler.write(res, ctx.state);
+  } else if (ctx.pending === CLEAR) {
+    cookieHandler.clear(res);
+  }
+}
+
+module.exports = { RequestAnonymousContext, flush };

--- a/lib/anonymousSession/cookie.js
+++ b/lib/anonymousSession/cookie.js
@@ -1,0 +1,83 @@
+const { compactDecrypt } = require('jose');
+const cookie = require('cookie');
+const { getKeyStore, encryptSync } = require('../crypto');
+const COOKIES = require('../cookies');
+const debug = require('../debug')('anonymousSession');
+
+const ALG = 'dir';
+const ENC = 'A256GCM';
+
+/**
+ * Reads, writes, and clears the encrypted `auth0_anon` cookie that stores the
+ * anonymous session state (`{ session_token, access_token, token_type,
+ * expires_at, session_expires_at, audience, scope }`).
+ *
+ * The payload is encrypted with the app `secret` using the same JWE profile
+ * (dir / A256GCM) as the main session cookie, so only the server can read it.
+ * Only the `session_token` is ever forwarded to Auth0 (on `/authorize`); the
+ * access token never leaves the server except when the developer sends it to
+ * their own API.
+ */
+module.exports = (config) => {
+  const { name, ...cookieOptions } = config.anonymousSession.cookie;
+  const [current, keystore] = getKeyStore(config.secret, true);
+
+  async function decrypt(jwe) {
+    let lastError;
+    for (const key of keystore) {
+      try {
+        const { plaintext } = await compactDecrypt(jwe, key, {
+          contentEncryptionAlgorithms: [ENC],
+          keyManagementAlgorithms: [ALG],
+        });
+        return JSON.parse(new TextDecoder().decode(plaintext));
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    throw lastError;
+  }
+
+  return {
+    /**
+     * Reads and decrypts the anonymous session state from the request, or
+     * returns `null` when there is no cookie or it cannot be decrypted.
+     */
+    async read(req) {
+      const cookies = req[COOKIES] || cookie.parse(req.get('cookie') || '');
+      const raw = cookies[name];
+      if (!raw) {
+        return null;
+      }
+      try {
+        return await decrypt(raw);
+      } catch (err) {
+        debug('could not decrypt %s cookie: %s', name, err);
+        return null;
+      }
+    },
+
+    /**
+     * Encrypts and writes the anonymous session state to the response. The
+     * cookie expiry is driven by `session_expires_at` so that renewals never
+     * extend the lifetime of the anonymous session.
+     */
+    write(res, state) {
+      const value = encryptSync(JSON.stringify(state), current);
+      res.cookie(name, value, {
+        ...cookieOptions,
+        expires: state.session_expires_at
+          ? new Date(state.session_expires_at * 1000)
+          : undefined,
+      });
+    },
+
+    /**
+     * Clears the anonymous session cookie from the response.
+     */
+    clear(res) {
+      const { domain, path, sameSite, secure } = cookieOptions;
+      res.clearCookie(name, { domain, path, sameSite, secure });
+    },
+  };
+};

--- a/lib/anonymousSession/errors.js
+++ b/lib/anonymousSession/errors.js
@@ -1,0 +1,24 @@
+/**
+ * Error thrown when an anonymous session operation fails.
+ *
+ * The `code` field carries the Auth0 error code returned by the
+ * `/anonymous/token` and `/anonymous/logout` endpoints, e.g. `metadata_too_large`,
+ * `unauthorized_client`, `feature_not_enabled`, `invalid_client`, `invalid_target`,
+ * `invalid_scope`, or `server_error`.
+ *
+ * The `session_expired` and `invalid_session_token` codes are handled internally
+ * (a new session is created transparently) and are never surfaced as this error.
+ */
+class AnonymousSessionError extends Error {
+  constructor(message, code, statusCode) {
+    super(message);
+    this.name = 'AnonymousSessionError';
+    this.code = code;
+    if (statusCode !== undefined) {
+      this.status = statusCode;
+      this.statusCode = statusCode;
+    }
+  }
+}
+
+module.exports = { AnonymousSessionError };

--- a/lib/client.js
+++ b/lib/client.js
@@ -334,5 +334,7 @@ exports.get = (config) => {
 
 exports.buildEndSessionUrl = buildEndSessionUrl;
 
+exports.createCustomFetch = createCustomFetch;
+
 // Re-export client module for access to functions
 exports.client = client;

--- a/lib/config.js
+++ b/lib/config.js
@@ -151,6 +151,35 @@ const paramsSchema = Joi.object({
   })
     .default()
     .unknown(false),
+  anonymousSession: Joi.object({
+    enabled: Joi.boolean().optional().default(false),
+    cookie: Joi.object({
+      name: Joi.string()
+        .pattern(/^[0-9a-zA-Z_.-]+$/, { name: 'cookie name' })
+        .optional()
+        .default('auth0_anon'),
+      httpOnly: Joi.boolean().optional().default(true),
+      sameSite: Joi.string()
+        .valid('Lax', 'Strict', 'None')
+        .optional()
+        .default(Joi.ref('....session.cookie.sameSite')),
+      secure: Joi.when(Joi.ref('/baseURL'), {
+        is: Joi.string().pattern(isHttps),
+        then: Joi.boolean().default(true),
+        otherwise: Joi.boolean().valid(false).default(false).messages({
+          'any.only':
+            'Cookies set with the `Secure` property wont be attached to http requests',
+        }),
+      }),
+      path: Joi.string().uri({ relativeOnly: true }).optional().default('/'),
+      domain: Joi.string().optional(),
+    })
+      .default()
+      .unknown(false),
+    store: Joi.object().optional(),
+  })
+    .default()
+    .unknown(false),
   auth0Logout: Joi.boolean().optional(),
   tokenEndpointParams: Joi.object().optional(),
   authorizationParams: Joi.object({

--- a/lib/context.js
+++ b/lib/context.js
@@ -698,6 +698,14 @@ class ResponseContext {
         ...options.authorizationParams,
       };
 
+      // Carry an active anonymous session into the authorization request so
+      // Auth0 can link it to the authenticated identity. The developer does
+      // nothing; the session token is read from the auth0_anon cookie.
+      const anonymousSessionToken = req.anonymousSession?.token;
+      if (anonymousSessionToken) {
+        options.authorizationParams.session_token = anonymousSessionToken;
+      }
+
       const stateValue = await config.getLoginState(req, options);
       if (typeof stateValue !== 'object') {
         next(new Error('Custom state value must be an object.'));

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const onHeaders = require('on-headers');
 
 const debug = require('../lib/debug')('auth');
 const { get: getConfig } = require('../lib/config');
@@ -8,6 +9,11 @@ const TransientCookieHandler = require('../lib/transientHandler');
 const { RequestContext, ResponseContext } = require('../lib/context');
 const appSession = require('../lib/appSession');
 const isLoggedOut = require('../lib/hooks/backchannelLogout/isLoggedOut');
+const makeAnonymousCookieHandler = require('../lib/anonymousSession/cookie');
+const {
+  RequestAnonymousContext,
+  flush: flushAnonymousSession,
+} = require('../lib/anonymousSession/context');
 
 const enforceLeadingSlash = (path) => {
   return path.split('')[0] === '/' ? path : '/' + path;
@@ -34,6 +40,24 @@ const auth = function (params) {
     res.oidc = new ResponseContext(config, req, res, next, transient);
     next();
   });
+
+  // Anonymous session context, attached when the feature is enabled.
+  if (config.anonymousSession.enabled) {
+    const anonymousCookie = makeAnonymousCookieHandler(config);
+    router.use(async (req, res, next) => {
+      try {
+        const state = await anonymousCookie.read(req);
+        const anonymousSession = new RequestAnonymousContext(config, state);
+        req.anonymousSession = anonymousSession;
+        onHeaders(res, () =>
+          flushAnonymousSession(anonymousSession, res, anonymousCookie),
+        );
+        next();
+      } catch (err) {
+        next(err);
+      }
+    });
+  }
 
   // Login route, configurable with routes.login
   if (config.routes.login) {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "mocha": {
     "exit": true,
     "file": "./test/setup.js",
+    "recursive": true,
     "timeout": 10000
   },
   "dependencies": {

--- a/test/anonymousSession.client.tests.js
+++ b/test/anonymousSession.client.tests.js
@@ -1,0 +1,194 @@
+const { assert } = require('chai').use(require('chai-as-promised'));
+const nock = require('nock');
+const { get: getConfig } = require('../lib/config');
+const { requestToken, logout } = require('../lib/anonymousSession/client');
+const { AnonymousSessionError } = require('../lib/anonymousSession/errors');
+const pkg = require('../package.json');
+
+const baseConfig = {
+  secret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  issuerBaseURL: 'https://op.example.com',
+  baseURL: 'https://example.org',
+  authRequired: false,
+};
+
+const tokenResponse = {
+  access_token: '__test_access_token__',
+  session_token: '__test_session_token__',
+  token_type: 'Bearer',
+  expires_in: 604800,
+  session_expires_in: 2592000,
+};
+
+describe('anonymousSession client', () => {
+  describe('requestToken', () => {
+    it('creates a new session (no session_token) and returns the token set', async () => {
+      const config = getConfig(baseConfig);
+      let capturedBody;
+      nock('https://op.example.com')
+        .post('/anonymous/token', (body) => {
+          capturedBody = body;
+          return true;
+        })
+        .reply(200, tokenResponse);
+
+      const result = await requestToken(config, {
+        audience: 'https://api.example.com',
+        scope: 'read:cart',
+        metadata: { cart_id: 'cart_123' },
+      });
+
+      assert.deepEqual(result, tokenResponse);
+      assert.equal(capturedBody.audience, 'https://api.example.com');
+      assert.equal(capturedBody.scope, 'read:cart');
+      assert.deepEqual(capturedBody.metadata, { cart_id: 'cart_123' });
+      assert.notProperty(capturedBody, 'session_token');
+    });
+
+    it('renews with an existing session_token and omits metadata', async () => {
+      const config = getConfig(baseConfig);
+      let capturedBody;
+      nock('https://op.example.com')
+        .post('/anonymous/token', (body) => {
+          capturedBody = body;
+          return true;
+        })
+        .reply(200, { ...tokenResponse, session_token: undefined });
+
+      const result = await requestToken(config, {
+        session_token: '__existing_session_token__',
+      });
+
+      assert.equal(result.access_token, '__test_access_token__');
+      assert.equal(capturedBody.session_token, '__existing_session_token__');
+    });
+
+    it('sends the default headers (User-Agent + Auth0-Client telemetry)', async () => {
+      const config = getConfig(baseConfig);
+      let headers;
+      nock('https://op.example.com')
+        .post('/anonymous/token')
+        .reply(200, function () {
+          headers = this.req.headers;
+          return tokenResponse;
+        });
+
+      await requestToken(config, {});
+
+      assert.equal(
+        headers['user-agent'],
+        `express-openid-connect/${pkg.version}`,
+      );
+      assert.exists(headers['auth0-client']);
+    });
+
+    it('omits the Auth0-Client header when telemetry is disabled', async () => {
+      const config = getConfig({ ...baseConfig, enableTelemetry: false });
+      let headers;
+      nock('https://op.example.com')
+        .post('/anonymous/token')
+        .reply(200, function () {
+          headers = this.req.headers;
+          return tokenResponse;
+        });
+
+      await requestToken(config, {});
+
+      assert.notExists(headers['auth0-client']);
+    });
+
+    it('sends Basic client authentication for a confidential client', async () => {
+      const config = getConfig({
+        ...baseConfig,
+        clientSecret: '__test_client_secret__',
+        clientAuthMethod: 'client_secret_basic',
+      });
+      let headers;
+      nock('https://op.example.com')
+        .post('/anonymous/token')
+        .reply(200, function () {
+          headers = this.req.headers;
+          return tokenResponse;
+        });
+
+      await requestToken(config, {});
+
+      const expected =
+        'Basic ' +
+        Buffer.from('__test_client_id__:__test_client_secret__').toString(
+          'base64',
+        );
+      assert.equal(headers['authorization'], expected);
+    });
+
+    it('sends client_id in the body for a public client', async () => {
+      const config = getConfig(baseConfig);
+      let capturedBody;
+      nock('https://op.example.com')
+        .post('/anonymous/token', (body) => {
+          capturedBody = body;
+          return true;
+        })
+        .reply(200, tokenResponse);
+
+      await requestToken(config, {});
+
+      assert.equal(capturedBody.client_id, '__test_client_id__');
+    });
+
+    it('throws AnonymousSessionError with the error code on a 4xx', async () => {
+      const config = getConfig(baseConfig);
+      nock('https://op.example.com').post('/anonymous/token').reply(400, {
+        error: 'metadata_too_large',
+        error_description: 'Attempted to grow metadata over 1kB limit',
+      });
+
+      const err = await requestToken(config, {}).then(
+        () => null,
+        (e) => e,
+      );
+
+      assert.instanceOf(err, AnonymousSessionError);
+      assert.equal(err.code, 'metadata_too_large');
+      assert.equal(err.statusCode, 400);
+    });
+
+    it('throws AnonymousSessionError with server_error on a 500', async () => {
+      const config = getConfig(baseConfig);
+      nock('https://op.example.com')
+        .post('/anonymous/token')
+        .reply(500, { error: 'server_error' });
+
+      const err = await requestToken(config, {}).then(
+        () => null,
+        (e) => e,
+      );
+
+      assert.instanceOf(err, AnonymousSessionError);
+      assert.equal(err.code, 'server_error');
+    });
+  });
+
+  describe('logout', () => {
+    it('posts to /anonymous/logout with the session_token', async () => {
+      const config = getConfig(baseConfig);
+      let capturedBody;
+      const scope = nock('https://op.example.com')
+        .post('/anonymous/logout', (body) => {
+          capturedBody = body;
+          return true;
+        })
+        .reply(200, {});
+
+      await logout(config, '__existing_session_token__');
+
+      assert.isTrue(scope.isDone());
+      assert.equal(capturedBody.session_token, '__existing_session_token__');
+    });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+});

--- a/test/anonymousSession/client.tests.js
+++ b/test/anonymousSession/client.tests.js
@@ -1,9 +1,9 @@
 const { assert } = require('chai').use(require('chai-as-promised'));
 const nock = require('nock');
-const { get: getConfig } = require('../lib/config');
-const { requestToken, logout } = require('../lib/anonymousSession/client');
-const { AnonymousSessionError } = require('../lib/anonymousSession/errors');
-const pkg = require('../package.json');
+const { get: getConfig } = require('../../lib/config');
+const { requestToken, logout } = require('../../lib/anonymousSession/client');
+const { AnonymousSessionError } = require('../../lib/anonymousSession/errors');
+const pkg = require('../../package.json');
 
 const baseConfig = {
   secret: '__test_session_secret__',

--- a/test/anonymousSession/context.tests.js
+++ b/test/anonymousSession/context.tests.js
@@ -1,0 +1,252 @@
+'use strict';
+
+const { assert } = require('chai');
+const nock = require('nock');
+const { get: getConfig } = require('../../lib/config');
+const {
+  RequestAnonymousContext,
+  flush,
+} = require('../../lib/anonymousSession/context');
+const { AnonymousSessionError } = require('../../lib/anonymousSession/errors');
+const { epoch } = require('../../lib/utils/epoch');
+
+const baseConfig = {
+  secret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  issuerBaseURL: 'https://op.example.com',
+  baseURL: 'https://example.org',
+  authRequired: false,
+  anonymousSession: { enabled: true },
+};
+
+const tokenResponse = (overrides = {}) => ({
+  access_token: '__access_token__',
+  session_token: '__session_token__',
+  token_type: 'Bearer',
+  expires_in: 604800,
+  session_expires_in: 2592000,
+  ...overrides,
+});
+
+const mockToken = (assertBody) =>
+  nock('https://op.example.com').post('/anonymous/token', (body) => {
+    if (assertBody) assertBody(body);
+    return true;
+  });
+
+const config = () => getConfig(baseConfig);
+
+// Build a context seeded with existing cookie state.
+const withState = (state) => new RequestAnonymousContext(config(), state);
+
+const validState = (overrides = {}) => ({
+  session_token: '__session_token__',
+  access_token: '__access_token__',
+  token_type: 'Bearer',
+  expires_at: epoch() + 3600,
+  session_expires_at: epoch() + 2592000,
+  audience: 'https://api.example.com',
+  scope: 'read:cart',
+  ...overrides,
+});
+
+describe('anonymousSession context', () => {
+  afterEach(() => nock.cleanAll());
+
+  describe('read accessors', () => {
+    it('isAnonymous is false and token is null with no state', () => {
+      const ctx = new RequestAnonymousContext(config(), null);
+      assert.isFalse(ctx.isAnonymous);
+      assert.isNull(ctx.token);
+    });
+
+    it('isAnonymous is true and token returns the session token with state', () => {
+      const ctx = withState(validState());
+      assert.isTrue(ctx.isAnonymous);
+      assert.equal(ctx.token, '__session_token__');
+    });
+  });
+
+  describe('start', () => {
+    it('creates a session and returns the access token', async () => {
+      let body;
+      mockToken((b) => (body = b)).reply(200, tokenResponse());
+      const ctx = new RequestAnonymousContext(config(), null);
+
+      const at = await ctx.start({
+        audience: 'https://api.example.com',
+        scope: 'read:cart',
+        metadata: { cart_id: 'c1' },
+      });
+
+      assert.equal(at.access_token, '__access_token__');
+      assert.equal(at.token_type, 'Bearer');
+      assert.isAbove(at.expires_in, 0);
+      assert.equal(body.audience, 'https://api.example.com');
+      assert.deepEqual(body.metadata, { cart_id: 'c1' });
+      assert.isTrue(ctx.isAnonymous);
+    });
+  });
+
+  describe('getAccessToken', () => {
+    it('throws when there is no active session', async () => {
+      const ctx = new RequestAnonymousContext(config(), null);
+      const err = await ctx.getAccessToken().then(
+        () => null,
+        (e) => e,
+      );
+      assert.instanceOf(err, AnonymousSessionError);
+      assert.equal(err.code, 'no_active_session');
+    });
+
+    it('returns the cached token when still valid (no network call)', async () => {
+      // A one-shot mock that must NOT be consumed if the cache is used.
+      const scope = mockToken().reply(200, tokenResponse());
+      const ctx = withState(validState());
+
+      const at = await ctx.getAccessToken();
+
+      assert.equal(at.access_token, '__access_token__');
+      assert.isFalse(scope.isDone(), 'should not call the token endpoint');
+    });
+
+    it('renews using the session token when the access token is expired', async () => {
+      let body;
+      mockToken((b) => (body = b)).reply(
+        200,
+        tokenResponse({
+          access_token: '__renewed__',
+          session_token: undefined,
+        }),
+      );
+      const ctx = withState(validState({ expires_at: epoch() - 10 }));
+
+      const at = await ctx.getAccessToken();
+
+      assert.equal(at.access_token, '__renewed__');
+      assert.equal(body.session_token, '__session_token__');
+      assert.equal(body.audience, 'https://api.example.com');
+    });
+
+    it('preserves session_expires_at across a renewal (no lifetime extension)', async () => {
+      mockToken().reply(
+        200,
+        tokenResponse({
+          access_token: '__renewed__',
+          session_token: undefined,
+        }),
+      );
+      const original = validState({ expires_at: epoch() - 10 });
+      const ctx = withState({ ...original });
+
+      await ctx.getAccessToken();
+      const res = captureWrite(ctx);
+      assert.equal(res.session_expires_at, original.session_expires_at);
+    });
+
+    it('creates a new session silently when the session token is expired', async () => {
+      let calls = 0;
+      nock('https://op.example.com')
+        .post('/anonymous/token')
+        .times(2)
+        .reply(function () {
+          calls += 1;
+          if (calls === 1) {
+            return [400, { error: 'session_expired' }];
+          }
+          return [200, tokenResponse({ access_token: '__new_session_at__' })];
+        });
+
+      const ctx = withState(validState({ expires_at: epoch() - 10 }));
+      const at = await ctx.getAccessToken();
+
+      assert.equal(at.access_token, '__new_session_at__');
+      assert.equal(calls, 2);
+    });
+
+    it('rethrows non-silent errors during renewal', async () => {
+      nock('https://op.example.com')
+        .post('/anonymous/token')
+        .reply(500, { error: 'server_error' });
+
+      const ctx = withState(validState({ expires_at: epoch() - 10 }));
+      const err = await ctx.getAccessToken().then(
+        () => null,
+        (e) => e,
+      );
+
+      assert.instanceOf(err, AnonymousSessionError);
+      assert.equal(err.code, 'server_error');
+    });
+  });
+
+  describe('end', () => {
+    it('calls logout and clears the session state', async () => {
+      const scope = nock('https://op.example.com')
+        .post('/anonymous/logout')
+        .reply(200, {});
+      const ctx = withState(validState());
+
+      await ctx.end();
+
+      assert.isTrue(scope.isDone());
+      assert.isFalse(ctx.isAnonymous);
+      assert.isNull(ctx.token);
+    });
+
+    it('clears state even if logout fails', async () => {
+      nock('https://op.example.com')
+        .post('/anonymous/logout')
+        .reply(500, { error: 'server_error' });
+      const ctx = withState(validState());
+
+      await ctx.end();
+
+      assert.isFalse(ctx.isAnonymous);
+    });
+  });
+
+  describe('flush', () => {
+    it('writes the cookie after start', async () => {
+      mockToken().reply(200, tokenResponse());
+      const ctx = new RequestAnonymousContext(config(), null);
+      await ctx.start({ audience: 'https://api.example.com' });
+
+      const written = captureWrite(ctx);
+      assert.equal(written.access_token, '__access_token__');
+    });
+
+    it('clears the cookie after end', async () => {
+      nock('https://op.example.com').post('/anonymous/logout').reply(200, {});
+      const ctx = withState(validState());
+      await ctx.end();
+
+      let cleared = false;
+      const handler = { write: () => {}, clear: () => (cleared = true) };
+      flush(ctx, {}, handler);
+      assert.isTrue(cleared);
+    });
+
+    it('does nothing when no change is pending', () => {
+      const ctx = withState(validState());
+      let touched = false;
+      const handler = {
+        write: () => (touched = true),
+        clear: () => (touched = true),
+      };
+      flush(ctx, {}, handler);
+      assert.isFalse(touched);
+    });
+  });
+});
+
+// Runs flush against a capturing cookie handler and returns the written state.
+function captureWrite(ctx) {
+  let written;
+  const handler = {
+    write: (res, state) => (written = state),
+    clear: () => {},
+  };
+  flush(ctx, {}, handler);
+  return written;
+}

--- a/test/anonymousSession/cookie.tests.js
+++ b/test/anonymousSession/cookie.tests.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { assert } = require('chai');
+const { get: getConfig } = require('../../lib/config');
+const makeCookieHandler = require('../../lib/anonymousSession/cookie');
+
+const baseConfig = {
+  secret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  issuerBaseURL: 'https://op.example.com',
+  baseURL: 'https://example.org',
+  authRequired: false,
+  anonymousSession: { enabled: true },
+};
+
+const state = {
+  session_token: '__session_token__',
+  access_token: '__access_token__',
+  token_type: 'Bearer',
+  expires_at: 1800000000,
+  session_expires_at: 1900000000,
+  audience: 'https://api.example.com',
+  scope: 'read:cart',
+};
+
+// Minimal req/res doubles capturing cookie I/O.
+const makeReq = (cookieHeader = '') => ({
+  get: (name) => (name.toLowerCase() === 'cookie' ? cookieHeader : undefined),
+});
+
+const makeRes = () => {
+  const set = [];
+  const cleared = [];
+  return {
+    set,
+    cleared,
+    cookie: (name, value, options) => set.push({ name, value, options }),
+    clearCookie: (name, options) => cleared.push({ name, options }),
+  };
+};
+
+describe('anonymousSession cookie', () => {
+  it('round-trips state through write then read', async () => {
+    const handler = makeCookieHandler(getConfig(baseConfig));
+    const res = makeRes();
+
+    handler.write(res, state);
+    assert.lengthOf(res.set, 1);
+    assert.equal(res.set[0].name, 'auth0_anon');
+
+    const req = makeReq(`auth0_anon=${res.set[0].value}`);
+    const decrypted = await handler.read(req);
+    assert.deepEqual(decrypted, state);
+  });
+
+  it('returns null when there is no cookie', async () => {
+    const handler = makeCookieHandler(getConfig(baseConfig));
+    assert.isNull(await handler.read(makeReq('')));
+  });
+
+  it('returns null when the cookie cannot be decrypted', async () => {
+    const handler = makeCookieHandler(getConfig(baseConfig));
+    const req = makeReq('auth0_anon=not-a-valid-jwe');
+    assert.isNull(await handler.read(req));
+  });
+
+  it('sets cookie expiry from session_expires_at', async () => {
+    const handler = makeCookieHandler(getConfig(baseConfig));
+    const res = makeRes();
+
+    handler.write(res, state);
+    assert.deepEqual(
+      res.set[0].options.expires,
+      new Date(state.session_expires_at * 1000),
+    );
+  });
+
+  it('honors a custom cookie name', async () => {
+    const config = getConfig({
+      ...baseConfig,
+      anonymousSession: { enabled: true, cookie: { name: 'custom_anon' } },
+    });
+    const handler = makeCookieHandler(config);
+    const res = makeRes();
+
+    handler.write(res, state);
+    assert.equal(res.set[0].name, 'custom_anon');
+  });
+
+  it('clears the cookie with the configured attributes', () => {
+    const config = getConfig({
+      ...baseConfig,
+      anonymousSession: {
+        enabled: true,
+        cookie: { name: 'auth0_anon', sameSite: 'None', domain: 'example.org' },
+      },
+    });
+    const handler = makeCookieHandler(config);
+    const res = makeRes();
+
+    handler.clear(res);
+    assert.lengthOf(res.cleared, 1);
+    assert.equal(res.cleared[0].name, 'auth0_anon');
+    assert.equal(res.cleared[0].options.sameSite, 'None');
+    assert.equal(res.cleared[0].options.domain, 'example.org');
+  });
+});

--- a/test/anonymousSession/integration.tests.js
+++ b/test/anonymousSession/integration.tests.js
@@ -1,4 +1,5 @@
 const { assert } = require('chai');
+const url = require('url');
 const nock = require('nock');
 const express = require('express');
 const request = require('request-promise-native').defaults({
@@ -100,5 +101,32 @@ describe('anonymousSession integration', () => {
 
     assert.isTrue(res.body.isAnonymous);
     assert.equal(res.body.token, '__session_token__');
+  });
+
+  it('injects session_token into the authorize URL on login', async () => {
+    await setup();
+    nock('https://op.example.com')
+      .post('/anonymous/token')
+      .reply(200, tokenResponse);
+
+    const jar = request.jar();
+    await request.get('/anon/start', { baseUrl, jar, json: true });
+
+    const res = await request.get('/login', {
+      baseUrl,
+      jar,
+      followRedirect: false,
+    });
+    const parsed = url.parse(res.headers.location, true);
+    assert.equal(parsed.pathname, '/authorize');
+    assert.equal(parsed.query.session_token, '__session_token__');
+  });
+
+  it('does not add session_token to the authorize URL without a session', async () => {
+    await setup();
+    const res = await request.get('/login', { baseUrl, followRedirect: false });
+    const parsed = url.parse(res.headers.location, true);
+    assert.equal(parsed.pathname, '/authorize');
+    assert.notProperty(parsed.query, 'session_token');
   });
 });

--- a/test/anonymousSession/integration.tests.js
+++ b/test/anonymousSession/integration.tests.js
@@ -1,0 +1,104 @@
+const { assert } = require('chai');
+const nock = require('nock');
+const express = require('express');
+const request = require('request-promise-native').defaults({
+  simple: false,
+  resolveWithFullResponse: true,
+});
+
+const { auth } = require('../..');
+const { create: createServer } = require('../fixture/server');
+
+const baseUrl = 'http://localhost:3000';
+
+const defaultConfig = {
+  secret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  baseURL: 'http://example.org',
+  issuerBaseURL: 'https://op.example.com',
+  authRequired: false,
+  anonymousSession: { enabled: true },
+};
+
+const tokenResponse = {
+  access_token: '__access_token__',
+  session_token: '__session_token__',
+  token_type: 'Bearer',
+  expires_in: 604800,
+  session_expires_in: 2592000,
+};
+
+describe('anonymousSession integration', () => {
+  let server;
+
+  afterEach(() => {
+    nock.cleanAll();
+    if (server) server.close();
+  });
+
+  const setup = async (config = defaultConfig) => {
+    const router = express.Router();
+    router.use(auth(config));
+    router.get('/anon', async (req, res, next) => {
+      try {
+        res.json({
+          isAnonymous: req.anonymousSession.isAnonymous,
+          token: req.anonymousSession.token,
+        });
+      } catch (err) {
+        next(err);
+      }
+    });
+    router.get('/anon/start', async (req, res, next) => {
+      try {
+        const at = await req.anonymousSession.start({
+          audience: 'https://api.example.com',
+        });
+        res.json(at);
+      } catch (err) {
+        next(err);
+      }
+    });
+    server = await createServer(router);
+  };
+
+  it('attaches req.anonymousSession when enabled', async () => {
+    await setup();
+    const res = await request.get('/anon', { baseUrl, json: true });
+    assert.deepEqual(res.body, { isAnonymous: false, token: null });
+  });
+
+  it('does not attach req.anonymousSession when disabled', async () => {
+    await setup({ ...defaultConfig, anonymousSession: { enabled: false } });
+    const res = await request.get('/anon', { baseUrl });
+    // req.anonymousSession is undefined -> reading .isAnonymous throws -> 500
+    assert.equal(res.statusCode, 500);
+  });
+
+  it('start() sets the encrypted auth0_anon cookie on the response', async () => {
+    await setup();
+    nock('https://op.example.com')
+      .post('/anonymous/token')
+      .reply(200, tokenResponse);
+
+    const res = await request.get('/anon/start', { baseUrl, json: true });
+
+    assert.equal(res.body.access_token, '__access_token__');
+    const setCookie = res.headers['set-cookie'].join(';');
+    assert.include(setCookie, 'auth0_anon=');
+  });
+
+  it('persisted cookie makes a subsequent request anonymous', async () => {
+    await setup();
+    nock('https://op.example.com')
+      .post('/anonymous/token')
+      .reply(200, tokenResponse);
+
+    const jar = request.jar();
+    await request.get('/anon/start', { baseUrl, jar, json: true });
+    const res = await request.get('/anon', { baseUrl, jar, json: true });
+
+    assert.isTrue(res.body.isAnonymous);
+    assert.equal(res.body.token, '__session_token__');
+  });
+});

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -299,6 +299,95 @@ describe('get config', () => {
     });
   });
 
+  it('should default anonymousSession to disabled with default cookie config', () => {
+    const config = getConfig(defaultConfig);
+    assert.deepEqual(config.anonymousSession, {
+      enabled: false,
+      cookie: {
+        name: 'auth0_anon',
+        httpOnly: true,
+        sameSite: 'Lax',
+        secure: true,
+        path: '/',
+      },
+    });
+  });
+
+  it('should default anonymousSession cookie secure to false over http', () => {
+    const config = getConfig({
+      ...defaultConfig,
+      baseURL: 'http://example.org',
+    });
+    assert.equal(config.anonymousSession.cookie.secure, false);
+  });
+
+  it('should default anonymousSession cookie sameSite from session cookie configuration', () => {
+    const config = getConfig({
+      ...defaultConfig,
+      session: { cookie: { sameSite: 'Strict' } },
+    });
+    assert.equal(config.anonymousSession.cookie.sameSite, 'Strict');
+  });
+
+  it('should enable anonymousSession and allow custom cookie configuration', () => {
+    const config = getConfig({
+      ...defaultConfig,
+      anonymousSession: {
+        enabled: true,
+        cookie: {
+          name: 'custom_anon',
+          sameSite: 'None',
+          httpOnly: false,
+          secure: true,
+          path: '/app',
+          domain: 'example.org',
+        },
+      },
+    });
+    assert.deepEqual(config.anonymousSession, {
+      enabled: true,
+      cookie: {
+        name: 'custom_anon',
+        sameSite: 'None',
+        httpOnly: false,
+        secure: true,
+        path: '/app',
+        domain: 'example.org',
+      },
+    });
+  });
+
+  it('should accept an anonymousSession store', () => {
+    const store = { get() {}, set() {}, destroy() {} };
+    const config = getConfig({
+      ...defaultConfig,
+      anonymousSession: { enabled: true, store },
+    });
+    assert.equal(config.anonymousSession.store, store);
+  });
+
+  it('should validate anonymousSession cookie name', () => {
+    assert.throws(
+      () =>
+        getConfig({
+          ...defaultConfig,
+          anonymousSession: { cookie: { name: 'invalid name' } },
+        }),
+      TypeError,
+    );
+  });
+
+  it('should reject unknown anonymousSession keys', () => {
+    assert.throws(
+      () =>
+        getConfig({
+          ...defaultConfig,
+          anonymousSession: { foo: 'bar' },
+        }),
+      TypeError,
+    );
+  });
+
   it('should allow setting custom cookie path to prevent collision on same domain', function () {
     const config = getConfig({
       ...defaultConfig,


### PR DESCRIPTION
## Description

Adds opt-in support for **Anonymous Sessions**, which let an application give a visitor an Auth0 identity before they log in. A visitor gets an anonymous session (backed by an `auth0_anon` cookie) and can obtain access tokens to call APIs; when they later authenticate, the anonymous session token is automatically carried into the authorization request so it can be linked to the authenticated identity.

The feature is disabled by default and fully additive — existing behavior is unchanged when `anonymousSession.enabled` is not set.

### Configuration

```js
app.use(
  auth({
    authRequired: false,
    anonymousSession: {
      enabled: true,
      // cookie options are optional and mirror the session cookie defaults
      // (name defaults to `auth0_anon`)
    },
  }),
);
```

### Request context

When enabled, every request gets a `req.anonymousSession`:

- `req.anonymousSession.isAnonymous` — `boolean`
- `req.anonymousSession.token` — the opaque anonymous session token, or `null`
- `await req.anonymousSession.start({ audience?, scope?, metadata? })` — creates a session and returns its access token (metadata is set once, at creation)
- `await req.anonymousSession.getAccessToken()` — returns the cached access token while valid, silently renewing it (or transparently creating a new session if the anonymous session has expired) when it is not
- `await req.anonymousSession.end()` — ends the session and clears the cookie

`AnonymousSessionError` (exported from the package) is thrown for surfaced failures and carries a `.code`.

## How it works

- **HTTP client** (`lib/anonymousSession/client.js`) calls `POST /anonymous/token` and `POST /anonymous/logout`. It reuses the existing custom-fetch wrapper so the telemetry and `User-Agent` headers (and the `enableTelemetry` opt-out) are preserved, and derives the endpoint from the discovered issuer. Client authentication is sent based on the configured `clientAuthMethod` (Basic for confidential clients, `client_id` in the body for public clients).
- **Cookie** (`lib/anonymousSession/cookie.js`) stores the anonymous session state in a single encrypted `auth0_anon` cookie, using the same encryption profile as the application session cookie. Only the session token is ever forwarded to the authorization server; the access token stays server-side. Renewals do not extend the cookie lifetime.
- **Context** (`lib/anonymousSession/context.js`) implements the read accessors and the `start`/`getAccessToken`/`end` methods. Cookie writes are deferred to an `on-headers` hook so request-side methods never touch the response directly, matching the application-session pattern.
- **Login** injects the anonymous session token into the `/authorize` request from the existing login handler; the developer calls login as usual.

Anonymous state is kept completely independent of `req.oidc.isAuthenticated()` and `req.oidc.user`.

## Testing

- New unit tests for config, the HTTP client, the cookie handler, and the request context, plus end-to-end integration tests through an Express server (all HTTP stubbed with `nock`).
- `index.d.ts` types and `tsd` type tests updated.
- `npm run test` and `npm run lint` pass.

## Checklist

- [x] Additive, opt-in, no breaking changes
- [x] Types kept in sync (`index.d.ts`)
- [x] Unit + integration tests added
- [x] `EXAMPLES.md` and a runnable example updated
