### PR TITLE
fix: verify signed cookies whose value contains dots

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -105,8 +105,9 @@ const verifyCookie = async (cookie, value, keystore) => {
   if (!value) {
     return undefined;
   }
-  let signature;
-  [value, signature] = value.split('.');
+  const lastDot = value.lastIndexOf('.');
+  const signature = value.slice(lastDot + 1);
+  value = value.slice(0, lastDot);
   if (await verifySignature(cookie, value, signature, keystore)) {
     return value;
   }

--- a/test/crypto.tests.js
+++ b/test/crypto.tests.js
@@ -206,5 +206,18 @@ describe('crypto', () => {
       // signatures should be deterministic for same inputs
       assert.equal(syncSigned, asyncSigned);
     });
+
+    it('round-trips a value containing dots', async () => {
+      // The signature is base64url (dot-free), so the separator is the last
+      // dot. A value with its own dots — e.g. a JSON transient cookie carrying
+      // an audience like https://api.example.com/ — must verify intact.
+      const [key, keystore] = getKeyStore('__test_secret__');
+      const value = JSON.stringify({
+        audience: 'https://api.example.com/products',
+      });
+      const signed = signCookieSync('auth_verification', value, key);
+      const result = await verifyCookie('auth_verification', signed, keystore);
+      assert.equal(result, value);
+    });
   });
 });


### PR DESCRIPTION
### Description

`verifyCookie` splits a signed cookie (`value.signature`) on the **first** dot and takes the first two segments. The HMAC signature is base64url (dot-free) and is always the **final** segment, but the signed *value* is not guaranteed dot-free. When the value contains a dot — for example a signed JSON payload carrying a URL such as an audience `https://api.example.com/` — the first-dot split truncates the value and picks up a wrong signature, so verification fails and the cookie is silently dropped.

This is a latent bug: every value signed to date (nonces, `state`, `code_verifier`, session store ids) has been base64url/dot-free, so the first-dot split happened to be correct. It surfaces as soon as any dot-containing value is signed.

### Changes

- `lib/crypto.js` — `verifyCookie` now splits on the **last** dot: everything before it is the value, everything after is the signature. Existing dot-free values are unaffected (for them the last dot is the only dot).
- `test/crypto.tests.js` — regression test signing/verifying a value that contains dots (a JSON payload with an audience URL).

### Notes

- The signature segment is `crypto.createHmac(...).digest('base64url')`; the base64url alphabet (`A–Z a–z 0–9 _ -`) never contains `.`, so the last-dot split is unambiguous.
- Both callers of `verifyCookie` benefit: the transient `auth_verification` cookie (`lib/transientHandler.js`) and the signed session-store cookie (`lib/appSession.js`).
- No cookie format change — the stored `value.signature` layout is identical; only the parse is corrected. Cookies signed before this change verify unchanged.

### Testing

- `npm run test` — all unit tests pass (437 passing), including the new regression test.
- `npm run test:end-to-end` — all e2e tests pass.
- Lint and Prettier clean.

### Checklist

- [x] I have added tests covering the fix
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used (`master`)
