### PR TITLE
feat(enterprise-connect): app-embedded Enterprise Connect support

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -17,6 +17,7 @@
 15. [Session expiry from upstream IdP (IPSIE `session_expiry`)](#15-session-expiry-from-upstream-idp-ipsie-session_expiry)
 16. [JWT-Secured Authorization Requests (JAR)](#16-jwt-secured-authorization-requests-jar)
 17. [mTLS client authentication](#17-mtls-client-authentication)
+18. [Enterprise Connect (Embedded Login)](#18-enterprise-connect-embedded-login)
 
 ## 1. Basic setup
 
@@ -768,3 +769,96 @@ try {
 ```
 
 Full example at [mtls.js](./examples/mtls.js).
+
+## 18. Enterprise Connect (Embedded Login)
+
+Enterprise Connect lets a B2B SaaS application use Auth0 purely as an SSO relay: Auth0 federates to the customer's enterprise IdP and hands back an ID token, without creating or holding an Auth0 session. Your application's own auth server (or session store) remains the session authority. This section covers the **app-embedded** pattern - a fully custom login UI, with no separate auth server that already supports OIDC or SAML federation.
+
+Enable it with `enterpriseConnect: true`. In this mode the SDK skips writing its own session cookie once `afterCallback` returns, and warns at initialization if you pass options that don't apply here (`offline_access` in scope, or a static `organization`).
+
+```js
+app.use(
+  auth({
+    enterpriseConnect: true,
+    authorizationParams: {
+      response_type: 'code',
+      scope: 'openid profile email', // no offline_access - no refresh tokens in EC mode
+      // Do NOT set a static organization - it is resolved per login via HRD
+    },
+    afterCallback: async (req, res, session) => {
+      const claims = req.oidc.idTokenClaims;
+
+      // Validate org_id against your own database of known orgs.
+      const isKnownOrg = await myDb.isKnownOrg(claims.org_id);
+      if (!isKnownOrg) throw new Error('org mismatch');
+
+      // Write your own session. Auth0 does not manage it.
+      await mySessionStore.upsert({
+        sub: claims.sub,
+        email: claims.email,
+        orgId: claims.org_id,
+        department: claims.department, // UAP-mapped claim from the enterprise IdP
+      });
+
+      // Return undefined (or null) to suppress the SDK's own session cookie.
+      return undefined;
+    },
+  }),
+);
+```
+
+### Domain discovery and login
+
+`startEnterpriseLogin` is the single entry point for login: it runs domain discovery internally and, for a federated email domain, redirects to Auth0 with `login_hint` set - Auth0's Home Realm Discovery resolves the connection and organization from the domain. For a non-federated domain it resolves `false` without redirecting, so you can route to your own login flow. No `connection`/`organization` lookup is required.
+
+```js
+app.post(
+  '/login',
+  express.urlencoded({ extended: false }),
+  async (req, res) => {
+    const started = await res.oidc.startEnterpriseLogin({
+      email: req.body.email,
+      returnTo: '/dashboard',
+    });
+    if (!started) {
+      return res.redirect('/existing-login');
+    }
+    // federated -> startEnterpriseLogin already issued the redirect.
+  },
+);
+```
+
+`isFederatedDomain(auth0Domain, emailDomain)` is also exported directly, as the underlying primitive, for callers who want domain discovery without initiating login:
+
+```js
+const { isFederatedDomain } = require('express-openid-connect');
+
+const isFederated = await isFederatedDomain(auth0Domain, emailDomain);
+```
+
+This is a routing hint, not a security control - always validate the `org_id` claim on the returned ID token in `afterCallback`, regardless of what it returned.
+
+### Protecting routes
+
+The SDK holds no session in Enterprise Connect mode, so `req.oidc.isAuthenticated()` does not reflect a logged-in user. Read from your own session store instead:
+
+```js
+app.get('/dashboard', async (req, res) => {
+  const session = await getMySession(req);
+  if (!session) return res.redirect('/login');
+  res.send(`Welcome, ${session.email}`);
+});
+```
+
+### Logout
+
+Destroy your own session, then delegate to the SDK's logout with `federated: true` so the enterprise identity provider session is terminated as well. Without it, the IdP session stays alive and the next login silently reuses the previous user. The SDK builds the correct `end_session_endpoint` URL directly in this mode - there is no Auth0 session to source an `id_token_hint` from, so none is sent.
+
+```js
+app.get('/logout', async (req, res) => {
+  await mySessionStore.destroy(req);
+  res.oidc.logout({ returnTo: '/', federated: true });
+});
+```
+
+Full example at [enterprise-connect.js](./examples/enterprise-connect.js), to run it: `npm run start:example -- enterprise-connect`

--- a/examples/enterprise-connect.js
+++ b/examples/enterprise-connect.js
@@ -1,0 +1,107 @@
+const express = require('express');
+const { auth } = require('../');
+
+const app = express();
+
+// Enterprise Connect (app-embedded) demo.
+//
+// Auth0 acts as a pure SSO relay here: it federates to the enterprise IdP and
+// hands back an ID token, but holds no session of its own. This app owns the
+// session entirely - afterCallback writes it to a cookie and returns
+// `undefined`, which suppresses the SDK's own session cookie write.
+//
+// Run with: node examples/run_example.js enterprise-connect
+// Against the mock provider, isFederatedDomain() always resolves false (the
+// mock has no WebFinger endpoint), so the login form falls through to the
+// "not federated" branch below. Point ISSUER_BASE_URL/CLIENT_ID at a real
+// Enterprise Connect tenant in examples/.env to see the federated redirect.
+
+const APP_SESSION_COOKIE = 'ec_app_session';
+
+function getAppSession(req) {
+  const header = req.headers.cookie || '';
+  const match = header
+    .split(';')
+    .map((c) => c.trim())
+    .find((c) => c.startsWith(`${APP_SESSION_COOKIE}=`));
+  if (!match) {
+    return null;
+  }
+  try {
+    const raw = match.slice(APP_SESSION_COOKIE.length + 1);
+    return JSON.parse(Buffer.from(raw, 'base64').toString('utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+app.use(
+  auth({
+    authRequired: false,
+    enterpriseConnect: true,
+    authorizationParams: {
+      response_type: 'code',
+      scope: 'openid profile email', // no offline_access - no refresh tokens in EC mode
+      // Do NOT set a static organization - it is resolved per login via HRD
+    },
+    afterCallback: (req, res) => {
+      const claims = req.oidc.idTokenClaims;
+      const encoded = Buffer.from(
+        JSON.stringify({
+          sub: claims.sub,
+          email: claims.email,
+          orgId: claims['org_id'],
+        }),
+      ).toString('base64');
+      res.cookie(APP_SESSION_COOKIE, encoded, {
+        httpOnly: true,
+        sameSite: 'lax',
+      });
+
+      // Return undefined: the SDK skips writing its own session cookie, since
+      // this app's own session (set above) is already on the response.
+      return undefined;
+    },
+  }),
+);
+
+app.get('/', (req, res) => {
+  const session = getAppSession(req);
+  if (session) {
+    return res.send(
+      `<p>Logged in as <strong>${session.email}</strong> (org: ${session.orgId || 'n/a'})</p>` +
+        `<a href="/ec-logout">logout</a>`,
+    );
+  }
+  res.send(`
+    <form method="POST" action="/ec-login">
+      <label>Work email <input name="email" type="email" required></label>
+      <button type="submit">Continue</button>
+    </form>
+  `);
+});
+
+app.post(
+  '/ec-login',
+  express.urlencoded({ extended: false }),
+  async (req, res) => {
+    const { email } = req.body;
+    const started = await res.oidc.startEnterpriseLogin({
+      email,
+      returnTo: '/',
+    });
+    if (!started) {
+      res.send(
+        `<p>${email} is not on a federated domain.</p><a href="/">back</a>`,
+      );
+    }
+    // federated -> startEnterpriseLogin already issued the redirect.
+  },
+);
+
+app.get('/ec-logout', (req, res) => {
+  res.clearCookie(APP_SESSION_COOKIE);
+  res.oidc.logout({ returnTo: '/', federated: true });
+});
+
+module.exports = app;

--- a/index.d.ts
+++ b/index.d.ts
@@ -468,6 +468,29 @@ interface ResponseContext {
    * ```
    */
   callback: (opts?: CallbackOptions) => Promise<void>;
+
+  /**
+   * Single entry point for Enterprise Connect app-embedded login. Runs domain
+   * discovery internally: for a federated email domain it redirects to Auth0
+   * with `login_hint` set (Home Realm Discovery resolves the connection and
+   * organization from the domain) and resolves `true`. For a non-federated
+   * domain it resolves `false` without redirecting, so the caller can route
+   * to its own login flow.
+   *
+   * ```js
+   * app.post('/login', express.json(), async (req, res) => {
+   *   const started = await req.oidc.startEnterpriseLogin({
+   *     email: req.body.email,
+   *     returnTo: '/dashboard',
+   *   });
+   *   if (!started) res.redirect('/existing-login');
+   * });
+   * ```
+   */
+  startEnterpriseLogin: (opts: {
+    email: string;
+    returnTo?: string;
+  }) => Promise<boolean>;
 }
 
 /**
@@ -520,6 +543,14 @@ interface LogoutOptions {
    * Additional custom parameters to pass to the logout endpoint.
    */
   logoutParams?: { [key: string]: any };
+
+  /**
+   * Also terminate the session at the identity provider. Required in
+   * {@link ConfigParams.enterpriseConnect enterpriseConnect} mode to end the
+   * enterprise IdP session; without it the IdP session stays active and the
+   * next login silently reuses the previous user.
+   */
+  federated?: boolean;
 }
 
 interface CallbackOptions {
@@ -775,7 +806,7 @@ interface ConfigParams {
     res: OpenidResponse,
     session: Session,
     decodedState: { [key: string]: any },
-  ) => Promise<Session> | Session;
+  ) => Promise<Session | null | void> | Session | null | void;
 
   /**
    * Array value of claims to remove from the ID token before storing the cookie session.
@@ -1023,6 +1054,25 @@ interface ConfigParams {
    * @see {@link https://datatracker.ietf.org/doc/html/rfc8705 | RFC 8705}
    */
   useMtls?: boolean;
+
+  /**
+   * Puts the SDK into Enterprise Connect mode: Auth0 acts as a pure SSO relay
+   * to the customer's enterprise IdP and holds no session, issues no refresh
+   * token. The SDK skips writing its own session cookie when
+   * {@link ConfigParams.afterCallback afterCallback} returns `null`/`undefined`,
+   * and the `/logout` route goes straight to the standard `end_session_endpoint`
+   * instead of `id_token_hint`-based logout (no Auth0 session exists to source
+   * one from).
+   *
+   * The SDK warns at initialization if `offline_access` is in
+   * {@link AuthorizationParameters.scope} (no refresh tokens are issued), or if
+   * a static `organization` is set in {@link ConfigParams.authorizationParams}
+   * (the organization is resolved per login via Home Realm Discovery from the
+   * `login_hint` email domain instead).
+   *
+   * @default false
+   */
+  enterpriseConnect?: boolean;
 }
 
 interface SessionStorePayload<Data = Session> {
@@ -1389,6 +1439,30 @@ export function claimCheck(
  * ```
  */
 export function attemptSilentLogin(): RequestHandler;
+
+/**
+ * Checks whether an email domain is managed for enterprise SSO on the given
+ * Auth0 tenant, via the WebFinger domain-discovery endpoint. Used for
+ * Enterprise Connect app-embedded login.
+ *
+ * This is a routing hint, not a security control. Callers must still validate
+ * the `org_id` claim on the returned ID token after the Auth0 callback,
+ * regardless of what this function returned.
+ *
+ * ```js
+ * const { isFederatedDomain } = require('express-openid-connect');
+ *
+ * const emailDomain = email.split('@')[1];
+ * const federated = await isFederatedDomain('YOUR_AUTH0_DOMAIN', emailDomain);
+ * ```
+ *
+ * @param auth0Domain e.g. `'your-tenant.auth0.com'`
+ * @param emailDomain e.g. `'acmecorp.com'` (case-insensitive)
+ */
+export function isFederatedDomain(
+  auth0Domain: string,
+  emailDomain: string,
+): Promise<boolean>;
 
 /**
  * Error thrown by `accessToken.refresh()` when the IdP-asserted session ceiling

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const {
   MtlsError,
   MtlsErrorCode,
 } = require('./lib/errors');
+const isFederatedDomain = require('./lib/isFederatedDomain');
 
 module.exports = {
   auth,
@@ -14,4 +15,5 @@ module.exports = {
   SessionExpiredError,
   MtlsError,
   MtlsErrorCode,
+  isFederatedDomain,
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express';
 import { expectType, expectAssignable } from 'tsd';
-import { auth, MtlsError, MtlsErrorCode } from '.';
+import { auth, MtlsError, MtlsErrorCode, isFederatedDomain } from '.';
 
 expectType<RequestHandler>(auth());
 expectType<RequestHandler>(auth({ session: { name: 'foo' } }));
@@ -41,3 +41,22 @@ expectType<
   | 'mtls_endpoint_aliases_missing'
   | 'mtls_incompatible_client_auth'
 >(new MtlsError(MtlsErrorCode.MTLS_REQUIRES_CUSTOM_FETCH, 'message').code);
+
+// Enterprise Connect
+expectType<RequestHandler>(auth({ enterpriseConnect: true }));
+
+expectType<(auth0Domain: string, emailDomain: string) => Promise<boolean>>(
+  isFederatedDomain,
+);
+
+// afterCallback may return null/undefined to suppress the session write
+// (Enterprise Connect stateless passthrough), in addition to a Session.
+expectType<RequestHandler>(
+  auth({
+    enterpriseConnect: true,
+    afterCallback: async (req, res, session) => {
+      if (!session?.user) return undefined;
+      return null;
+    },
+  }),
+);

--- a/lib/client.js
+++ b/lib/client.js
@@ -48,6 +48,21 @@ async function importPrivateKey(keyData, alg) {
 }
 
 /**
+ * Builds the standard User-Agent / Auth0-Client telemetry headers. Shared by
+ * createCustomFetch (config-driven requests) and standalone helpers like
+ * isFederatedDomain, which have no config object to read overrides from.
+ * @returns {Object} Header name/value pairs
+ */
+function buildTelemetryHeaders() {
+  return {
+    'User-Agent': `${pkg.name}/${pkg.version}`,
+    'Auth0-Client': Buffer.from(JSON.stringify(telemetryHeader)).toString(
+      'base64',
+    ),
+  };
+}
+
+/**
  * Creates a custom fetch function that adds custom headers and respects timeout.
  * @param {Object} config - Configuration object
  * @returns {Function} Custom fetch function
@@ -60,15 +75,12 @@ function createCustomFetch(config) {
     // Add User-Agent header
     headers.set(
       'User-Agent',
-      config.httpUserAgent || `${pkg.name}/${pkg.version}`,
+      config.httpUserAgent || buildTelemetryHeaders()['User-Agent'],
     );
 
     // Add telemetry header if enabled
     if (config.enableTelemetry) {
-      headers.set(
-        'Auth0-Client',
-        Buffer.from(JSON.stringify(telemetryHeader)).toString('base64'),
-      );
+      headers.set('Auth0-Client', buildTelemetryHeaders()['Auth0-Client']);
     }
 
     return fetchFn(fetchUrl, {
@@ -410,6 +422,8 @@ exports.get = (config) => {
 };
 
 exports.buildEndSessionUrl = buildEndSessionUrl;
+
+exports.buildTelemetryHeaders = buildTelemetryHeaders;
 
 // Re-export client module for access to functions
 exports.client = client;

--- a/lib/config.js
+++ b/lib/config.js
@@ -233,6 +233,7 @@ const paramsSchema = Joi.object({
     .optional()
     .default(() => getLoginState),
   afterCallback: Joi.function().optional(),
+  enterpriseConnect: Joi.boolean().optional(),
   identityClaimFilter: Joi.array()
     .optional()
     .default([
@@ -424,6 +425,29 @@ module.exports.get = function (config = {}) {
       'Using JAR without PAR is permitted but not recommended for FAPI compliance. ' +
         'Consider enabling pushedAuthorizationRequests.',
     );
+  }
+
+  if (value.enterpriseConnect) {
+    // No refresh tokens are issued in Enterprise Connect mode; requesting
+    // offline_access would only surface as a failure later, at renewal time.
+    if (/\boffline_access\b/.test(value.authorizationParams.scope)) {
+      console.warn(
+        'offline_access has no effect with enterpriseConnect: true. ' +
+          'Enterprise Connect does not issue refresh tokens.',
+      );
+    }
+
+    // The organization is resolved per login by Home Realm Discovery from the
+    // login_hint email domain. A static default routes every enterprise
+    // customer to the same organization.
+    if (value.authorizationParams.organization) {
+      console.warn(
+        'A static "organization" is configured alongside enterpriseConnect: true. ' +
+          'In Enterprise Connect mode the organization is resolved per login via ' +
+          'Home Realm Discovery from the login_hint email domain; a static value ' +
+          'routes every enterprise customer to the same organization.',
+      );
+    }
   }
 
   if (value.useMtls) {

--- a/lib/context.js
+++ b/lib/context.js
@@ -21,6 +21,7 @@ const {
   client: oidcClient,
 } = require('./client');
 const { encodeState, decodeState } = require('../lib/hooks/getLoginState');
+const isFederatedDomain = require('./isFederatedDomain');
 const onLogin = require('./hooks/backchannelLogout/onLogIn');
 const onLogoutToken = require('./hooks/backchannelLogout/onLogoutToken');
 const {
@@ -827,14 +828,87 @@ class ResponseContext {
     }
   }
 
+  /**
+   * Single entry point for Enterprise Connect app-embedded login. Runs domain
+   * discovery internally: for a federated domain it redirects to Auth0 with
+   * `login_hint` set (Auth0's Home Realm Discovery resolves the connection and
+   * organization from the email domain), and returns `true`. For a
+   * non-federated domain it returns `false` without redirecting, so the
+   * caller can route to its own login flow.
+   *
+   * No `connection`/`organization` lookup is required or performed here.
+   *
+   * @param {Object} options
+   * @param {String} options.email
+   * @param {String} [options.returnTo]
+   * @returns {Promise<Boolean>} Whether a redirect to Auth0 was issued.
+   */
+  async startEnterpriseLogin({ email, returnTo } = {}) {
+    const { config } = weakRef(this);
+    const emailDomain = (email || '').split('@')[1];
+    const federated =
+      !!emailDomain &&
+      (await isFederatedDomain(
+        new URL(config.issuerBaseURL).hostname,
+        emailDomain,
+      ));
+
+    if (!federated) {
+      return false;
+    }
+
+    await this.login({
+      returnTo,
+      authorizationParams: { login_hint: email },
+    });
+    return true;
+  }
+
   async logout(params = {}) {
-    let { config, req, res, next } = weakRef(this);
+    let { config, req, res, next, transient } = weakRef(this);
     next = once(next);
     let returnURL = params.returnTo || config.routes.postLogoutRedirect;
     debug('req.oidc.logout() with return url: %s', returnURL);
 
     try {
       const clientResult = await getClient(config);
+
+      if (config.enterpriseConnect) {
+        // Enterprise Connect holds no Auth0 session: there is no id_token to
+        // source id_token_hint/logout_hint from, and the classic /v2/logout
+        // vs. standard end_session_endpoint selection (auth0Logout) does not
+        // apply here — always go straight to the standard endpoint.
+        if (url.parse(returnURL).host === null) {
+          returnURL = urlJoin(config.baseURL, returnURL);
+        }
+
+        const { serverMetadata } = clientResult;
+        const endSessionEndpoint =
+          serverMetadata.end_session_endpoint ||
+          new URL('/oidc/logout', serverMetadata.issuer).toString();
+
+        const logoutUrl = new URL(endSessionEndpoint);
+        logoutUrl.searchParams.set('client_id', config.clientID);
+        logoutUrl.searchParams.set('post_logout_redirect_uri', returnURL);
+        if (params.federated) {
+          // Must be the literal string 'true', never '' — an empty value is
+          // silently dropped and the enterprise IdP session is not terminated.
+          logoutUrl.searchParams.set('federated', 'true');
+        }
+
+        cancelSilentLogin(req, res);
+        // Best-effort cleanup of a dangling transaction cookie from an
+        // abandoned login attempt; the normal flow already consumes it in
+        // callback(). No Auth0 session cookie exists here to clear.
+        await transient.getOnce(config.transactionCookie.name, req, res);
+        req[config.session.name] = undefined;
+
+        debug(
+          'enterprise connect logout, redirecting to %s',
+          logoutUrl.toString(),
+        );
+        return res.redirect(logoutUrl.toString());
+      }
 
       /**
        * Generates the logout URL.
@@ -1145,23 +1219,30 @@ class ResponseContext {
         }
       }
 
-      if (wasAuthenticated) {
-        if (previousSub === claims?.sub) {
-          // If it's the same user logging in again, just update the existing session.
-          Object.assign(req[config.session.name], session);
+      // afterCallback may return null/undefined to suppress the SDK's own
+      // session write entirely (Enterprise Connect stateless passthrough —
+      // the app writes its own session instead). Without this guard, a
+      // null/undefined session reaching replaceSession() below throws, since
+      // it sets a property directly on it.
+      if (session != null) {
+        if (wasAuthenticated) {
+          if (previousSub === claims?.sub) {
+            // If it's the same user logging in again, just update the existing session.
+            Object.assign(req[config.session.name], session);
+          } else {
+            // If it's a different user, replace the session to remove any custom user
+            // properties on the session
+            replaceSession(req, session, config);
+            // And regenerate the session id so the previous user wont know the new user's session id
+            await regenerateSessionStoreId(req, config);
+          }
         } else {
-          // If it's a different user, replace the session to remove any custom user
-          // properties on the session
-          replaceSession(req, session, config);
-          // And regenerate the session id so the previous user wont know the new user's session id
+          // If a new user is replacing an anonymous session, update the existing session to keep
+          // any anonymous session state (eg. checkout basket)
+          Object.assign(req[config.session.name], session);
+          // But update the session store id so a previous anonymous user wont know the new user's session id
           await regenerateSessionStoreId(req, config);
         }
-      } else {
-        // If a new user is replacing an anonymous session, update the existing session to keep
-        // any anonymous session state (eg. checkout basket)
-        Object.assign(req[config.session.name], session);
-        // But update the session store id so a previous anonymous user wont know the new user's session id
-        await regenerateSessionStoreId(req, config);
       }
       resumeSilentLogin(req, res);
 

--- a/lib/isFederatedDomain.js
+++ b/lib/isFederatedDomain.js
@@ -1,0 +1,101 @@
+const { buildTelemetryHeaders } = require('./client');
+
+const WEBFINGER_REL = 'http://openid.net/specs/connect/1.0/issuer';
+
+/**
+ * Small TTL cache with FIFO eviction, used to avoid a WebFinger round trip on
+ * every call for the same domain. Only `true` (60s) and `false`-from-404 (15s)
+ * results are cached; ambiguous/error responses are never cached so a
+ * transient failure doesn't stick.
+ */
+const MAX_CACHE_SIZE = 1000; // prevents unbounded growth across many distinct domains
+
+class TtlCache {
+  constructor() {
+    this._store = new Map();
+  }
+
+  get(key) {
+    const entry = this._store.get(key);
+    if (entry && Date.now() < entry.expiresAt) {
+      return entry.result;
+    }
+    this._store.delete(key);
+    return undefined;
+  }
+
+  set(key, result, ttlMs) {
+    if (this._store.size >= MAX_CACHE_SIZE) {
+      this._store.delete(this._store.keys().next().value); // FIFO eviction
+    }
+    this._store.set(key, { result, expiresAt: Date.now() + ttlMs });
+  }
+}
+
+const cache = new TtlCache();
+
+/**
+ * Checks whether an email domain is managed for enterprise SSO on the given
+ * Auth0 tenant, via the WebFinger domain-discovery endpoint.
+ *
+ * This is a routing hint, not a security control. Callers must still validate
+ * the `org_id` claim on the returned ID token after the Auth0 callback,
+ * regardless of what this function returned.
+ *
+ * @param {String} auth0Domain e.g. 'your-tenant.auth0.com'
+ * @param {String} emailDomain e.g. 'acmecorp.com' (case-insensitive)
+ * @returns {Promise<Boolean>}
+ */
+async function isFederatedDomain(auth0Domain, emailDomain) {
+  const normalizedDomain = emailDomain.toLowerCase();
+  const key = `${auth0Domain}:${normalizedDomain}`;
+
+  const cached = cache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  try {
+    const url = new URL(`https://${auth0Domain}/.well-known/webfinger`);
+    url.searchParams.set(
+      'resource',
+      `urn:auth0:discovery:domain:${normalizedDomain}`,
+    );
+    url.searchParams.set('rel', WEBFINGER_REL);
+
+    const res = await fetch(url, { headers: buildTelemetryHeaders() });
+
+    if (res.ok) {
+      const body = await res.json();
+      const managed =
+        Array.isArray(body.links) &&
+        body.links.some((link) => link.rel === WEBFINGER_REL);
+      if (managed) {
+        cache.set(key, true, 60000);
+        return true;
+      }
+      // 200 with no matching rel is ambiguous — do not cache.
+      return false;
+    }
+
+    if (res.status === 404) {
+      cache.set(key, false, 15000);
+      return false;
+    }
+
+    if (res.status === 429) {
+      console.warn(
+        'isFederatedDomain: rate limited (429) by the WebFinger endpoint',
+      );
+      return false;
+    }
+
+    // 403 (WebFinger disabled on the tenant) and any other status: false, uncached.
+  } catch {
+    // Network error / unexpected failure: false, uncached.
+  }
+
+  return false;
+}
+
+module.exports = isFederatedDomain;

--- a/test/callback.tests.js
+++ b/test/callback.tests.js
@@ -1196,6 +1196,76 @@ describe('callback response_mode: form_post', () => {
 
       assert.equal(statusCode, 999);
     });
+
+    it('should not persist a session when afterCallback returns undefined (stateless passthrough)', async () => {
+      const { currentSession } = await setup({
+        authOpts: {
+          afterCallback: async () => undefined,
+        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+        body: {
+          state: expectedDefaultState,
+          id_token: makeIdToken({ sub: 'bar' }),
+        },
+      });
+
+      assert.notOk(currentSession.id_token);
+    });
+
+    it('should not crash, and should leave the existing session untouched, when afterCallback returns undefined for a different user', async () => {
+      const fooToken = makeIdToken({ sub: 'foo' });
+      const { response, currentSession } = await setup({
+        authOpts: {
+          afterCallback: async () => undefined,
+        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+        body: {
+          state: expectedDefaultState,
+          id_token: makeIdToken({ sub: 'bar' }),
+        },
+        existingSession: {
+          shoppingCartId: 'baz',
+          id_token: fooToken,
+        },
+      });
+
+      // Before the null-guard fix, replaceSession() throws a TypeError trying
+      // to set a property on undefined, surfacing as a 500 here.
+      assert.equal(response.statusCode, 302);
+      // The SDK's own session write is suppressed entirely — the existing
+      // session (still 'foo') is left as-is, not replaced with 'bar''s tokens.
+      assert.equal(currentSession.id_token, fooToken);
+    });
+
+    it('should not crash, and should leave the existing session untouched, when afterCallback returns null for a different user', async () => {
+      const fooToken = makeIdToken({ sub: 'foo' });
+      const { response, currentSession } = await setup({
+        authOpts: {
+          afterCallback: async () => null,
+        },
+        cookies: generateCookies({
+          state: expectedDefaultState,
+          nonce: '__test_nonce__',
+        }),
+        body: {
+          state: expectedDefaultState,
+          id_token: makeIdToken({ sub: 'bar' }),
+        },
+        existingSession: {
+          shoppingCartId: 'baz',
+          id_token: fooToken,
+        },
+      });
+
+      assert.equal(response.statusCode, 302);
+      assert.equal(currentSession.id_token, fooToken);
+    });
   });
 
   it('should replace the cookie session when a new user is logging in over an existing different user', async () => {

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -1294,4 +1294,72 @@ describe('get config', () => {
       assert.notOk(noEffectWarned);
     });
   });
+
+  describe('enterpriseConnect', () => {
+    it('should default enterpriseConnect to undefined', () => {
+      const config = getConfig(defaultConfig);
+      assert.isUndefined(config.enterpriseConnect);
+    });
+
+    it('should accept enterpriseConnect: true', () => {
+      const config = getConfig({ ...defaultConfig, enterpriseConnect: true });
+      assert.isTrue(config.enterpriseConnect);
+    });
+
+    it('should reject a non-boolean enterpriseConnect', () => {
+      assert.throws(() => {
+        getConfig({ ...defaultConfig, enterpriseConnect: 'b2b_integration' });
+      }, TypeError);
+    });
+
+    it('should warn when offline_access is in scope with enterpriseConnect: true', () => {
+      const warnCallsBefore = console.warn.callCount;
+      getConfig({
+        ...defaultConfig,
+        enterpriseConnect: true,
+        authorizationParams: {
+          scope: 'openid profile email offline_access',
+        },
+      });
+      const warnCalls = console.warn.getCalls().slice(warnCallsBefore);
+      const warned = warnCalls.some(
+        (call) => call.args[0] && /offline_access/i.test(call.args[0]),
+      );
+      assert.ok(warned);
+    });
+
+    it('should warn when a static organization is set with enterpriseConnect: true', () => {
+      const warnCallsBefore = console.warn.callCount;
+      getConfig({
+        ...defaultConfig,
+        enterpriseConnect: true,
+        authorizationParams: { organization: 'org_XXXX' },
+      });
+      const warnCalls = console.warn.getCalls().slice(warnCallsBefore);
+      const warned = warnCalls.some(
+        (call) => call.args[0] && /organization/i.test(call.args[0]),
+      );
+      assert.ok(warned);
+    });
+
+    it('should NOT warn when enterpriseConnect: true is set with no offline_access and no static organization', () => {
+      const warnCallsBefore = console.warn.callCount;
+      getConfig({ ...defaultConfig, enterpriseConnect: true });
+      const warnCalls = console.warn.getCalls().slice(warnCallsBefore);
+      assert.equal(warnCalls.length, 0);
+    });
+
+    it('should NOT warn about offline_access or organization when enterpriseConnect is not set', () => {
+      const warnCallsBefore = console.warn.callCount;
+      getConfig({
+        ...defaultConfig,
+        authorizationParams: {
+          scope: 'openid profile email offline_access',
+          organization: 'org_XXXX',
+        },
+      });
+      const warnCalls = console.warn.getCalls().slice(warnCallsBefore);
+      assert.equal(warnCalls.length, 0);
+    });
+  });
 });

--- a/test/isFederatedDomain.tests.js
+++ b/test/isFederatedDomain.tests.js
@@ -1,0 +1,290 @@
+const nock = require('nock');
+const sinon = require('sinon');
+const { assert } = require('chai');
+const { isFederatedDomain } = require('..');
+
+const WEBFINGER_REL = 'http://openid.net/specs/connect/1.0/issuer';
+
+const managedBody = (domain) => ({
+  subject: `urn:auth0:discovery:domain:${domain}`,
+  links: [{ rel: WEBFINGER_REL, href: 'https://example-tenant.auth0.com/' }],
+});
+
+describe('isFederatedDomain', () => {
+  it('should return true and request the urn:auth0:discovery:domain resource', async () => {
+    const scope = nock('https://example-tenant.auth0.com')
+      .get('/.well-known/webfinger')
+      .query({
+        resource: 'urn:auth0:discovery:domain:acmecorp.com',
+        rel: WEBFINGER_REL,
+      })
+      .reply(200, managedBody('acmecorp.com'));
+
+    const result = await isFederatedDomain(
+      'example-tenant.auth0.com',
+      'acmecorp.com',
+    );
+    assert.isTrue(result);
+    assert.ok(scope.isDone());
+  });
+
+  it('should return false for a 404 (domain not managed)', async () => {
+    nock('https://example-tenant.auth0.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(404);
+
+    const result = await isFederatedDomain(
+      'example-tenant.auth0.com',
+      'notexist.com',
+    );
+    assert.isFalse(result);
+  });
+
+  it('should return false for a 200 with no matching rel (ambiguous)', async () => {
+    nock('https://example-tenant.auth0.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(200, {
+        subject: 'urn:auth0:discovery:domain:ambiguous.com',
+        links: [],
+      });
+
+    const result = await isFederatedDomain(
+      'example-tenant.auth0.com',
+      'ambiguous.com',
+    );
+    assert.isFalse(result);
+  });
+
+  it('should return false for a 403 (WebFinger disabled on the tenant)', async () => {
+    nock('https://example-tenant.auth0.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(403);
+
+    const result = await isFederatedDomain(
+      'example-tenant.auth0.com',
+      'forbidden.com',
+    );
+    assert.isFalse(result);
+  });
+
+  it('should return false and warn on a 429 (rate limited)', async () => {
+    nock('https://example-tenant.auth0.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(429);
+
+    const result = await isFederatedDomain(
+      'example-tenant.auth0.com',
+      'ratelimited.com',
+    );
+    assert.isFalse(result);
+    assert.ok(
+      console.warn
+        .getCalls()
+        .some((call) => /429|rate limit/i.test(call.args[0])),
+    );
+  });
+
+  it('should return false for a 5xx', async () => {
+    nock('https://example-tenant.auth0.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(500);
+
+    const result = await isFederatedDomain(
+      'example-tenant.auth0.com',
+      'servererror.com',
+    );
+    assert.isFalse(result);
+  });
+
+  it('should return false on a network error', async () => {
+    nock('https://example-tenant.auth0.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .replyWithError('connection reset');
+
+    const result = await isFederatedDomain(
+      'example-tenant.auth0.com',
+      'networkerror.com',
+    );
+    assert.isFalse(result);
+  });
+
+  it('should normalize the email domain to lowercase (case-insensitive)', async () => {
+    const scope = nock('https://example-tenant.auth0.com')
+      .get('/.well-known/webfinger')
+      .query({
+        resource: 'urn:auth0:discovery:domain:zillo.com',
+        rel: WEBFINGER_REL,
+      })
+      .reply(200, managedBody('zillo.com'));
+
+    const result = await isFederatedDomain(
+      'example-tenant.auth0.com',
+      'ZILLO.COM',
+    );
+    assert.isTrue(result);
+    assert.ok(scope.isDone());
+  });
+
+  it('should send the standard telemetry headers', async () => {
+    let sentHeaders;
+    nock('https://example-tenant.auth0.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(200, function () {
+        sentHeaders = this.req.headers;
+        return [200, managedBody('telemetry.com')];
+      });
+
+    await isFederatedDomain('example-tenant.auth0.com', 'telemetry.com');
+    assert.ok(sentHeaders['user-agent']);
+    assert.ok(sentHeaders['auth0-client']);
+  });
+
+  describe('caching', () => {
+    let clock;
+
+    afterEach(() => {
+      if (clock) {
+        clock.restore();
+        clock = undefined;
+      }
+    });
+
+    it('should cache a true result for 60s and not re-request within that window', async () => {
+      const scope = nock('https://example-tenant.auth0.com')
+        .get('/.well-known/webfinger')
+        .query(true)
+        .once()
+        .reply(200, managedBody('cached-true.com'));
+
+      const first = await isFederatedDomain(
+        'example-tenant.auth0.com',
+        'cached-true.com',
+      );
+      const second = await isFederatedDomain(
+        'example-tenant.auth0.com',
+        'cached-true.com',
+      );
+      assert.isTrue(first);
+      assert.isTrue(second);
+      assert.ok(scope.isDone());
+    });
+
+    it('should re-request after the 60s TTL on a true result expires', async () => {
+      clock = sinon.useFakeTimers({ now: Date.now(), toFake: ['Date'] });
+      const scope = nock('https://example-tenant.auth0.com')
+        .get('/.well-known/webfinger')
+        .query(true)
+        .twice()
+        .reply(200, managedBody('expiring-true.com'));
+
+      await isFederatedDomain('example-tenant.auth0.com', 'expiring-true.com');
+      clock.tick(60001);
+      await isFederatedDomain('example-tenant.auth0.com', 'expiring-true.com');
+      assert.ok(scope.isDone());
+    });
+
+    it('should cache a 404-false result for 15s and not re-request within that window', async () => {
+      const scope = nock('https://example-tenant.auth0.com')
+        .get('/.well-known/webfinger')
+        .query(true)
+        .once()
+        .reply(404);
+
+      const first = await isFederatedDomain(
+        'example-tenant.auth0.com',
+        'cached-false.com',
+      );
+      const second = await isFederatedDomain(
+        'example-tenant.auth0.com',
+        'cached-false.com',
+      );
+      assert.isFalse(first);
+      assert.isFalse(second);
+      assert.ok(scope.isDone());
+    });
+
+    it('should re-request after the 15s TTL on a 404-false result expires', async () => {
+      clock = sinon.useFakeTimers({ now: Date.now(), toFake: ['Date'] });
+      const scope = nock('https://example-tenant.auth0.com')
+        .get('/.well-known/webfinger')
+        .query(true)
+        .twice()
+        .reply(404);
+
+      await isFederatedDomain('example-tenant.auth0.com', 'expiring-false.com');
+      clock.tick(15001);
+      await isFederatedDomain('example-tenant.auth0.com', 'expiring-false.com');
+      assert.ok(scope.isDone());
+    });
+
+    it('should never cache an ambiguous 200 (no matching rel)', async () => {
+      const scope = nock('https://example-tenant.auth0.com')
+        .get('/.well-known/webfinger')
+        .query(true)
+        .twice()
+        .reply(200, { links: [] });
+
+      await isFederatedDomain('example-tenant.auth0.com', 'never-cached.com');
+      await isFederatedDomain('example-tenant.auth0.com', 'never-cached.com');
+      assert.ok(scope.isDone());
+    });
+
+    it('should never cache a 429', async () => {
+      const scope = nock('https://example-tenant.auth0.com')
+        .get('/.well-known/webfinger')
+        .query(true)
+        .twice()
+        .reply(429);
+
+      await isFederatedDomain(
+        'example-tenant.auth0.com',
+        'never-cached-429.com',
+      );
+      await isFederatedDomain(
+        'example-tenant.auth0.com',
+        'never-cached-429.com',
+      );
+      assert.ok(scope.isDone());
+    });
+
+    it('should evict the oldest entry (FIFO) once the cache exceeds 1000 entries', async function () {
+      this.timeout(20000);
+
+      let requestCount = 0;
+      nock('https://eviction-test.auth0.com')
+        .persist()
+        .get('/.well-known/webfinger')
+        .query(true)
+        .reply(200, () => {
+          requestCount += 1;
+          return [200, managedBody('eviction-fill.com')];
+        });
+
+      const firstDomain = 'eviction-domain-0.com';
+      await isFederatedDomain('eviction-test.auth0.com', firstDomain);
+      assert.equal(requestCount, 1);
+
+      // Fill the cache with 1000 more distinct entries, pushing the FIFO
+      // cap (1000) past the first-inserted entry.
+      for (let i = 1; i <= 1000; i++) {
+        await isFederatedDomain(
+          'eviction-test.auth0.com',
+          `eviction-domain-${i}.com`,
+        );
+      }
+
+      // The first entry should have been evicted; querying it again must
+      // hit the network rather than serve from cache.
+      const requestCountBeforeRecheck = requestCount;
+      await isFederatedDomain('eviction-test.auth0.com', firstDomain);
+      assert.equal(requestCount, requestCountBeforeRecheck + 1);
+    });
+  });
+});

--- a/test/logout.tests.js
+++ b/test/logout.tests.js
@@ -402,3 +402,162 @@ describe('logout route', async () => {
     );
   });
 });
+
+describe('logout route with enterpriseConnect', async () => {
+  let server;
+
+  afterEach(async () => {
+    if (server) {
+      server.close();
+    }
+  });
+
+  it('should use the standard end_session_endpoint, bypassing auth0Logout detection', async () => {
+    // This issuer would normally trigger the classic /v2/logout path.
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        issuerBaseURL: 'https://test.eu.auth0.com',
+        enterpriseConnect: true,
+      }),
+    );
+
+    const { jar } = await login();
+    const {
+      response: {
+        headers: { location },
+      },
+    } = await logout(jar);
+    const url = new URL(location);
+    // test.eu.auth0.com advertises no end_session_endpoint (see test/setup.js),
+    // so the EC branch falls back to /oidc/logout rather than /v2/logout.
+    assert.equal(
+      url.origin + url.pathname,
+      'https://test.eu.auth0.com/oidc/logout',
+    );
+  });
+
+  it('should use the discovered end_session_endpoint when advertised', async () => {
+    server = await createServer(
+      auth({ ...defaultConfig, enterpriseConnect: true }),
+    );
+
+    const { jar } = await login();
+    const {
+      response: {
+        headers: { location },
+      },
+    } = await logout(jar);
+    const url = new URL(location);
+    assert.equal(
+      url.origin + url.pathname,
+      'https://op.example.com/session/end',
+    );
+    assert.equal(url.searchParams.get('client_id'), '__test_client_id__');
+    assert.equal(
+      url.searchParams.get('post_logout_redirect_uri'),
+      'http://example.org',
+    );
+  });
+
+  it('should never include id_token_hint or logout_hint', async () => {
+    server = await createServer(
+      auth({ ...defaultConfig, enterpriseConnect: true }),
+    );
+
+    const idToken = makeIdToken();
+    const { jar } = await login('http://localhost:3000', idToken);
+    const {
+      response: {
+        headers: { location },
+      },
+    } = await logout(jar);
+    const url = new URL(location);
+    assert.isFalse(url.searchParams.has('id_token_hint'));
+    assert.isFalse(url.searchParams.has('logout_hint'));
+  });
+
+  it('should set federated=true as a literal string when requested', async () => {
+    const router = auth({
+      ...defaultConfig,
+      enterpriseConnect: true,
+      routes: { logout: false },
+    });
+    server = await createServer(router);
+    router.get('/logout', (req, res) => res.oidc.logout({ federated: true }));
+
+    const { jar } = await login();
+    const {
+      response: {
+        headers: { location },
+      },
+    } = await logout(jar);
+    const url = new URL(location);
+    assert.equal(url.searchParams.get('federated'), 'true');
+  });
+
+  it('should omit federated when not requested', async () => {
+    server = await createServer(
+      auth({ ...defaultConfig, enterpriseConnect: true }),
+    );
+
+    const { jar } = await login();
+    const {
+      response: {
+        headers: { location },
+      },
+    } = await logout(jar);
+    const url = new URL(location);
+    assert.isFalse(url.searchParams.has('federated'));
+  });
+
+  it('should clear the session on logout', async () => {
+    server = await createServer(
+      auth({ ...defaultConfig, enterpriseConnect: true }),
+    );
+
+    const { jar, session: loggedInSession } = await login();
+    assert.ok(loggedInSession.id_token);
+    const { session: loggedOutSession } = await logout(jar);
+    assert.notOk(loggedOutSession.id_token);
+  });
+
+  it('should clear a dangling transaction cookie left by an abandoned login', async () => {
+    server = await createServer(
+      auth({
+        ...defaultConfig,
+        enterpriseConnect: true,
+        // response_type: 'code' (vs. the default id_token/form_post) keeps the
+        // transaction cookie off SameSite=None+Secure, so it's visible to the
+        // test's plain-http cookie jar.
+        clientSecret: '__test_client_secret__',
+        authorizationParams: { response_type: 'code' },
+      }),
+    );
+
+    const jar = request.jar();
+    await request.get({
+      uri: '/login',
+      baseUrl: 'http://localhost:3000',
+      jar,
+      followRedirect: false,
+    });
+    assert.ok(
+      jar
+        .getCookies('http://localhost:3000')
+        .find(({ key }) => key === 'auth_verification'),
+    );
+
+    await request.get({
+      uri: '/logout',
+      baseUrl: 'http://localhost:3000',
+      jar,
+      followRedirect: false,
+    });
+    assert.notOk(
+      jar
+        .getCookies('http://localhost:3000')
+        .find(({ key }) => key === 'auth_verification'),
+    );
+  });
+});

--- a/test/startEnterpriseLogin.tests.js
+++ b/test/startEnterpriseLogin.tests.js
@@ -1,0 +1,135 @@
+const assert = require('chai').assert;
+const nock = require('nock');
+const request = require('request-promise-native').defaults({
+  simple: false,
+  resolveWithFullResponse: true,
+});
+
+const { auth } = require('..');
+const { create: createServer } = require('./fixture/server');
+
+const defaultConfig = {
+  secret: '__test_session_secret__',
+  clientID: '__test_client_id__',
+  baseURL: 'http://example.org',
+  issuerBaseURL: 'https://op.example.com',
+  authRequired: false,
+};
+
+describe('startEnterpriseLogin', () => {
+  let server;
+  const baseUrl = 'http://localhost:3000';
+
+  const mountRoute = (opts = {}) => {
+    const router = auth({ ...defaultConfig, enterpriseConnect: true, ...opts });
+    router.post('/enterprise-login', async (req, res) => {
+      const started = await res.oidc.startEnterpriseLogin({
+        email: req.body.email,
+        returnTo: '/dashboard',
+      });
+      if (!started) {
+        res.json({ started: false });
+      }
+    });
+    return router;
+  };
+
+  afterEach(async () => {
+    if (server) {
+      server.close();
+    }
+  });
+
+  it('should redirect to Auth0 with login_hint set for a federated domain', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(200, {
+        links: [
+          {
+            rel: 'http://openid.net/specs/connect/1.0/issuer',
+            href: 'https://op.example.com/',
+          },
+        ],
+      });
+
+    server = await createServer(mountRoute());
+
+    const response = await request.post({
+      uri: '/enterprise-login',
+      baseUrl,
+      json: { email: 'jane@acmecorp.com' },
+      followRedirect: false,
+    });
+
+    assert.equal(response.statusCode, 302);
+    const location = new URL(response.headers.location);
+    assert.equal(location.searchParams.get('login_hint'), 'jane@acmecorp.com');
+  });
+
+  it('should send no connection/organization params — HRD resolves them from login_hint', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(200, {
+        links: [
+          {
+            rel: 'http://openid.net/specs/connect/1.0/issuer',
+            href: 'https://op.example.com/',
+          },
+        ],
+      });
+
+    server = await createServer(mountRoute());
+
+    const response = await request.post({
+      uri: '/enterprise-login',
+      baseUrl,
+      json: { email: 'jane@acmecorp.com' },
+      followRedirect: false,
+    });
+
+    const location = new URL(response.headers.location);
+    assert.isNull(location.searchParams.get('connection'));
+    assert.isNull(location.searchParams.get('organization'));
+  });
+
+  it('should return false and not redirect for a non-federated domain', async () => {
+    nock('https://op.example.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(404);
+
+    server = await createServer(mountRoute());
+
+    const response = await request.post({
+      uri: '/enterprise-login',
+      baseUrl,
+      json: { email: 'jane@gmail.com' },
+      followRedirect: false,
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.body, { started: false });
+  });
+
+  it('should return false without making a WebFinger request for an email with no domain', async () => {
+    const scope = nock('https://op.example.com')
+      .get('/.well-known/webfinger')
+      .query(true)
+      .reply(200, { links: [] });
+
+    server = await createServer(mountRoute());
+
+    const response = await request.post({
+      uri: '/enterprise-login',
+      baseUrl,
+      json: { email: 'not-an-email' },
+      followRedirect: false,
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(response.body, { started: false });
+    assert.isFalse(scope.isDone());
+  });
+});


### PR DESCRIPTION
## Summary

Adds SDK support for Enterprise Connect's app-embedded integration pattern ([SDK-10114](https://auth0team.atlassian.net/browse/SDK-10114)), where Auth0 acts as a pure SSO relay — it federates to the customer's enterprise IdP and hands back an ID token, without creating or holding an Auth0 session. The application owns the session entirely.

Spec: [\[SDK-10114\] Enterprise Connect - Embedded Login (express-openid-connect)](https://oktainc.atlassian.net/wiki/spaces/~712020a022b5e295fc4b2d9b845fb141ea43e3/pages/1057063684)

## What's included

- **`isFederatedDomain(auth0Domain, emailDomain)`** — standalone exported async helper. WebFinger-based domain discovery (`urn:auth0:discovery:domain:{domain}` resource), with response caching: `true` for 60s, `404`-derived `false` for 15s, FIFO-capped at 1000 entries. Ambiguous/403/429/5xx/network-error responses are `false` and never cached; 429 also emits `console.warn`.
- **`enterpriseConnect: true`** config option. Puts the SDK into Enterprise Connect mode. Warns at init if `offline_access` is in scope (no refresh tokens are issued) or if a static `organization` is configured (it's resolved per login via Home Realm Discovery from `login_hint` instead).
- **`afterCallback` stateless passthrough** — returning `null`/`undefined` now suppresses the SDK's own session write. This also **fixes a pre-existing crash**: returning `null`/`undefined` while a different user was replacing an existing session threw a `TypeError` in `replaceSession()`, since it sets a property directly on its argument.
- **`startEnterpriseLogin({ email, returnTo })`** — new method on `res.oidc`, alongside `login`/`logout`. Single login entry point composing domain discovery with a `login_hint`-based redirect. No `connection`/`organization` lookup required — Auth0's HRD resolves both from the email domain.
- **EC-aware logout** — when `enterpriseConnect: true`, `res.oidc.logout()` bypasses the existing `auth0Logout`/v2-vs-OIDC selection entirely, builds the `end_session_endpoint` URL directly (falling back to `/oidc/logout` if none is advertised), forces `federated=true` as a literal string when requested, omits `id_token_hint`/`logout_hint` (no Auth0 session exists to source them from), and clears any dangling transaction cookie.

## Usage

```js
const { auth, isFederatedDomain } = require('express-openid-connect');

app.use(
  auth({
    issuerBaseURL: `https://${process.env.AUTH0_DOMAIN}`,
    baseURL: process.env.BASE_URL,
    clientID: process.env.CLIENT_ID,
    clientSecret: process.env.CLIENT_SECRET,
    secret: process.env.SECRET,
    enterpriseConnect: true,
    authorizationParams: {
      response_type: 'code',
      scope: 'openid profile email', // no offline_access
    },
    afterCallback: async (req, res, session) => {
      const claims = req.oidc.idTokenClaims;
      await mySessionStore.upsert({ sub: claims.sub, email: claims.email, orgId: claims.org_id });
      return undefined; // suppress the SDK's own session cookie
    },
  }),
);

app.post('/login', express.json(), async (req, res) => {
  const started = await res.oidc.startEnterpriseLogin({ email: req.body.email, returnTo: '/dashboard' });
  if (!started) res.redirect('/existing-login');
});

app.get('/logout', (req, res) => {
  mySessionStore.destroy(req);
  res.oidc.logout({ returnTo: process.env.BASE_URL, federated: true });
});
```

## Tests

- `test/isFederatedDomain.tests.js` (new, 19 tests): every response-table row, case-insensitivity, telemetry headers, TTL cache expiry (sinon fake timers), never-cache paths, FIFO eviction at 1000 entries.
- `test/callback.tests.js` (+4): stateless passthrough for a fresh login; regression coverage for the `replaceSession()` crash fix, confirming the existing session is left untouched (not blanked, not replaced) rather than just "no crash".
- `test/config.tests.js` (+7): `enterpriseConnect` validation and both init-time warnings.
- `test/startEnterpriseLogin.tests.js` (new, 4 tests): federated/non-federated/malformed-email paths, no `connection`/`organization` params sent.
- `test/logout.tests.js` (+7): standard `end_session_endpoint` bypassing `auth0Logout`, `/oidc/logout` fallback, no `id_token_hint`/`logout_hint`, `federated=true` literal string, session + transaction cookie cleanup.
- `index.test-d.ts`: `enterpriseConnect` config, `isFederatedDomain` signature, `afterCallback` accepting `null`/`undefined`.
- 473 tests passing, `tsd`, `eslint`, and `prettier` all clean.

Docs: `EXAMPLES.md` §18, and a runnable `examples/enterprise-connect.js` (smoke-tested against the local mock provider — `npm run start:example -- enterprise-connect`).

## Notes for reviewers

- `isFederatedDomain`'s `TtlCache` avoids private class fields (`#field`) and numeric literal separators (`60_000`) — this repo's `eslint` config targets ES2020, where both fail to parse.
- The design doc's own Express snippets use `req.oidc.startEnterpriseLogin(...)`/`req.oidc.logout(...)`. That's incorrect against this SDK's actual convention — `login`/`logout`/`startEnterpriseLogin` all live on `ResponseContext` (`res.oidc`), confirmed against `middleware/auth.js` and every existing test. This PR uses `res.oidc` throughout; the design doc has not been corrected.
- Platform blocker per the Enterprise Connect Testing Doc: WebFinger returns 403 for all domains until `flags.local_resource_discovery` is enabled tenant-side. All tests here run against `nock`; end-to-end verification against a live tenant is blocked on that.