### PR TITLE
docs: add passwordless authentication example and guide

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -17,6 +17,7 @@
 15. [Session expiry from upstream IdP (IPSIE `session_expiry`)](#15-session-expiry-from-upstream-idp-ipsie-session_expiry)
 16. [JWT-Secured Authorization Requests (JAR)](#16-jwt-secured-authorization-requests-jar)
 17. [mTLS client authentication](#17-mtls-client-authentication)
+18. [Passwordless authentication](#18-passwordless-authentication)
 
 ## 1. Basic setup
 
@@ -768,3 +769,32 @@ try {
 ```
 
 Full example at [mtls.js](./examples/mtls.js).
+
+## 18. Passwordless authentication
+
+[Passwordless](https://auth0.com/docs/authenticate/passwordless) lets users sign in without a password, using a one-time code (email or SMS) or a magic link (email). It is driven through Universal Login: Auth0 hosts the page that sends and collects the code or link. Select the connection with the `connection` authorization parameter, and optionally prefill the identifier with `login_hint`. No dedicated config is needed — `authorizationParams` accepts these directly.
+
+```js
+app.use(auth({ authRequired: false }));
+
+app.get('/passwordless/email', (req, res) =>
+  res.oidc.login({
+    authorizationParams: { connection: 'email', login_hint: req.query.email },
+  }),
+);
+
+app.get('/passwordless/sms', (req, res) =>
+  res.oidc.login({
+    authorizationParams: {
+      connection: 'sms',
+      login_hint: req.query.phone_number,
+    },
+  }),
+);
+```
+
+Whether the `email` connection sends a code or a magic link is configured on the Auth0 connection, not chosen here; SMS sends a code. The connection must be enabled on your Auth0 application.
+
+**Magic-link limitation:** a magic link only completes in the **same browser** that started the login, because `/callback` validates the browser-bound transaction cookie (`state`/`nonce`/PKCE) set at `/login`. Cross-device magic links (start on laptop, click on phone) are not supported by this redirect-based SDK; the Auth0 setting `allow_magiclink_verify_without_session` lifts Auth0's own same-session check but not this SDK's cookie requirement. One-time code flows are unaffected.
+
+Full example at [passwordless.js](./examples/passwordless.js), to run it: `npm run start:example -- passwordless`

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -779,12 +779,14 @@ app.use(auth({ authRequired: false }));
 
 app.get('/passwordless/email', (req, res) =>
   res.oidc.login({
+    returnTo: '/',
     authorizationParams: { connection: 'email', login_hint: req.query.email },
   }),
 );
 
 app.get('/passwordless/sms', (req, res) =>
   res.oidc.login({
+    returnTo: '/',
     authorizationParams: {
       connection: 'sms',
       login_hint: req.query.phone_number,

--- a/examples/passwordless.js
+++ b/examples/passwordless.js
@@ -1,0 +1,91 @@
+const express = require('express');
+const { auth } = require('../');
+
+const app = express();
+
+// Passwordless authentication via Universal Login.
+//
+// Passwordless is an Auth0 connection type (`email` or `sms`). Auth0 hosts the
+// entire experience on the Universal Login page: it sends the one-time code (or
+// magic link) and collects it from the user. This SDK only has to point the
+// browser at the right connection — it never touches the email/phone, the code,
+// or the /passwordless/start endpoint.
+//
+// The SDK signals the connection through the `connection` authorization
+// parameter, and can prefill the identifier with `login_hint`. Both are ordinary
+// authorizationParams, so no dedicated config is needed.
+//
+// Whether the email connection delivers a one-time CODE or a MAGIC LINK is a
+// setting on the Auth0 Email connection, not something the application chooses
+// here. SMS connections deliver a code.
+//
+// Magic-link note: a magic link only completes in the SAME browser that started
+// login, because the callback validates the browser-bound transaction cookie
+// (state/nonce/PKCE). Cross-device magic links (start on laptop, click on phone)
+// are not supported by this redirect-based SDK. One-time codes are unaffected.
+//
+// Run with: node examples/run_example.js passwordless.js
+// NOTE: the bundled mock provider has no passwordless connections, so the
+// /passwordless/email and /passwordless/sms routes below will only reach a real
+// Auth0 tenant that has the email/sms connections enabled. Configure a tenant
+// via .env (ISSUER_BASE_URL, CLIENT_ID, CLIENT_SECRET, BASE_URL, SECRET) to try
+// them end to end.
+
+app.use(
+  auth({
+    authRequired: false,
+    // `code` returns an authorization code the SDK exchanges for tokens. The
+    // default `id_token` (implicit) also works for passwordless; use `code`
+    // when you also need an access token or refresh token.
+    authorizationParams: {
+      response_type: 'code',
+      scope: 'openid profile email',
+    },
+  }),
+);
+
+app.get('/', (req, res) => {
+  if (req.oidc.isAuthenticated()) {
+    res.send(
+      `<p>Logged in as <strong>${req.oidc.user.sub}</strong></p>` +
+        `<a href="/logout">logout</a>`,
+    );
+  } else {
+    res.send(
+      '<p>Log in with passwordless:</p>' +
+        '<ul>' +
+        '<li><a href="/passwordless/email">Email</a></li>' +
+        '<li><a href="/passwordless/sms">SMS</a></li>' +
+        '</ul>',
+    );
+  }
+});
+
+// Email passwordless. Auth0 sends a one-time code or a magic link (per the
+// Email connection's configuration) to the address. Pass the address as
+// `login_hint` to prefill it on the Universal Login page, e.g.
+// /passwordless/email?email=user@example.com
+app.get('/passwordless/email', (req, res) =>
+  res.oidc.login({
+    authorizationParams: {
+      connection: 'email',
+      ...(req.query.email ? { login_hint: req.query.email } : undefined),
+    },
+  }),
+);
+
+// SMS passwordless. Auth0 texts a one-time code to the phone number. Pass the
+// number (E.164, e.g. +14155550100) as `login_hint` to prefill it, e.g.
+// /passwordless/sms?phone_number=+14155550100
+app.get('/passwordless/sms', (req, res) =>
+  res.oidc.login({
+    authorizationParams: {
+      connection: 'sms',
+      ...(req.query.phone_number
+        ? { login_hint: req.query.phone_number }
+        : undefined),
+    },
+  }),
+);
+
+module.exports = app;

--- a/examples/passwordless.js
+++ b/examples/passwordless.js
@@ -3,33 +3,35 @@ const { auth } = require('../');
 
 const app = express();
 
-// Passwordless authentication via Universal Login.
-//
-// Passwordless is an Auth0 connection type (`email` or `sms`). Auth0 hosts the
-// entire experience on the Universal Login page: it sends the one-time code (or
-// magic link) and collects it from the user. This SDK only has to point the
-// browser at the right connection — it never touches the email/phone, the code,
-// or the /passwordless/start endpoint.
-//
-// The SDK signals the connection through the `connection` authorization
-// parameter, and can prefill the identifier with `login_hint`. Both are ordinary
-// authorizationParams, so no dedicated config is needed.
-//
-// Whether the email connection delivers a one-time CODE or a MAGIC LINK is a
-// setting on the Auth0 Email connection, not something the application chooses
-// here. SMS connections deliver a code.
-//
-// Magic-link note: a magic link only completes in the SAME browser that started
-// login, because the callback validates the browser-bound transaction cookie
-// (state/nonce/PKCE). Cross-device magic links (start on laptop, click on phone)
-// are not supported by this redirect-based SDK. One-time codes are unaffected.
-//
-// Run with: node examples/run_example.js passwordless.js
-// NOTE: the bundled mock provider has no passwordless connections, so the
-// /passwordless/email and /passwordless/sms routes below will only reach a real
-// Auth0 tenant that has the email/sms connections enabled. Configure a tenant
-// via .env (ISSUER_BASE_URL, CLIENT_ID, CLIENT_SECRET, BASE_URL, SECRET) to try
-// them end to end.
+/*
+ * Passwordless authentication via Universal Login.
+ *
+ * Passwordless is an Auth0 connection type (`email` or `sms`). Auth0 hosts the
+ * entire experience on the Universal Login page: it sends the one-time code (or
+ * magic link) and collects it from the user. This SDK only has to point the
+ * browser at the right connection — it never touches the email/phone, the code,
+ * or the /passwordless/start endpoint.
+ *
+ * The SDK signals the connection through the `connection` authorization
+ * parameter, and can prefill the identifier with `login_hint`. Both are ordinary
+ * authorizationParams, so no dedicated config is needed.
+ *
+ * Whether the email connection delivers a one-time CODE or a MAGIC LINK is a
+ * setting on the Auth0 Email connection, not something the application chooses
+ * here. SMS connections deliver a code.
+ *
+ * Magic-link note: a magic link only completes in the SAME browser that started
+ * login, because the callback validates the browser-bound transaction cookie
+ * (state/nonce/PKCE). Cross-device magic links (start on laptop, click on phone)
+ * are not supported by this redirect-based SDK. One-time codes are unaffected.
+ *
+ * Run with: npm run start:example -- passwordless
+ * NOTE: the bundled mock provider has no passwordless connections, so the
+ * /passwordless/email and /passwordless/sms routes below will only reach a real
+ * Auth0 tenant that has the email/sms connections enabled. Configure a tenant
+ * via .env (ISSUER_BASE_URL, CLIENT_ID, CLIENT_SECRET, BASE_URL, SECRET) to try
+ * them end to end.
+ */
 
 app.use(
   auth({
@@ -67,6 +69,7 @@ app.get('/', (req, res) => {
 // /passwordless/email?email=user@example.com
 app.get('/passwordless/email', (req, res) =>
   res.oidc.login({
+    returnTo: '/',
     authorizationParams: {
       connection: 'email',
       ...(req.query.email ? { login_hint: req.query.email } : undefined),
@@ -79,6 +82,7 @@ app.get('/passwordless/email', (req, res) =>
 // /passwordless/sms?phone_number=+14155550100
 app.get('/passwordless/sms', (req, res) =>
   res.oidc.login({
+    returnTo: '/',
     authorizationParams: {
       connection: 'sms',
       ...(req.query.phone_number


### PR DESCRIPTION
### Description

Documents how to use Auth0 **passwordless authentication** (email one-time code, SMS one-time code, and email magic link) with \`express-openid-connect\` via **Universal Login**.

Passwordless is driven entirely through Universal Login: Auth0 hosts the page that sends and collects the code or link. The SDK only needs to signal which connection to use via the \`connection\` authorization parameter (and optionally prefill the identifier with \`login_hint\`). Because \`authorizationParams\` already forwards arbitrary parameters to the \`/authorize\` request, **no SDK code change is required** — this PR is documentation and a runnable example only.

### Changes

- \`examples/passwordless.js\` — runnable example with dedicated email and SMS passwordless login routes, including \`returnTo: '/'\` to prevent a redirect loop after callback.
- \`EXAMPLES.md\` — new section 18 (plus table-of-contents entry) explaining the Universal Login model, the \`connection\` / \`login_hint\` parameters, and the magic-link limitation.

### Notes

- **Magic-link limitation (documented):** a magic link only completes in the *same browser* that started the login, because \`/callback\` validates the browser-bound transaction cookie (\`state\`/\`nonce\`/PKCE). Cross-device magic links are inherently unsupported by this redirect-based SDK. The Auth0 tenant setting \`allow_magiclink_verify_without_session\` lifts Auth0's own same-session check but not this SDK's transaction-cookie requirement. One-time code flows (email and SMS) are unaffected.
- Whether the email connection delivers a code or a magic link is an Auth0 connection setting, not an SDK parameter.
- The embedded \`/passwordless/start\` + OTP-grant API (used by the headless SDKs) is intentionally **not** added — it contradicts this SDK's redirect-only architecture and would expand the public API surface.

### Testing

- All existing unit tests pass (\`npm run test\` — 436 passing).
- Lint and Prettier clean.
- Verified end-to-end against a real Auth0 tenant with the \`email\` passwordless connection enabled: \`/passwordless/email\` redirects to \`/authorize\` carrying the correct \`connection\` and \`login_hint\` parameters, and the callback completes successfully, establishing a session.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (docs-only PR)
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not \`master\`