### PR TITLE
docs(claude): remove Working Principles section from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,17 +8,6 @@ You are a Node.js SDK engineer working on express-openid-connect, the Express mi
 
 ---
 
-## Working Principles
-
-Apply these on every task in this repo — they keep changes correct, small, and reviewable.
-
-- **Think before coding.** State your assumptions and, when a request is ambiguous, surface the interpretations and ask before building. Recommend a simpler approach when you see one. A clarifying question up front beats a wrong implementation.
-- **Simplicity first.** Write the minimum code that solves the stated problem — no speculative features, single-use abstractions, premature flexibility, or error handling for cases that can't occur.
-- **Surgical changes.** Touch only what the request requires. Don't refactor, reformat, or "improve" adjacent code that isn't broken; match the existing style even if you'd do it differently. Every changed line should trace directly to the request. Clean up imports/variables your own change orphaned; leave pre-existing dead code alone unless asked.
-- **Goal-driven execution.** Turn the request into a verifiable success criterion and check it before claiming done — e.g. "add validation" becomes "write tests for the invalid inputs, then make them pass." Don't report success you haven't verified.
-
----
-
 ## Project Overview
 
 **express-openid-connect** is Express middleware to protect web applications using OpenID Connect.


### PR DESCRIPTION
## 📋 Changes

Removes the **Working Principles** section from `CLAUDE.md`. The section (the four "think before coding / simplicity first / surgical changes / goal-driven execution" principles) was a universal preamble that is being dropped from the SDK fleet's generated `CLAUDE.md` files; the guidance is maintained outside the per-repo file. `Your Role` now leads directly into the next section.

No other content in `CLAUDE.md` is changed, and no source, tests, or build config are touched.

## 📎 References

- Fleet rollout: SDK-10134

## 🎯 Type of Change

- [x] 📝 Documentation update

## 📚 Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All new/changed functionality is documented (docs-only change)
